### PR TITLE
chore: upgrade pako to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -645,13 +645,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/pako": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
-            "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/pathfinding": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/@types/pathfinding/-/pathfinding-0.1.0.tgz",
@@ -2392,9 +2385,9 @@
             }
         },
         "node_modules/pako": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
-            "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-3.0.0.tgz",
+            "integrity": "sha512-TGPtlCI1pSUSbkOIxOUUHNrBa0muz4mAp32cYUF3RoSa5c73jiQTKOKo22gaa4DxLggQrda/DAdax5QkcHPvYA==",
             "funding": [
                 {
                     "type": "github",
@@ -3233,14 +3226,13 @@
                 "buffer": "6.0.3",
                 "delaunator": "5.1.0",
                 "eventemitter3": "^5.0.4",
-                "pako": "2.2.0",
+                "pako": "3.0.0",
                 "pathfinding": "0.4.18",
                 "pixi.js": "^8.17.1",
                 "utility-types": "3.11.0"
             },
             "devDependencies": {
                 "@types/delaunator": "5.0.3",
-                "@types/pako": "2.0.4",
                 "@types/pathfinding": "0.1.0",
                 "typed-factorio": "^3.35.0"
             }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -16,14 +16,13 @@
         "buffer": "6.0.3",
         "delaunator": "5.1.0",
         "eventemitter3": "^5.0.4",
-        "pako": "2.2.0",
+        "pako": "3.0.0",
         "pathfinding": "0.4.18",
         "pixi.js": "^8.17.1",
         "utility-types": "3.11.0"
     },
     "devDependencies": {
         "@types/delaunator": "5.0.3",
-        "@types/pako": "2.0.4",
         "@types/pathfinding": "0.1.0",
         "typed-factorio": "^3.35.0"
     }

--- a/packages/editor/src/core/bpString.ts
+++ b/packages/editor/src/core/bpString.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer'
 import Ajv, { ErrorObject, KeywordDefinition } from 'ajv'
-import pako from 'pako'
+import * as pako from 'pako'
 import { IBlueprint, IBlueprintBook, IBlueprintBookEntry } from '../types'
 import FD from './factorioData'
 import blueprintSchema from './blueprintSchema.json'
@@ -169,7 +169,7 @@ function decode(str: string): Promise<Blueprint | Book> {
         try {
             const decodedStr = Buffer.from(str.slice(1), 'base64')
             const data = pako
-                .inflate(decodedStr, { to: 'string' })
+                .inflate(decodedStr, { toText: true })
                 .replace(nameMigrationsRegex, match => nameMigrations[match])
             const parsedData = JSON.parse(data)
             resolve(parsedData)


### PR DESCRIPTION
## Summary

Upgrades `pako` from 2.2.0 to 3.0.0 (the gzip/deflate library used for blueprint string encode/decode in `bpString.ts`).

pako 3 has breaking API changes, all handled here:

- **Default export removed** -> switched to a namespace import (`import * as pako from 'pako'`).
- **`{ to: 'string' }` removed** -> the `inflate` call now uses `{ toText: true }`.
- **pako 3 ships its own type definitions** (`dist/pako.d.ts`) -> dropped the now-redundant `@types/pako` devDependency (DefinitelyTyped never published a v3).

The `deflate` call site is unchanged (pako 3 still accepts a string input and returns `Uint8Array`).

## Notes

- Not a security fix: `npm audit` and the GitHub Advisory Database report no advisories for pako at any version. This is a stay-current-with-latest-major bump.
- pako 3's `legacyHash` now defaults to `false`, making deflate output match standard/Node zlib. Factorio reads standard zlib, so encoded blueprint strings remain valid.

## Test plan

- [x] `tsc` type-check clean on the pako/bpString path (pako 3 self-types)
- [x] Node round-trip (mirroring decode/encode logic) on two real Space Age blueprint books: decode + encode + deep-equal **PASS**
- [x] Browser smoke test in the Vite/PixiJS bundle: `getBlueprintOrBookFromSource()` decoded a 12-entry Book and `loadBp()` rendered it with no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)