### PR TITLE
fix: address code review issues in Space Age work

### DIFF
--- a/packages/editor/src/containers/EntityContainer.ts
+++ b/packages/editor/src/containers/EntityContainer.ts
@@ -182,6 +182,10 @@ export class EntityContainer {
                 is: ['stone-wall', 'gate', 'legacy-straight-rail', 'straight-rail'],
                 updates: ['stone-wall', 'gate', 'legacy-straight-rail', 'straight-rail'],
             },
+            {
+                is: ['cargo-bay', 'cargo-landing-pad'],
+                updates: ['cargo-bay', 'cargo-landing-pad'],
+            },
         ]
 
         return mappigs

--- a/packages/editor/src/containers/EntitySprite.ts
+++ b/packages/editor/src/containers/EntitySprite.ts
@@ -258,7 +258,10 @@ export class EntitySprite extends Sprite {
             }
             sprite.zOrder = i
 
-            if (entityColor && !data.tint && !data.draw_as_shadow) {
+            // Only tint the colorable mask layers (those flagged apply_runtime_tint),
+            // matching Factorio's runtime tinting. Tinting every layer washes the
+            // whole entity (e.g. over-tints train stop posts and locomotive bodies).
+            if (entityColor && data.apply_runtime_tint) {
                 F.applyTint(sprite, getColor(entityColor))
             }
 

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -76,7 +76,14 @@ let bpSource: string
 let bpIndex = 0
 for (const p of params) {
     if (p.includes('source')) {
-        bpSource = decodeURIComponent(p.split('=')[1])
+        const raw = p.split('=')[1]
+        // decodeURIComponent throws URIError on malformed input (e.g. ?source=%);
+        // fall back to the raw value so a bad param can't abort app init.
+        try {
+            bpSource = decodeURIComponent(raw)
+        } catch {
+            bpSource = raw
+        }
     }
     if (p.includes('index')) {
         bpIndex = Number(p.split('=')[1])


### PR DESCRIPTION
## Summary

Fixes three issues found in code review of the recent Space Age feature/fix work (commits `29a5edff`..`ce667ba1`).

### Changes

- **Malformed `?source=` no longer crashes app init** (`packages/website/src/index.ts`)
  `decodeURIComponent` runs at module top level with no guard; a value like `?source=%` throws `URIError` and aborts before `editor.init()`, so the whole app fails to load. Now wrapped in try/catch with a raw-value fallback.

- **Cargo bay walls update during editing** (`packages/editor/src/containers/EntityContainer.ts`)
  `cargo-bay`/`cargo-landing-pad` were absent from every update group, so an existing cargo bay never redrew when an adjacent one was placed/removed - its exterior wall facing the new neighbor persisted until reload. Added the matching update group. (Blueprint *load* was already correct since every entity draws fresh; this only affected interactive editing.)

- **Custom entity color no longer over-tints** (`packages/editor/src/containers/EntitySprite.ts`)
  The blueprint entity color was applied to *every* non-tinted, non-shadow layer, washing the whole entity. Factorio only tints the colorable mask layers (flagged `apply_runtime_tint`). Now gated on `apply_runtime_tint`, which fixes the train-stop post / locomotive-body over-tint regression. Verified `applyTint` replaces rather than multiplies, so colorable layers still receive the entity color.

### Verification

- `npx tsc --noEmit` on editor and website configs: no new errors in the touched files (only pre-existing Space Age type mismatches remain).
- Prettier clean on all three files.

### Not included

The pre-existing open CORS proxy / SSRF surface in `packages/worker/src/index.ts` (`/corsproxy?url=`) is intentionally left out - hardening it (host allowlist, GET-only, size cap) is a separate threat-model decision for the deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3odxv7MfifCn7MGZvGZGQ