### PR TITLE
chore: bump eslint to 10.6.0 and prettier to 3.8.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1338,9 +1338,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-            "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+            "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -2580,9 +2580,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-            "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+            "version": "3.8.5",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.5.tgz",
+            "integrity": "sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==",
             "dev": true,
             "license": "MIT",
             "bin": {


### PR DESCRIPTION
## Summary

Lockfile-only refresh of two dev tooling dependencies, both within their existing caret ranges in `package.json`:

- eslint `10.5.0` -> `10.6.0`
- prettier `3.8.4` -> `3.8.5`

No source changes; only `package-lock.json` is touched.

## Notes

- `npm audit` reports 0 vulnerabilities; neither bump is a security fix.
- The Space Age review-fix commit referenced by this branch name (`9d7aa2b2`) is already present on `wormeyman-space-age-support`, so it is not part of this diff.

## Test plan

- [x] `npm update eslint prettier` resolved cleanly (0 vulnerabilities)
- [x] Confirmed diff is limited to the two version bumps in the lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)