### PR TITLE
fix(editor): Batch 2a - narrow sprite-shape unions in spriteDataBuilder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: npm run test:scripts
 
+      - name: Unit tests (editor)
+        if: ${{ !cancelled() }}
+        run: npm run test:unit
+
       - name: Type-check gate
         if: ${{ !cancelled() }}
         run: npm run type-check:gate

--- a/docs/superpowers/plans/2026-06-29-batch-2a-sprite-shape-narrowing-implementation.md
+++ b/docs/superpowers/plans/2026-06-29-batch-2a-sprite-shape-narrowing-implementation.md
@@ -1,0 +1,831 @@
+# Batch 2a: Sprite-shape narrowing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the 49 mechanical sprite-shape/return-type TypeScript errors in `packages/editor/src/core/spriteDataBuilder.ts` by routing typed-factorio `Base | Struct` union access through a new, unit-tested pure helper module, dropping the type-check gate baseline from 59 to the measured remainder (expected 10).
+
+**Architecture:** Add `packages/editor/src/core/spriteShape.ts` — pure functions that collapse typed-factorio sprite unions (`SpriteVariations`, `Sprite4Way`, `Animation4Way`, `RotatedAnimation8Way`, turret `base_visualisation`) to the concrete `SpriteData` runtime shape using `in`-operator narrowing. Call sites in `spriteDataBuilder.ts` replace direct struct-member access (`.layers`, `.sheet`, `.sheets`, `.animation`, `.north`) with helper calls. Helpers are unit-tested with Vitest, which is new to `packages/editor`.
+
+**Tech Stack:** TypeScript 5.9, typed-factorio 3.35, Vitest 3.x (new), the existing `scripts/type-check-gate.mjs` CI gate.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-27-batch-2a-sprite-shape-narrowing-design.md`
+
+## Global Constraints
+
+These are locked principles from the spec's review reconciliation. Every task is bound by them; **do not reverse without asking the user.**
+
+- **No defensive null-handling in helpers.** Helpers take typed-factorio field types as-is (mostly non-optional) and do **not** accept `undefined | null` or swallow it into `[]`. A malformed-data access must still throw so the existing `getSpriteData` try/catch (`spriteDataBuilder.ts:150-159`) catches it, logs, and returns `SPRITE_GENERATION_FAILED`. Silent empty returns would hide that diagnostic. Call sites that are already optional (e.g. `e.folded_animation?.layers?.[0]`) keep handling optionality locally.
+- **`sheetOf` returns `SpriteData`, never `SpriteData | undefined`.** Results feed straight into `duplicateAndSetPropertyUsing(...)`, which requires non-undefined `SpriteData`.
+- **No speculative recursion / branches.** Add a union branch to a helper only when a real failing call site needs it (TDD-driven). Do not pre-handle shapes no site exercises.
+- **Narrowest cast, not `as any`.** Where a struct member (`SpriteSheet`, `SpriteNWaySheet`) must become `SpriteData`, use `as SpriteData` (or `as unknown as SpriteData`) with a short comment. Blanket `as any` is the exact thing this cleanup removes.
+- **`SpriteData` is the file alias** for `factorio:prototype` `Sprite` (`import { Sprite as SpriteData } from 'factorio:prototype'`). The new module imports it the same way. `spriteShape.ts` lives in `core/`, so its util import is `../common/util` (not needed unless a helper uses it).
+- **No typed-factorio augmentation in 2a.** If a site that looks mechanical turns out to need a genuinely-absent field, defer it to 2b and leave it as a remaining gate error. The 2a target is "whatever remains after the mechanical sites are fixed" (expected 10); `maxErrors` is set to that measured number, not a hard zero.
+- **Prefer the latest stable Vitest** (3.x line) per repo's current-versions preference.
+
+---
+
+## File Structure
+
+- **Create** `packages/editor/src/core/spriteShape.ts` — the six pure narrowing helpers. No PixiJS / FD dependency.
+- **Create** `packages/editor/src/core/spriteShape.test.ts` — Vitest unit tests, one `describe` per helper, every union branch covered with inline fixtures.
+- **Create** `packages/editor/vitest.config.ts` — Vitest config (node env, `src/**/*.test.ts`).
+- **Modify** `packages/editor/package.json` — add `vitest` devDependency + `test:unit` / `test:unit:watch` scripts.
+- **Modify** `package.json` (root) — add `"test:unit": "npm --workspace=@fbe/editor run test:unit"`.
+- **Modify** `.github/workflows/ci.yml` — add a unit-test step before the type-check gate.
+- **Modify** `packages/editor/src/core/spriteDataBuilder.ts` — convert ~49 call sites to helpers; add the `spriteShape` import.
+- **Modify** `scripts/type-check-baseline.json` — ratchet `maxErrors` 59 → measured remainder.
+
+## Helper interfaces (the shared contract)
+
+Every conversion task consumes these. Signatures are pinned during TDD but should land as:
+
+```ts
+// packages/editor/src/core/spriteShape.ts
+import { Sprite as SpriteData } from 'factorio:prototype'
+import type {
+    SpriteVariations,
+    Sprite4Way,
+    Animation4Way,
+    RotatedAnimation8Way,
+    TurretBaseVisualisation,
+} from 'factorio:prototype'
+
+// 'layers' in x ? x.layers : [x]
+export function layersOf(
+    x: SpriteVariations | SpriteData | Animation4Way | RotatedAnimation8Way
+): readonly SpriteData[]
+
+// 'sheet' in x ? x.sheet : x   (struct member coerced `as SpriteData`)
+export function sheetOf(x: SpriteVariations | Sprite4Way): SpriteData
+
+// 'sheets' in x ? x.sheets : [x]
+export function sheetsOf(x: Sprite4Way): readonly SpriteData[]
+
+// directional Animation4Way -> that direction's layers
+export function fourWayAnimation(x: Animation4Way, dir: number): readonly SpriteData[]
+
+// resolve array|object base_visualisation, return its animation layers;
+// pass dir for the directional (fluid-turret) form
+export function baseVisualisationLayers(
+    bv: TurretBaseVisualisation | readonly TurretBaseVisualisation[],
+    dir?: number
+): readonly SpriteData[]
+
+// SpriteVariations -> SpriteData[] for return/arg-type positions
+export function toSpriteArray(x: SpriteVariations): readonly SpriteData[]
+```
+
+> The exact member type names (`TurretBaseVisualisation`, the `Animation4Way` direction keys) must be confirmed against the installed `typed-factorio` `.d.ts` during Task 1 — adjust imports to the real exported names. Use `util.getDirName(dir)` from `../common/util` inside `fourWayAnimation` for the direction key, matching existing call-site usage.
+
+---
+
+### Task 1: Vitest infrastructure + first helper (`layersOf`)
+
+Stands up the editor's unit-test home and delivers the first helper end-to-end (TDD). Folds all Vitest scaffolding into the task whose deliverable needs it.
+
+**Files:**
+
+- Create: `packages/editor/vitest.config.ts`
+- Create: `packages/editor/src/core/spriteShape.ts`
+- Create: `packages/editor/src/core/spriteShape.test.ts`
+- Modify: `packages/editor/package.json`
+- Modify: `package.json` (root)
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+
+- Produces: `layersOf(x): readonly SpriteData[]` — `'layers' in x ? x.layers : [x]`.
+
+- [ ] **Step 1: Install Vitest**
+
+```bash
+npm install --save-dev --workspace=@fbe/editor vitest
+```
+
+Expected: `vitest` (3.x) added to `packages/editor/package.json` devDependencies; lockfile updated.
+
+- [ ] **Step 2: Add Vitest config**
+
+Create `packages/editor/vitest.config.ts`:
+
+```ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/*.test.ts'],
+    },
+})
+```
+
+- [ ] **Step 3: Add unit-test scripts**
+
+In `packages/editor/package.json`, add to `scripts` (create the block if absent):
+
+```json
+"scripts": {
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest"
+}
+```
+
+In root `package.json` `scripts`, add:
+
+```json
+"test:unit": "npm --workspace=@fbe/editor run test:unit"
+```
+
+- [ ] **Step 4: Write the failing test for `layersOf`**
+
+Create `packages/editor/src/core/spriteShape.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { layersOf } from './spriteShape'
+
+describe('layersOf', () => {
+    it('returns the layers array when the value has a layers property', () => {
+        const a = { filename: 'a.png' }
+        const b = { filename: 'b.png' }
+        const input = { layers: [a, b] }
+        expect(layersOf(input as never)).toEqual([a, b])
+    })
+
+    it('wraps a bare sprite (no layers) into a single-element array', () => {
+        const bare = { filename: 'c.png' }
+        expect(layersOf(bare as never)).toEqual([bare])
+    })
+})
+```
+
+- [ ] **Step 5: Run the test to verify it fails**
+
+Run: `npm run test:unit --workspace=@fbe/editor`
+Expected: FAIL — `layersOf` is not exported / module `./spriteShape` not found.
+
+- [ ] **Step 6: Implement `layersOf`**
+
+Create `packages/editor/src/core/spriteShape.ts`:
+
+```ts
+import { Sprite as SpriteData } from 'factorio:prototype'
+import type { SpriteVariations, Animation4Way, RotatedAnimation8Way } from 'factorio:prototype'
+
+/**
+ * Sprite-shape narrowing helpers.
+ *
+ * typed-factorio models several sprite types as `Base | Struct` unions. The
+ * runtime data from data.json is always one concrete shape; these helpers
+ * collapse the union to `SpriteData` using `in`-operator guards. No defensive
+ * null-handling: malformed data still throws and is caught + logged by
+ * getSpriteData's try/catch in spriteDataBuilder.ts.
+ */
+
+/** `'layers' in x ? x.layers : [x]` */
+export function layersOf(
+    x: SpriteVariations | SpriteData | Animation4Way | RotatedAnimation8Way
+): readonly SpriteData[] {
+    return 'layers' in x ? (x.layers as readonly SpriteData[]) : [x as SpriteData]
+}
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `npm run test:unit --workspace=@fbe/editor`
+Expected: PASS (2 tests).
+
+- [ ] **Step 8: Add the CI unit-test step**
+
+In `.github/workflows/ci.yml`, insert before the `Type-check gate` step:
+
+```yaml
+- name: Unit tests (editor)
+  if: ${{ !cancelled() }}
+  run: npm run test:unit
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/editor/vitest.config.ts packages/editor/src/core/spriteShape.ts \
+  packages/editor/src/core/spriteShape.test.ts packages/editor/package.json \
+  package.json package-lock.json .github/workflows/ci.yml
+git commit -m "test(editor): add Vitest + layersOf sprite-shape helper
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_018WQod3TsJZkoYZPzL6k8MS"
+```
+
+---
+
+### Task 2: Convert `.layers` call sites via `layersOf`
+
+Routes every `.layers`-on-union TS2339 site through `layersOf` and removes any `(e as any)` used purely to dodge that union. ~18 + the two RotatedAnimation8Way `.layers` sites.
+
+**Files:**
+
+- Modify: `packages/editor/src/core/spriteDataBuilder.ts`
+
+**Interfaces:**
+
+- Consumes: `layersOf` (Task 1).
+
+- [ ] **Step 1: Add the import**
+
+Near the top of `spriteDataBuilder.ts`, add (group with existing local-core imports):
+
+```ts
+import { layersOf } from './spriteShape'
+```
+
+- [ ] **Step 2: Convert the representative sites**
+
+Examples (apply the same transform to every `.layers`-on-union site `tsc` flags):
+
+`draw_ammo_turret` (lines ~848-849):
+
+```ts
+duplicateAndSetPropertyUsing(layersOf(e.folded_animation)[0], 'y', 'height', data.dir / 4),
+duplicateAndSetPropertyUsing(layersOf(e.folded_animation)[1], 'y', 'height', data.dir / 4),
+```
+
+`draw_artillery_turret` `base_picture.layers` (line ~927):
+
+```ts
+return [...layersOf(e.base_picture), barrel, base]
+```
+
+`draw_assembling_machine` `idle_animation.layers` (line ~959):
+
+```ts
+return layersOf(e.graphics_set.idle_animation)
+```
+
+`draw_*` SpriteVariations `.layers` (line ~2114) and the RotatedAnimation8Way `.layers` (lines ~2227, ~2230): wrap each in `layersOf(...)`.
+
+- [ ] **Step 3: Recompile to confirm only `.layers` errors cleared**
+
+Run: `npx tsc --noEmit -p packages/editor/tsconfig.json 2>&1 | grep -c "error TS"`
+Expected: count dropped by the number of `.layers` sites converted; no new errors introduced. Spot-check `grep "layers" ` of the tsc output is empty for converted sites.
+
+- [ ] **Step 4: Run unit tests**
+
+Run: `npm run test:unit`
+Expected: PASS (still green — no helper change).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/editor/src/core/spriteDataBuilder.ts
+git commit -m "refactor(editor): route .layers union access through layersOf
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_018WQod3TsJZkoYZPzL6k8MS"
+```
+
+---
+
+### Task 3: `sheetOf` helper + `.sheet` call sites
+
+Delivers `sheetOf` (TDD) and converts the ~14 `.sheet` TS2339 sites plus the beacon-module `SpriteVariations -> ExtendedSpriteData` TS2345 sites that resolve to a single sprite.
+
+**Files:**
+
+- Modify: `packages/editor/src/core/spriteShape.ts`
+- Modify: `packages/editor/src/core/spriteShape.test.ts`
+- Modify: `packages/editor/src/core/spriteDataBuilder.ts`
+
+**Interfaces:**
+
+- Consumes: nothing new.
+- Produces: `sheetOf(x): SpriteData` — `'sheet' in x ? x.sheet : x`, struct member coerced `as SpriteData`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spriteShape.test.ts`:
+
+```ts
+import { sheetOf } from './spriteShape'
+
+describe('sheetOf', () => {
+    it('returns the sheet when the value is a struct with a sheet', () => {
+        const sheet = { filename: 's.png', width: 1, height: 1 }
+        expect(sheetOf({ sheet } as never)).toBe(sheet)
+    })
+
+    it('returns the value itself when it is a bare sheet/sprite', () => {
+        const bare = { filename: 'bare.png', width: 1, height: 1 }
+        expect(sheetOf(bare as never)).toBe(bare)
+    })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm run test:unit --workspace=@fbe/editor`
+Expected: FAIL — `sheetOf` not exported.
+
+- [ ] **Step 3: Implement `sheetOf`**
+
+Add to `spriteShape.ts` (extend the `Sprite4Way` import):
+
+```ts
+/** `'sheet' in x ? x.sheet : x` — struct member coerced to SpriteData. */
+export function sheetOf(x: SpriteVariations | Sprite4Way): SpriteData {
+    // SpriteSheet/SpriteNWaySheet are structurally SpriteData at runtime.
+    return 'sheet' in x ? (x.sheet as unknown as SpriteData) : (x as SpriteData)
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm run test:unit --workspace=@fbe/editor`
+Expected: PASS.
+
+- [ ] **Step 5: Convert the `.sheet` call sites**
+
+Examples — apply to every `.sheet`-on-union site `tsc` flags:
+
+`draw_locomotive` `platform_picture.sheet` (line ~1670):
+
+```ts
+duplicateAndSetPropertyUsing(sheetOf(e.platform_picture), 'x', 'width', ((data.dir + 8) % 16) / 4),
+```
+
+`draw_gate` (line ~1819, two occurrences on one line): wrap each `*.sheet` in `sheetOf(...)`.
+
+Foundry/locomotive `SpriteVariations.sheet` / `AnimationVariations.sheet` (lines ~2043, ~2053, ~2208, ~2216) and `Sprite4Way.sheet` (line ~2311): wrap in `sheetOf(...)`.
+
+beacon module pictures `util.duplicate(slot.pictures)` (lines ~1022, ~1029 TS2345): change `slot.pictures` to `sheetOf(slot.pictures)` so the duplicated value is `SpriteData` (resolves the `SpriteVariations -> ExtendedSpriteData` argument error). Confirm with tsc that these two specific TS2345 lines clear; the neighbouring `module.tier` (line ~1018) and `module.beacon_tint` (line ~1025) are **2b — leave them erroring.**
+
+Add the import line for `sheetOf` (extend the existing `./spriteShape` import).
+
+- [ ] **Step 6: Recompile + unit tests**
+
+Run: `npx tsc --noEmit -p packages/editor/tsconfig.json 2>&1 | grep -c "error TS"`
+Expected: count dropped by the `.sheet` sites; `tier`/`beacon_tint` still present.
+Run: `npm run test:unit`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/editor/src/core/spriteShape.ts packages/editor/src/core/spriteShape.test.ts \
+  packages/editor/src/core/spriteDataBuilder.ts
+git commit -m "refactor(editor): add sheetOf and route .sheet union access through it
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_018WQod3TsJZkoYZPzL6k8MS"
+```
+
+---
+
+### Task 4: `sheetsOf` helper + `.sheets` call sites
+
+`sheetsOf` (TDD) and the 4 `.sheets`-on-`Sprite4Way` sites (pumpjack `base_picture.sheets[0]`, transport-belt structures).
+
+**Files:**
+
+- Modify: `packages/editor/src/core/spriteShape.ts`, `spriteShape.test.ts`, `spriteDataBuilder.ts`
+
+**Interfaces:**
+
+- Produces: `sheetsOf(x): readonly SpriteData[]` — `'sheets' in x ? x.sheets : [x]`.
+
+- [ ] **Step 1: Failing test**
+
+```ts
+import { sheetsOf } from './spriteShape'
+
+describe('sheetsOf', () => {
+    it('returns the sheets array from a struct', () => {
+        const s0 = { filename: 's0.png' }
+        expect(sheetsOf({ sheets: [s0] } as never)).toEqual([s0])
+    })
+
+    it('wraps a bare sprite into a single-element array', () => {
+        const bare = { filename: 'b.png' }
+        expect(sheetsOf(bare as never)).toEqual([bare])
+    })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails** — `npm run test:unit --workspace=@fbe/editor` → FAIL.
+
+- [ ] **Step 3: Implement**
+
+```ts
+/** `'sheets' in x ? x.sheets : [x]` */
+export function sheetsOf(x: Sprite4Way): readonly SpriteData[] {
+    return 'sheets' in x && x.sheets
+        ? (x.sheets as unknown as readonly SpriteData[])
+        : [x as SpriteData]
+}
+```
+
+- [ ] **Step 4: Run to verify it passes** — PASS.
+
+- [ ] **Step 5: Convert call sites**
+
+`draw_mining_drill` pumpjack (line ~1857):
+
+```ts
+duplicateAndSetPropertyUsing(sheetsOf(e.base_picture)[0], 'x', 'width', data.dir / 4),
+```
+
+Transport-belt `.sheets` sites (lines ~2154, ~2157): wrap in `sheetsOf(...)`. Extend the `./spriteShape` import.
+
+- [ ] **Step 6: Recompile + unit tests** — count drops by the `.sheets` sites; `npm run test:unit` PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/editor/src/core/spriteShape.ts packages/editor/src/core/spriteShape.test.ts \
+  packages/editor/src/core/spriteDataBuilder.ts
+git commit -m "refactor(editor): add sheetsOf and route .sheets union access through it
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_018WQod3TsJZkoYZPzL6k8MS"
+```
+
+---
+
+### Task 5: `fourWayAnimation` helper + directional `.animation`/`.north` sites
+
+`fourWayAnimation` (TDD) for the directional `Animation4Way` sites: pumpjack `graphics_set.animation.north.layers` (line ~1858) and the `Animation4Way` `.layers` sites that are actually directional (lines ~927 family if directional, ~959). Confirm per site whether the animation is directional (struct with `north`/`east`/...) or flat (`layers`) — flat ones already went through `layersOf` in Task 2; only directional ones use `fourWayAnimation`.
+
+**Files:**
+
+- Modify: `packages/editor/src/core/spriteShape.ts`, `spriteShape.test.ts`, `spriteDataBuilder.ts`
+
+**Interfaces:**
+
+- Produces: `fourWayAnimation(x, dir): readonly SpriteData[]` — directional struct → `layersOf(x[dirName(dir)])`.
+
+- [ ] **Step 1: Failing test**
+
+```ts
+import { fourWayAnimation } from './spriteShape'
+
+describe('fourWayAnimation', () => {
+    it('returns the layers for the resolved direction', () => {
+        const n0 = { filename: 'n.png' }
+        const input = {
+            north: { layers: [n0] },
+            east: { layers: [] },
+            south: { layers: [] },
+            west: { layers: [] },
+        }
+        expect(fourWayAnimation(input as never, 0)).toEqual([n0])
+    })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails** — FAIL.
+
+- [ ] **Step 3: Implement** (uses `util.getDirName`)
+
+```ts
+import util from '../common/util'
+// ...
+/** Resolve a directional Animation4Way to its layers for `dir`. */
+export function fourWayAnimation(x: Animation4Way, dir: number): readonly SpriteData[] {
+    const directional = x as Record<string, unknown>
+    return layersOf(directional[util.getDirName(dir)] as never)
+}
+```
+
+> Confirm `util.getDirName` returns the lowercase `north`/`east`/`south`/`west` keys these structs use; it is already used for this exact purpose at call sites like line ~1853.
+
+- [ ] **Step 4: Run to verify it passes** — PASS.
+
+- [ ] **Step 5: Convert call sites**
+
+pumpjack (line ~1858):
+
+```ts
+...fourWayAnimation(e.graphics_set.animation, 0),
+```
+
+(`north` == dir 0.) Any other directional `Animation4Way` site `tsc` still flags: route through `fourWayAnimation(anim, data.dir)`.
+
+- [ ] **Step 6: Recompile + unit tests** — count drops; `npm run test:unit` PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/editor/src/core/spriteShape.ts packages/editor/src/core/spriteShape.test.ts \
+  packages/editor/src/core/spriteDataBuilder.ts
+git commit -m "refactor(editor): add fourWayAnimation for directional animation access
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_018WQod3TsJZkoYZPzL6k8MS"
+```
+
+---
+
+### Task 6: `baseVisualisationLayers` helper + turret base-visualisation sites
+
+`baseVisualisationLayers` (TDD) replacing the `(e as any)` array/object handling in `draw_electric_turret` (lines ~1335-1336), and the `base_visualisation.animation.layers` TS2339 in `draw_ammo_turret` (line ~847) and the directional `draw_fluid_turret` (line ~1376).
+
+**Files:**
+
+- Modify: `packages/editor/src/core/spriteShape.ts`, `spriteShape.test.ts`, `spriteDataBuilder.ts`
+
+**Interfaces:**
+
+- Consumes: `layersOf`, `fourWayAnimation`.
+- Produces: `baseVisualisationLayers(bv, dir?): readonly SpriteData[]`.
+
+- [ ] **Step 1: Failing test**
+
+```ts
+import { baseVisualisationLayers } from './spriteShape'
+
+describe('baseVisualisationLayers', () => {
+    const layer = { filename: 'base.png' }
+
+    it('handles the object form (non-directional animation)', () => {
+        expect(baseVisualisationLayers({ animation: { layers: [layer] } } as never)).toEqual([
+            layer,
+        ])
+    })
+
+    it('handles the array form by taking the first element', () => {
+        expect(baseVisualisationLayers([{ animation: { layers: [layer] } }] as never)).toEqual([
+            layer,
+        ])
+    })
+
+    it('handles the directional form when dir is provided', () => {
+        const bv = {
+            animation: {
+                north: { layers: [layer] },
+                east: { layers: [] },
+                south: { layers: [] },
+                west: { layers: [] },
+            },
+        }
+        expect(baseVisualisationLayers(bv as never, 0)).toEqual([layer])
+    })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails** — FAIL.
+
+- [ ] **Step 3: Implement**
+
+```ts
+import type { TurretBaseVisualisation } from 'factorio:prototype'
+// ...
+/**
+ * Resolve a turret base_visualisation (array or object form) to its animation
+ * layers. Pass `dir` for the directional (fluid-turret) animation form.
+ */
+export function baseVisualisationLayers(
+    bv: TurretBaseVisualisation | readonly TurretBaseVisualisation[],
+    dir?: number
+): readonly SpriteData[] {
+    const base = Array.isArray(bv) ? bv[0] : bv
+    const anim = (base as TurretBaseVisualisation).animation
+    return dir === undefined ? layersOf(anim as never) : fourWayAnimation(anim as never, dir)
+}
+```
+
+> Confirm the real exported name for the base-visualisation element type and `animation` member against the installed typed-factorio `.d.ts`; adjust the import/cast if it differs.
+
+- [ ] **Step 4: Run to verify it passes** — PASS.
+
+- [ ] **Step 5: Convert call sites**
+
+`draw_ammo_turret` (line ~847):
+
+```ts
+...baseVisualisationLayers(e.graphics_set.base_visualisation),
+```
+
+`draw_electric_turret` (lines ~1335-1336) — remove the `(e as any)` + `Array.isArray` dance:
+
+```ts
+const baseLayers = baseVisualisationLayers(e.graphics_set.base_visualisation)
+return [
+    ...baseLayers,
+    duplicateAndSetPropertyUsing(layersOf(e.folded_animation)[0], 'y', 'height', data.dir / 4),
+    duplicateAndSetPropertyUsing(layersOf(e.folded_animation)[2], 'y', 'height', data.dir / 4),
+]
+```
+
+`draw_fluid_turret` (line ~1376):
+
+```ts
+...baseVisualisationLayers(e.graphics_set.base_visualisation, data.dir),
+```
+
+> Leave `draw_railgun_turret` (lines ~855-856) as-is — it uses `(e as any)` with optional chaining and is **not** in the 49-error set; converting it is out of scope.
+
+- [ ] **Step 6: Recompile + unit tests** — count drops; `npm run test:unit` PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/editor/src/core/spriteShape.ts packages/editor/src/core/spriteShape.test.ts \
+  packages/editor/src/core/spriteDataBuilder.ts
+git commit -m "refactor(editor): add baseVisualisationLayers for turret base visualisation
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_018WQod3TsJZkoYZPzL6k8MS"
+```
+
+---
+
+### Task 7: `toSpriteArray` helper + return/arg-type sites
+
+`toSpriteArray` (TDD) for the TS2322 `draw_*` return-type mismatches and TS2345 arg-type mismatches where a `SpriteVariations`-typed value flows into a `readonly Sprite[]` / `Sprite[]` position — the rail `getBaseSprites` (lines ~1701, ~1711, ~1713) and the `util.getRandomItem(...)` args at lines ~1533, ~1535.
+
+**Files:**
+
+- Modify: `packages/editor/src/core/spriteShape.ts`, `spriteShape.test.ts`, `spriteDataBuilder.ts`
+
+**Interfaces:**
+
+- Produces: `toSpriteArray(x): readonly SpriteData[]`.
+
+- [ ] **Step 1: Failing test**
+
+```ts
+import { toSpriteArray } from './spriteShape'
+
+describe('toSpriteArray', () => {
+    it('returns an array unchanged', () => {
+        const arr = [{ filename: 'a.png' }, { filename: 'b.png' }]
+        expect(toSpriteArray(arr as never)).toEqual(arr)
+    })
+
+    it('wraps a single sprite into an array', () => {
+        const one = { filename: 'a.png' }
+        expect(toSpriteArray(one as never)).toEqual([one])
+    })
+
+    it('returns the sheet struct member wrapped in an array', () => {
+        const sheet = { filename: 's.png' }
+        expect(toSpriteArray({ sheet } as never)).toEqual([sheet])
+    })
+})
+```
+
+> Pin the branches to exactly the runtime shapes the rail/getRandomItem sites produce — do not add a `.sheet` branch unless a real site needs it (Global Constraint: no speculative branches). Trim the third test if no site exercises the struct form.
+
+- [ ] **Step 2: Run to verify it fails** — FAIL.
+
+- [ ] **Step 3: Implement** (start minimal; add branches only as sites demand)
+
+```ts
+/** Coerce a SpriteVariations value to a SpriteData[] for return/arg positions. */
+export function toSpriteArray(x: SpriteVariations): readonly SpriteData[] {
+    if (Array.isArray(x)) return x as readonly SpriteData[]
+    if ('sheet' in x) return [(x as { sheet: unknown }).sheet as SpriteData]
+    return [x as SpriteData]
+}
+```
+
+- [ ] **Step 4: Run to verify it passes** — PASS.
+
+- [ ] **Step 5: Convert call sites**
+
+`draw_straight_rail` `getBaseSprites` (lines ~1713-1719): change the return type to `SpriteData[]` and map each entry through the right helper so the function returns `readonly SpriteData[]`. Each `ps.*` is a `SpriteVariations`; flatten:
+
+```ts
+function getBaseSprites(): readonly SpriteData[] {
+    let ps = e.pictures[util.getDirName8Way(dir)]
+    if (Object.entries(ps).length === 0) {
+        ps = e.pictures[util.getDirName8Way(dir % 8)]
+    }
+    return [
+        ...toSpriteArray(ps.stone_path_background),
+        ...toSpriteArray(ps.stone_path),
+        ...toSpriteArray(ps.ties),
+        ...toSpriteArray(ps.backplates),
+        ...toSpriteArray(ps.metals),
+    ]
+}
+```
+
+> Verify against the existing `draw_rail` runtime behavior (line ~1707 returns the bare `ps.*` values as elements). If each `ps.*` is a single sprite (not variations), `toSpriteArray` yields a one-element array per entry and the flattened result matches the original 5-element list — confirm with the render check in Task 8. If they are genuinely single sprites, a narrower `sheetOf`/`as SpriteData` per entry may read better; choose whichever keeps the rendered output identical.
+
+`util.getRandomItem(getOpt())` / `getRandomItem(e.connection_sprites.single)` (lines ~1533, ~1535): wrap the `SpriteVariations` arg so it matches `getRandomItem`'s `Sprite[]` parameter — `util.getRandomItem(toSpriteArray(getOpt()))`. Confirm `getRandomItem`'s signature in `../common/util` and that wrapping preserves the prior random-pick behavior.
+
+The `draw_*` return-type TS2322 errors (lines ~1003, ~1345, ~1701, ~1711) clear once their inner arrays are `SpriteData[]`.
+
+- [ ] **Step 6: Recompile + unit tests** — count drops; `npm run test:unit` PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/editor/src/core/spriteShape.ts packages/editor/src/core/spriteShape.test.ts \
+  packages/editor/src/core/spriteDataBuilder.ts
+git commit -m "refactor(editor): add toSpriteArray for return/arg-type sprite coercion
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_018WQod3TsJZkoYZPzL6k8MS"
+```
+
+---
+
+### Task 8: Ratchet the gate, verify rendering, open the PR
+
+Measure the final error count, lock it into the gate, run the full local CI surface, render-check the touched entities, and open the PR.
+
+**Files:**
+
+- Modify: `scripts/type-check-baseline.json`
+
+- [ ] **Step 1: Measure remaining errors**
+
+Run: `npx tsc --noEmit -p packages/editor/tsconfig.json 2>&1 | grep -c "error TS"`
+Expected: ~10. Confirm the remainder is exactly the 2b set — `'size'` (×5), `tier`, `beacon_tint`, `horizontal_rail_base`, `vertical_rail_base`, `line_length`:
+Run: `npx tsc --noEmit -p packages/editor/tsconfig.json 2>&1 | grep "error TS"`
+Expected: every line matches a 2b item. **If any non-2b error remains, it is an unconverted 2a site — go back and convert it before ratcheting.** If a site turned out to need augmentation, leave it and note it for 2b (the measured number absorbs it).
+
+- [ ] **Step 2: Set the baseline to the measured number**
+
+Edit `scripts/type-check-baseline.json` — set `"maxErrors"` to the exact count from Step 1:
+
+```json
+{
+    "project": "packages/editor/tsconfig.json",
+    "maxErrors": 10
+}
+```
+
+- [ ] **Step 3: Run the gate and the full check surface**
+
+```bash
+npm run type-check:gate
+npm run test:unit
+npm run test:scripts
+npm run lint
+npm run format
+```
+
+Expected: gate PASSES at the new ceiling; unit + script tests green; eslint clean; prettier reports no formatting issues. If prettier flags files, run `npm run format:fix` and re-stage (avoids the Batch 1 CI prettier miss).
+
+- [ ] **Step 4: Render check in the dev editor**
+
+Start both dev servers (see CLAUDE.md): `cd packages/website && npm run start` and `npx serve packages/exporter/data/output -l 8081 --cors`. Load a blueprint exercising the touched `draw_*` functions and confirm sprites render unchanged:
+
+- rails (straight + elevated), walls, beacon, ammo turret, electric turret, fluid turret, transport belt, pumpjack, locomotive.
+
+Use a known Space Age blueprint from `wormeyman-tests/` or factorio.school. Confirm no new console errors and no `SPRITE_GENERATION_FAILED` placeholders for these entities.
+
+- [ ] **Step 5: Commit the ratchet**
+
+```bash
+git add scripts/type-check-baseline.json
+git commit -m "chore(editor): lower type-check baseline 59 -> 10 after Batch 2a
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_018WQod3TsJZkoYZPzL6k8MS"
+```
+
+- [ ] **Step 6: Push and open the PR against the fork**
+
+```bash
+git push -u origin fix/editor-type-errors-batch-2a
+gh pr create --base wormeyman-space-age-support \
+  --title "fix(editor): Batch 2a — narrow sprite-shape unions in spriteDataBuilder" \
+  --body "$(cat <<'EOF'
+## Summary
+Batch 2a of the editor type-error cleanup. Introduces `packages/editor/src/core/spriteShape.ts`, a unit-tested module of pure narrowing helpers that collapse typed-factorio `Base | Struct` sprite unions to `SpriteData`. Call sites in `spriteDataBuilder.ts` now route union access through these helpers instead of reading struct-only members off the union. Lowers the type-check gate baseline 59 -> 10 with no runtime behavior change.
+
+Helpers: `layersOf`, `sheetOf`, `sheetsOf`, `fourWayAnimation`, `baseVisualisationLayers`, `toSpriteArray`. Adds Vitest to `packages/editor` as the editor's unit-test home (new CI step before the gate).
+
+Remaining 10 errors are the Batch 2b judgment calls (the `'size'` key + 5 genuine typed-factorio gaps).
+
+## Verification
+- `npm run test:unit` green (every helper branch covered)
+- type-check gate passes at maxErrors 10; remaining errors are all 2b items
+- prettier + eslint clean
+- render check: rails, walls, beacon, ammo/electric/fluid turret, transport belt, pumpjack, locomotive render unchanged in the dev editor
+
+Design spec: `docs/superpowers/specs/2026-06-27-batch-2a-sprite-shape-narrowing-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Verification (PR done-criteria summary)
+
+1. `npm run test:unit` green — every helper branch covered.
+2. `npx tsc --noEmit -p packages/editor/tsconfig.json` error count is the measured 2a remainder (expected 10); `scripts/type-check-baseline.json` `maxErrors` set to exactly that; `npm run type-check:gate` passes.
+3. Render check: rails, walls, beacon, ammo/electric/fluid turret, transport belt, pumpjack, locomotive render unchanged in the dev editor; no new `SPRITE_GENERATION_FAILED`.
+4. `npm run format` and `npm run lint` clean before pushing.
+
+## Out of scope (Batch 2b)
+
+- The 5 `'size'` argument errors → augment `ExtendedSpriteData` with `size`.
+- Genuine typed-factorio gaps: `beacon_tint`, `tier`, `horizontal_rail_base`, `vertical_rail_base`, `line_length`.
+- Any unrelated `(e as any)` cleanup not required to fix a 2a error (e.g. `draw_railgun_turret`).

--- a/docs/superpowers/specs/2026-06-27-batch-2a-sprite-shape-narrowing-design.md
+++ b/docs/superpowers/specs/2026-06-27-batch-2a-sprite-shape-narrowing-design.md
@@ -1,0 +1,164 @@
+# Batch 2a: Sprite-shape narrowing in spriteDataBuilder.ts
+
+Date: 2026-06-27
+Status: Approved (design)
+Branch base: `wormeyman-space-age-support`
+
+## Context
+
+The editor enforces a TypeScript error budget via a CI gate
+(`scripts/type-check-baseline.json`, runner `scripts/type-check-gate.mjs`). The
+gate fails only when the error count exceeds the committed `maxErrors`. As
+errors are fixed, `maxErrors` is ratcheted down to lock the gain.
+
+Batch 1 (merged, PR #7) lowered the baseline 87 -> 59 by narrowing entity
+prototypes to their typed-factorio subtypes via `in`-operator and `isX` type
+guards instead of `as any` casts. All 59 remaining errors live in one file:
+`packages/editor/src/core/spriteDataBuilder.ts` (2452 lines).
+
+Those 59 split into two kinds of problem. Batch 2 was scoped (with the user)
+into two PRs:
+
+- **2a (this spec):** the 49 "mechanical" errors - sprite-data-structure
+  union access and `draw_*` return/argument-type mismatches. These are
+  genuinely narrowable from typed-factorio's existing types; no augmentation
+  needed.
+- **2b (separate spec, later):** the 10 judgment-call errors - the `'size'`
+  key (5, needs `ExtendedSpriteData` augmentation) and genuine typed-factorio
+  gaps (5: `beacon_tint`, `tier`, `horizontal_rail_base`,
+  `vertical_rail_base`, `line_length`).
+
+The intended outcome of 2a: baseline 59 -> 10, no runtime behavior change, and
+a reusable unit-test home for the editor package.
+
+## Problem detail
+
+typed-factorio models several sprite types as `Base | Struct` unions, e.g.:
+
+- `Sprite4Way = Sprite4WayStruct | Sprite` where the struct has optional
+  `sheets`, `sheet`, `north`/`east`/`south`/`west`.
+- `SpriteVariations = SpriteVariationsStruct | SpriteSheet | readonly Sprite[]`
+  (the struct has `sheet`).
+- `Animation4Way = Animation4WayStruct | Animation`.
+- `RotatedAnimation8Way = RotatedAnimation8WayStruct | RotatedAnimation`.
+- `AnimationVariations = AnimationVariationsStruct | Animation | readonly Animation[]`.
+- Base `Sprite` itself has `layers?: readonly Sprite[]`.
+
+The code reads struct-only members (`.layers`, `.sheet`, `.sheets`,
+`.animation`, `.north`) directly off the whole union, producing TS2339. Related
+TS2322/TS2345 errors occur where a value typed `SpriteVariations` flows into a
+`readonly Sprite[]` / `Sprite` / `ExtendedSpriteData` position.
+
+Error breakdown (the 2a subset, 49 of 59):
+
+- TS2339 (40): `.layers` (18), `.sheet` (14), `.sheets` (4), `.animation` (3),
+  `.north` (1) on the union types above.
+- TS2322 (4): `draw_*` functions returning `SpriteVariations[]` /
+  union arrays where `readonly Sprite[]` is expected.
+- TS2345 (5): `SpriteVariations` passed where `Sprite[]` / `Sprite` /
+  `ExtendedSpriteData` is expected.
+
+(The 5 `'size'` TS2345 errors and the 5 genuine-gap TS2339 errors are 2b.)
+
+## Approach (chosen: A - encapsulated coercion helpers)
+
+Add a small module of pure narrowing functions. Each takes a typed-factorio
+union and returns the concrete runtime shape, using `in`-operator guards
+internally. Call sites in `spriteDataBuilder.ts` replace direct union-member
+access with a helper call. Branching logic lives in one tested place; call
+sites get shorter; no unsafe casts.
+
+Alternatives rejected:
+
+- **B - predicate guards only** (`hasLayers(x): x is ...`, branch at each call
+  site): scatters identical `if/else` shape logic across ~48 sites and bloats
+  the `draw_*` functions.
+- **C - one broad structural coercer** casting through `unknown`: fewest lines
+  but reintroduces unsafe casts, contradicting the Batch 1 principle.
+
+## Design
+
+### New module: `packages/editor/src/core/spriteShape.ts`
+
+Pure functions, no PixiJS or FD dependency. Approximate set (final signatures
+pinned during TDD - some may merge):
+
+| Helper                    | Signature (approx)                                                                         | Covers                                                                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `layersOf`                | `(x: SpriteVariations \| Sprite \| Animation4Way \| RotatedAnimation8Way) => SpriteData[]` | the 18 `.layers` sites; `'layers' in x ? x.layers : [x]`                                                                         |
+| `sheetOf`                 | `(x: SpriteVariations \| Sprite4Way) => SpriteData`                                        | the ~14 `.sheet` sites; `'sheet' in x ? x.sheet : x`                                                                             |
+| `sheetsOf`                | `(x: Sprite4Way) => SpriteData[]`                                                          | the 4 `.sheets` sites                                                                                                            |
+| `baseVisualisationLayers` | `(bv: TurretBaseVisualisation \| readonly TurretBaseVisualisation[]) => SpriteData[]`      | turret `base_visualisation.animation.layers`, array or object form; replaces the existing `(e as any)` in `draw_electric_turret` |
+| `fourWayAnimation`        | `(x: Animation4Way, dir: number) => SpriteData[]`                                          | the `.north`/directional `.animation` sites (pumpjack)                                                                           |
+| `toSpriteArray`           | `(x: SpriteVariations) => SpriteData[]`                                                    | the TS2322 return-type and TS2345 arg-type sites (e.g. `draw_straight_rail`'s `getBaseSprites`)                                  |
+
+Helpers operate on `SpriteData`/`ExtendedSpriteData` as already used in
+`spriteDataBuilder.ts`. Where typed-factorio's struct member type and the
+runtime `SpriteData` differ harmlessly, the helper's return type is the
+`SpriteData`-shaped value the rest of the file already consumes.
+
+### Call-site changes in `spriteDataBuilder.ts`
+
+Replace direct union-member access with the helper:
+
+- `e.platform_picture.sheet` -> `sheetOf(e.platform_picture)`
+- `x.layers` -> `layersOf(x)`
+- `e.base_picture.sheets[0]` -> `sheetsOf(e.base_picture)[0]`
+- `structure.direction_in.sheet` -> `sheetOf(structure.direction_in)`
+- `draw_electric_turret`'s `(e as any).graphics_set.base_visualisation` array
+  handling -> `baseVisualisationLayers(e.graphics_set.base_visualisation)`
+- `draw_straight_rail`'s `getBaseSprites(): SpriteVariations[]` -> map each
+  element through `toSpriteArray`/`sheetOf` so it returns `SpriteData[]`
+
+`draw_*` signatures stay `(data: IDrawData) => readonly SpriteData[]`. Where a
+site currently uses `(e as any)` purely to dodge one of these unions, route it
+through the typed helper and remove the cast. Do **not** remove `(e as any)`
+casts that dodge unrelated issues (those are out of scope).
+
+### Scope boundary (mechanical vs gap)
+
+2a introduces **no** typed-factorio augmentation. If a site that looks
+mechanical turns out to require a genuinely-absent field, defer it to 2b and
+leave it as a remaining gate error rather than augmenting here. The 2a target
+is 10 (the 2b errors), not a hard zero - the exact final count is whatever
+remains after the mechanical sites are fixed, and `maxErrors` is set to that
+measured number.
+
+### Testing: Vitest in `packages/editor`
+
+The editor package has no unit-test runner today (only Playwright e2e and the
+gate's `scripts/**/*.test.mjs` via `node --test`). Add Vitest (Vite-native; the
+project already uses Vite 8):
+
+- `vitest` devDependency in `packages/editor/package.json`.
+- Scripts: `"test:unit": "vitest run"`, `"test:unit:watch": "vitest"`.
+- `packages/editor/vitest.config.ts`: node environment (pure data functions, no
+  DOM).
+- `packages/editor/src/core/spriteShape.test.ts`: for each helper, cover every
+  union branch with small inline fixtures - e.g. `layersOf` gets a
+  `{ layers: [...] }` input, a bare `Sprite`, and a variations/array input;
+  `sheetOf` gets a `{ sheet: {...} }` struct and a bare sheet. Assert the
+  returned shape. No real sprite/`.basis` files needed.
+- Add a `test:unit` step to `.github/workflows/ci.yml` alongside the existing
+  prettier/eslint/gate checks. This becomes the editor's unit-test home, reused
+  by 2b.
+
+## Verification (PR done-criteria)
+
+1. `npm run test:unit` green - every helper branch covered.
+2. Type-gate: `npx tsc --noEmit -p packages/editor/tsconfig.json` error count
+   drops to the measured 2a number (expected 10). Set `maxErrors` in
+   `scripts/type-check-baseline.json` to exactly that number.
+3. Render check: load a blueprint exercising the touched `draw_*` functions
+   (rails, walls, beacon, ammo turret, electric turret, transport belt,
+   pumpjack, locomotive) in the dev editor; confirm sprites still render
+   unchanged.
+4. `npm run format` (prettier) and `npm run lint` (eslint) clean before pushing
+    - avoids the Batch 1 CI prettier miss.
+
+## Out of scope (deferred to Batch 2b)
+
+- The 5 `'size'` argument errors -> augment `ExtendedSpriteData` with `size`.
+- Genuine typed-factorio gaps: `beacon_tint`, `tier`, `horizontal_rail_base`,
+  `vertical_rail_base`, `line_length`.
+- Any unrelated `(e as any)` cleanup not required to fix a 2a error.

--- a/docs/superpowers/specs/2026-06-27-batch-2a-sprite-shape-narrowing-design.md
+++ b/docs/superpowers/specs/2026-06-27-batch-2a-sprite-shape-narrowing-design.md
@@ -93,9 +93,36 @@ pinned during TDD - some may merge):
 | `toSpriteArray`           | `(x: SpriteVariations) => SpriteData[]`                                                    | the TS2322 return-type and TS2345 arg-type sites (e.g. `draw_straight_rail`'s `getBaseSprites`)                                  |
 
 Helpers operate on `SpriteData`/`ExtendedSpriteData` as already used in
-`spriteDataBuilder.ts`. Where typed-factorio's struct member type and the
-runtime `SpriteData` differ harmlessly, the helper's return type is the
-`SpriteData`-shaped value the rest of the file already consumes.
+`spriteDataBuilder.ts`. Note `SpriteData` is the file's alias for
+typed-factorio's `Sprite` (`import { Sprite as SpriteData } from 'factorio:prototype'`,
+`spriteDataBuilder.ts:24`); the new module imports it the same way.
+`spriteShape.ts` lives in `core/`, so its util import is `../common/util`.
+
+#### Helper implementation principles
+
+These were settled against an external spec review; they constrain the
+implementation:
+
+- **No defensive null-handling.** Helpers take the typed-factorio field types
+  as-is (mostly non-optional) and do **not** accept `undefined | null` or
+  swallow it into `[]`. This preserves current behavior: a malformed-data
+  access still throws and is caught + logged by the existing `getSpriteData`
+  try/catch (`spriteDataBuilder.ts:149-160`), which returns
+  `SPRITE_GENERATION_FAILED` and skips the entity with a diagnostic. Silent
+  empty returns would hide that. Call sites that are already optional (e.g.
+  `draw_turret`'s `e.folded_animation?.layers?.[0]`) keep handling optionality
+  locally.
+- **`sheetOf` returns `SpriteData`, never `SpriteData | undefined`.** Its
+  results feed straight into `duplicateAndSetPropertyUsing(...)`, which requires
+  non-undefined `SpriteData`; an optional return would create new type errors
+  or force `!` at ~14 sites.
+- **No speculative recursion / branches.** Add a union branch to a helper only
+  when a real failing call site needs it (TDD-driven). Do not pre-handle shapes
+  no site exercises (e.g. `layersOf` recursing through `.sheet`).
+- **Coerce with the narrowest cast, not `as any`.** Where a struct member
+  (`SpriteSheet`, `SpriteNWaySheet`) must become `SpriteData`, use
+  `as SpriteData` (or `as unknown as SpriteData`) with a short comment. Blanket
+  `as any` is the exact thing this cleanup removes.
 
 ### Call-site changes in `spriteDataBuilder.ts`
 
@@ -130,18 +157,42 @@ The editor package has no unit-test runner today (only Playwright e2e and the
 gate's `scripts/**/*.test.mjs` via `node --test`). Add Vitest (Vite-native; the
 project already uses Vite 8):
 
-- `vitest` devDependency in `packages/editor/package.json`.
-- Scripts: `"test:unit": "vitest run"`, `"test:unit:watch": "vitest"`.
-- `packages/editor/vitest.config.ts`: node environment (pure data functions, no
-  DOM).
+- `vitest` devDependency in `packages/editor/package.json` (latest stable at
+  implementation time - 3.x line; pin per repo preference for current versions).
+- Scripts in `packages/editor/package.json`: `"test:unit": "vitest run"`,
+  `"test:unit:watch": "vitest"`. Add a root convenience script to
+  `package.json`: `"test:unit": "npm --workspace=@fbe/editor run test:unit"`.
+- `packages/editor/vitest.config.ts`:
+
+    ```ts
+    import { defineConfig } from 'vitest/config'
+
+    export default defineConfig({
+        test: {
+            environment: 'node',
+            include: ['src/**/*.test.ts'],
+        },
+    })
+    ```
+
 - `packages/editor/src/core/spriteShape.test.ts`: for each helper, cover every
   union branch with small inline fixtures - e.g. `layersOf` gets a
   `{ layers: [...] }` input, a bare `Sprite`, and a variations/array input;
-  `sheetOf` gets a `{ sheet: {...} }` struct and a bare sheet. Assert the
-  returned shape. No real sprite/`.basis` files needed.
-- Add a `test:unit` step to `.github/workflows/ci.yml` alongside the existing
-  prettier/eslint/gate checks. This becomes the editor's unit-test home, reused
-  by 2b.
+  `sheetOf` gets a `{ sheet: {...} }` struct and a bare sheet;
+  `baseVisualisationLayers` gets both array and object forms;
+  `fourWayAnimation` gets a directional struct. Assert the returned shape. No
+  real sprite/`.basis` files needed. (Per TDD, tests are written before each
+  helper.)
+- Add a unit-test step to `.github/workflows/ci.yml` in the `checks` job,
+  before the type-check gate, so broken transforms fail CI:
+
+    ```yaml
+    - name: Unit tests (editor)
+      if: ${{ !cancelled() }}
+      run: npm run test:unit
+    ```
+
+    This becomes the editor's unit-test home, reused by 2b.
 
 ## Verification (PR done-criteria)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -253,6 +253,13 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -586,6 +593,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.3",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -597,10 +611,28 @@
                 "tslib": "^2.4.0"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
         "node_modules/@types/dat.gui": {
             "version": "0.7.13",
             "resolved": "https://registry.npmjs.org/@types/dat.gui/-/dat.gui-0.7.13.tgz",
             "integrity": "sha512-LmG4Pr0mbsB/1WVttf8xaHx45BvSBDGY5D9+0/9AZCbI4vvOguwBHZdKyJMxt5Yst8+icRSHKmr7ClV2u5ZtDA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
             "dev": true,
             "license": "MIT"
         },
@@ -890,6 +922,119 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+            "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.9",
+                "@vitest/utils": "4.1.9",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+            "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.9",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+            "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+            "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.9",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+            "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.9",
+                "@vitest/utils": "4.1.9",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+            "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+            "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.9",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/@webgpu/types": {
             "version": "0.1.71",
             "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
@@ -996,6 +1141,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/balanced-match": {
@@ -1107,6 +1262,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/chokidar": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1159,6 +1324,13 @@
             "engines": {
                 "node": ">=20"
             }
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -1306,6 +1478,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
+            "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/escalade": {
             "version": "3.2.0",
@@ -1475,6 +1654,16 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1490,6 +1679,16 @@
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
             "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "license": "MIT"
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -2241,6 +2440,16 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
         "node_modules/minimatch": {
             "version": "10.2.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -2298,6 +2507,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/obug": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/open": {
@@ -2433,6 +2656,13 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/pathfinding": {
             "version": "0.4.18",
@@ -2776,6 +3006,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/source-map": {
             "version": "0.7.6",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -2795,6 +3032,20 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/string-width": {
             "version": "7.2.0",
@@ -2868,6 +3119,23 @@
                 "node": ">=12"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.17",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2883,6 +3151,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/to-regex-range": {
@@ -3105,6 +3383,96 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+            "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.9",
+                "@vitest/mocker": "4.1.9",
+                "@vitest/pretty-format": "4.1.9",
+                "@vitest/runner": "4.1.9",
+                "@vitest/snapshot": "4.1.9",
+                "@vitest/spy": "4.1.9",
+                "@vitest/utils": "4.1.9",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.9",
+                "@vitest/browser-preview": "4.1.9",
+                "@vitest/browser-webdriverio": "4.1.9",
+                "@vitest/coverage-istanbul": "4.1.9",
+                "@vitest/coverage-v8": "4.1.9",
+                "@vitest/ui": "4.1.9",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3119,6 +3487,23 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {
@@ -3234,7 +3619,8 @@
             "devDependencies": {
                 "@types/delaunator": "5.0.3",
                 "@types/pathfinding": "0.1.0",
-                "typed-factorio": "^3.35.0"
+                "typed-factorio": "^3.35.0",
+                "vitest": "^4.1.9"
             }
         },
         "packages/editor/node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "build:website": "npm --workspace=@fbe/website run build",
         "type-check": "tsc",
         "type-check:gate": "node scripts/type-check-gate.mjs",
+        "test:unit": "npm --workspace=@fbe/editor run test:unit",
         "test:scripts": "node --test 'scripts/**/*.test.mjs'",
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -11,6 +11,10 @@
     "bugs": "https://github.com/Teoxoy/factorio-blueprint-editor/issues",
     "homepage": "https://github.com/Teoxoy/factorio-blueprint-editor",
     "module": "./src/index.ts",
+    "scripts": {
+        "test:unit": "vitest run",
+        "test:unit:watch": "vitest"
+    },
     "dependencies": {
         "ajv": "^8.18.0",
         "buffer": "6.0.3",
@@ -24,6 +28,7 @@
     "devDependencies": {
         "@types/delaunator": "5.0.3",
         "@types/pathfinding": "0.1.0",
-        "typed-factorio": "^3.35.0"
+        "typed-factorio": "^3.35.0",
+        "vitest": "^4.1.9"
     }
 }

--- a/packages/editor/src/common/util.ts
+++ b/packages/editor/src/common/util.ts
@@ -8,7 +8,7 @@ const getRandomInt = (min: number, max: number): number => {
     return Math.floor(Math.random() * (MAX - MIN)) + MIN
 }
 
-const getRandomItem = <T>(array: T[]): T => array[getRandomInt(0, array.length - 1)]
+const getRandomItem = <T>(array: readonly T[]): T => array[getRandomInt(0, array.length - 1)]
 
 const Point = (p: IPoint | readonly [number, number]): IPoint => {
     if (Array.isArray(p)) return { x: p[0], y: p[1] }

--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -17,7 +17,7 @@ import FD, {
 } from './factorioData'
 import { PositionGrid } from './PositionGrid'
 import { Entity } from './Entity'
-import { layersOf, sheetOf } from './spriteShape'
+import { layersOf, sheetOf, sheetsOf } from './spriteShape'
 import {
     SpriteVariations,
     EntityWithOwnerPrototype,
@@ -1865,7 +1865,12 @@ function draw_mining_drill(e: MiningDrillPrototype): (data: IDrawData) => readon
 
         case 'pumpjack':
             return (data: IDrawData) => [
-                duplicateAndSetPropertyUsing(e.base_picture.sheets[0], 'x', 'width', data.dir / 4),
+                duplicateAndSetPropertyUsing(
+                    sheetsOf(e.base_picture)[0],
+                    'x',
+                    'width',
+                    data.dir / 4
+                ),
                 ...e.graphics_set.animation.north.layers,
             ]
 
@@ -2162,10 +2167,10 @@ function draw_storage_tank(e: StorageTankPrototype): (data: IDrawData) => readon
     return (data: IDrawData) => [
         addToShift([0, 1], util.duplicate(e.pictures.window_background)),
         setPropertyUsing(
-            util.duplicate(e.pictures.picture.sheets[0]),
+            util.duplicate(sheetsOf(e.pictures.picture)[0]),
             'x',
             'width',
-            Math.floor(data.dir / 4) % e.pictures.picture.sheets[0].frames
+            Math.floor(data.dir / 4) % sheetsOf(e.pictures.picture)[0].frames
         ),
     ]
 }
@@ -2411,7 +2416,7 @@ function draw_wall(e: WallPrototype): (data: IDrawData) => readonly SpriteData[]
 
             for (const relDir of neighbourDirections) {
                 const patch = duplicateAndSetPropertyUsing(
-                    pictures.gate_connection_patch.sheets[0],
+                    sheetsOf(pictures.gate_connection_patch)[0],
                     'x',
                     'width',
                     relDir / 4

--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -17,7 +17,7 @@ import FD, {
 } from './factorioData'
 import { PositionGrid } from './PositionGrid'
 import { Entity } from './Entity'
-import { layersOf } from './spriteShape'
+import { layersOf, sheetOf } from './spriteShape'
 import {
     SpriteVariations,
     EntityWithOwnerPrototype,
@@ -1014,7 +1014,7 @@ function draw_beacon(e: BeaconPrototype): (data: IDrawData) => readonly SpriteDa
                 const module = modules[i]
                 if (module) {
                     return arr.map(slot => {
-                        const img = util.duplicate(slot.pictures)
+                        const img = util.duplicate(sheetOf(slot.pictures))
 
                         let variationIndex = module.tier - 1
                         if (slot.has_empty_slot) {
@@ -1678,7 +1678,7 @@ function draw_inserter(e: InserterPrototype): (data: IDrawData) => readonly Spri
 
         return [
             duplicateAndSetPropertyUsing(
-                e.platform_picture.sheet,
+                sheetOf(e.platform_picture),
                 'x',
                 'width',
                 ((data.dir + 8) % 16) / 4
@@ -1827,7 +1827,7 @@ function draw_loader(e: LoaderPrototype): (data: IDrawData) => readonly SpriteDa
 
         sprites.push(
             duplicateAndSetPropertyUsing(
-                isInput ? structure.direction_in.sheet : structure.direction_out.sheet,
+                isInput ? sheetOf(structure.direction_in) : sheetOf(structure.direction_out),
                 'x',
                 'width',
                 dir / 4
@@ -2051,7 +2051,7 @@ function draw_reactor(e: ReactorPrototype): (data: IDrawData) => readonly Sprite
     return (data: IDrawData) => {
         const patches = []
         for (const [i, conn] of e.heat_buffer.connections.entries()) {
-            let patchSheet = e.connection_patches_disconnected.sheet
+            let patchSheet = sheetOf(e.connection_patches_disconnected)
             if (data.positionGrid) {
                 const c = getHeatConnections(
                     {
@@ -2061,7 +2061,7 @@ function draw_reactor(e: ReactorPrototype): (data: IDrawData) => readonly Sprite
                     data.positionGrid
                 )
                 if (c[conn.direction / 4]) {
-                    patchSheet = e.connection_patches_connected.sheet
+                    patchSheet = sheetOf(e.connection_patches_connected)
                 }
             }
             patchSheet = duplicateAndSetPropertyUsing(patchSheet, 'x', 'width', i)
@@ -2216,7 +2216,7 @@ function draw_transport_belt(
             const sprites = []
 
             if (patchIndex !== undefined) {
-                const patch = e.connector_frame_sprites.frame_back_patch.sheet
+                const patch = sheetOf(e.connector_frame_sprites.frame_back_patch)
                 sprites.push(duplicateAndSetPropertyUsing(patch, 'x', 'width', patchIndex))
             }
 
@@ -2224,7 +2224,7 @@ function draw_transport_belt(
                 ...getBeltSprites(e.belt_animation_set, data.position, data.dir, data.positionGrid)
             )
 
-            let frame = e.connector_frame_sprites.frame_main.sheet
+            let frame = sheetOf(e.connector_frame_sprites.frame_main)
             frame = duplicateAndSetPropertyUsing(frame, 'x', 'width', 1)
             sprites.push(setPropertyUsing(frame, 'y', 'height', connIndex))
 
@@ -2319,7 +2319,7 @@ function draw_underground_belt(
 
         if (!sideloadingBack) {
             sprites.push(
-                duplicateAndSetPropertyUsing(structure.back_patch.sheet, 'x', 'width', dir / 4)
+                duplicateAndSetPropertyUsing(sheetOf(structure.back_patch), 'x', 'width', dir / 4)
             )
         }
 
@@ -2329,11 +2329,11 @@ function draw_underground_belt(
             duplicateAndSetPropertyUsing(
                 sideloadingFront
                     ? isInput
-                        ? structure.direction_in_side_loading.sheet
-                        : structure.direction_out_side_loading.sheet
+                        ? sheetOf(structure.direction_in_side_loading)
+                        : sheetOf(structure.direction_out_side_loading)
                     : isInput
-                      ? structure.direction_in.sheet
-                      : structure.direction_out.sheet,
+                      ? sheetOf(structure.direction_in)
+                      : sheetOf(structure.direction_out),
                 'x',
                 'width',
                 dir / 4
@@ -2342,7 +2342,7 @@ function draw_underground_belt(
 
         if (!sideloadingFront) {
             sprites.push(
-                duplicateAndSetPropertyUsing(structure.front_patch.sheet, 'x', 'width', dir / 4)
+                duplicateAndSetPropertyUsing(sheetOf(structure.front_patch), 'x', 'width', dir / 4)
             )
         }
 
@@ -2449,7 +2449,12 @@ function draw_wall(e: WallPrototype): (data: IDrawData) => readonly SpriteData[]
 
             sprites.push(
                 ...neighbourDirections.map(relDir =>
-                    duplicateAndSetPropertyUsing(e.wall_diode_red.sheet, 'x', 'width', relDir / 4)
+                    duplicateAndSetPropertyUsing(
+                        sheetOf(e.wall_diode_red),
+                        'x',
+                        'width',
+                        relDir / 4
+                    )
                 )
             )
 

--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -17,7 +17,13 @@ import FD, {
 } from './factorioData'
 import { PositionGrid } from './PositionGrid'
 import { Entity } from './Entity'
-import { layersOf, sheetOf, sheetsOf, fourWayAnimation } from './spriteShape'
+import {
+    layersOf,
+    sheetOf,
+    sheetsOf,
+    fourWayAnimation,
+    baseVisualisationLayers,
+} from './spriteShape'
 import {
     SpriteVariations,
     EntityWithOwnerPrototype,
@@ -845,7 +851,7 @@ function draw_agricultural_tower(
 }
 function draw_ammo_turret(e: AmmoTurretPrototype): (data: IDrawData) => readonly SpriteData[] {
     return (data: IDrawData) => [
-        ...e.graphics_set.base_visualisation.animation.layers,
+        ...baseVisualisationLayers(e.graphics_set.base_visualisation),
         duplicateAndSetPropertyUsing(layersOf(e.folded_animation)[0], 'y', 'height', data.dir / 4),
         duplicateAndSetPropertyUsing(layersOf(e.folded_animation)[1], 'y', 'height', data.dir / 4),
     ]
@@ -1333,8 +1339,7 @@ function draw_electric_turret(
     e: ElectricTurretPrototype
 ): (data: IDrawData) => readonly SpriteData[] {
     return (data: IDrawData) => {
-        const bv = (e as any).graphics_set.base_visualisation
-        const baseLayers = Array.isArray(bv) ? bv[0].animation.layers : bv.animation.layers
+        const baseLayers = baseVisualisationLayers(e.graphics_set.base_visualisation)
         return [
             ...baseLayers,
             duplicateAndSetPropertyUsing(
@@ -1384,7 +1389,7 @@ function draw_elevated_straight_rail(
 }
 function draw_fluid_turret(e: FluidTurretPrototype): (data: IDrawData) => readonly SpriteData[] {
     return (data: IDrawData) => [
-        ...e.graphics_set.base_visualisation.animation[util.getDirName(data.dir)].layers,
+        ...baseVisualisationLayers(e.graphics_set.base_visualisation, data.dir),
         ...e.folded_animation[util.getDirName(data.dir)].layers,
     ]
 }

--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -23,6 +23,7 @@ import {
     sheetsOf,
     fourWayAnimation,
     baseVisualisationLayers,
+    toSpriteArray,
 } from './spriteShape'
 import {
     SpriteVariations,
@@ -1038,7 +1039,9 @@ function draw_beacon(e: BeaconPrototype): (data: IDrawData) => readonly SpriteDa
                         return img
                     })
                 } else {
-                    return arr.filter(slot => slot.has_empty_slot).map(slot => slot.pictures)
+                    return arr
+                        .filter(slot => slot.has_empty_slot)
+                        .map(slot => sheetOf(slot.pictures))
                 }
             })
 
@@ -1364,7 +1367,9 @@ function draw_elevated_rail(e: RailPrototype): (data: IDrawData) => readonly Spr
         if (Object.entries(ps).length === 0) {
             ps = e.pictures[util.getDirName8Way(dir % 8)]
         }
-        return [ps.stone_path_background, ps.stone_path, ps.backplates, ps.metals].filter(Boolean)
+        return [ps.stone_path_background, ps.stone_path, ps.backplates, ps.metals]
+            .filter(Boolean)
+            .map(p => sheetOf(p))
     }
 }
 function draw_elevated_curved_rail_a(
@@ -1546,9 +1551,9 @@ function draw_heat_pipe(e: HeatPipePrototype): (data: IDrawData) => readonly Spr
                 }
                 return e.connection_sprites.single
             }
-            return [util.getRandomItem(getOpt())]
+            return [util.getRandomItem(toSpriteArray(getOpt()))]
         }
-        return [util.getRandomItem(e.connection_sprites.single)]
+        return [util.getRandomItem(toSpriteArray(e.connection_sprites.single))]
     }
 }
 function draw_infinity_cargo_wagon(
@@ -1720,18 +1725,22 @@ function draw_rail(e: RailPrototype): (data: IDrawData) => readonly SpriteData[]
         if (Object.entries(ps).length === 0) {
             ps = e.pictures[util.getDirName8Way(dir % 8)]
         }
-        return [ps.stone_path_background, ps.stone_path, ps.ties, ps.backplates, ps.metals]
+        return [ps.stone_path_background, ps.stone_path, ps.ties, ps.backplates, ps.metals].map(p =>
+            sheetOf(p)
+        )
     }
 }
 function draw_straight_rail(e: RailPrototype): (data: IDrawData) => readonly SpriteData[] {
     return (data: IDrawData) => {
         const dir = data.dir
-        function getBaseSprites(): SpriteVariations[] {
+        function getBaseSprites(): readonly SpriteData[] {
             let ps = e.pictures[util.getDirName8Way(dir)]
             if (Object.entries(ps).length === 0) {
                 ps = e.pictures[util.getDirName8Way(dir % 8)]
             }
-            return [ps.stone_path_background, ps.stone_path, ps.ties, ps.backplates, ps.metals]
+            return [ps.stone_path_background, ps.stone_path, ps.ties, ps.backplates, ps.metals].map(
+                p => sheetOf(p)
+            )
         }
 
         if (data.positionGrid && dir % 4 === 0) {
@@ -2448,7 +2457,7 @@ function draw_wall(e: WallPrototype): (data: IDrawData) => readonly SpriteData[]
 
             if (spawnFilling) {
                 let filling = duplicateAndSetPropertyUsing(
-                    pictures.filling,
+                    sheetOf(pictures.filling),
                     'x',
                     'width',
                     util.getRandomInt(0, pictures.filling.line_length)

--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -17,7 +17,7 @@ import FD, {
 } from './factorioData'
 import { PositionGrid } from './PositionGrid'
 import { Entity } from './Entity'
-import { layersOf, sheetOf, sheetsOf } from './spriteShape'
+import { layersOf, sheetOf, sheetsOf, fourWayAnimation } from './spriteShape'
 import {
     SpriteVariations,
     EntityWithOwnerPrototype,
@@ -1871,7 +1871,7 @@ function draw_mining_drill(e: MiningDrillPrototype): (data: IDrawData) => readon
                     'width',
                     data.dir / 4
                 ),
-                ...e.graphics_set.animation.north.layers,
+                ...fourWayAnimation(e.graphics_set.animation, 0),
             ]
 
         case 'electric-mining-drill':

--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -17,6 +17,7 @@ import FD, {
 } from './factorioData'
 import { PositionGrid } from './PositionGrid'
 import { Entity } from './Entity'
+import { layersOf } from './spriteShape'
 import {
     SpriteVariations,
     EntityWithOwnerPrototype,
@@ -845,8 +846,8 @@ function draw_agricultural_tower(
 function draw_ammo_turret(e: AmmoTurretPrototype): (data: IDrawData) => readonly SpriteData[] {
     return (data: IDrawData) => [
         ...e.graphics_set.base_visualisation.animation.layers,
-        duplicateAndSetPropertyUsing(e.folded_animation.layers[0], 'y', 'height', data.dir / 4),
-        duplicateAndSetPropertyUsing(e.folded_animation.layers[1], 'y', 'height', data.dir / 4),
+        duplicateAndSetPropertyUsing(layersOf(e.folded_animation)[0], 'y', 'height', data.dir / 4),
+        duplicateAndSetPropertyUsing(layersOf(e.folded_animation)[1], 'y', 'height', data.dir / 4),
     ]
 }
 function draw_railgun_turret(e: AmmoTurretPrototype): (data: IDrawData) => readonly SpriteData[] {
@@ -924,7 +925,7 @@ function draw_artillery_turret(
                     return [1, 0.31]
             }
         }
-        return [...e.base_picture.layers, barrel, base]
+        return [...layersOf(e.base_picture), barrel, base]
     }
 }
 function draw_artillery_wagon(
@@ -956,7 +957,7 @@ function draw_assembling_machine(
 ): (data: IDrawData) => readonly SpriteData[] {
     return (data: IDrawData) => {
         if (e.graphics_set.always_draw_idle_animation) {
-            return e.graphics_set.idle_animation.layers
+            return layersOf(e.graphics_set.idle_animation)
         } else {
             const out = [...getAnimation(e.graphics_set.animation, data.dir).layers]
 
@@ -1336,8 +1337,18 @@ function draw_electric_turret(
         const baseLayers = Array.isArray(bv) ? bv[0].animation.layers : bv.animation.layers
         return [
             ...baseLayers,
-            duplicateAndSetPropertyUsing(e.folded_animation.layers[0], 'y', 'height', data.dir / 4),
-            duplicateAndSetPropertyUsing(e.folded_animation.layers[2], 'y', 'height', data.dir / 4),
+            duplicateAndSetPropertyUsing(
+                layersOf(e.folded_animation)[0],
+                'y',
+                'height',
+                data.dir / 4
+            ),
+            duplicateAndSetPropertyUsing(
+                layersOf(e.folded_animation)[2],
+                'y',
+                'height',
+                data.dir / 4
+            ),
         ]
     }
 }
@@ -2111,7 +2122,7 @@ function draw_selector_combinator(
     }
 }
 function draw_solar_panel(e: SolarPanelPrototype): (data: IDrawData) => readonly SpriteData[] {
-    return () => e.picture.layers
+    return () => layersOf(e.picture)
 }
 function draw_space_platform_hub(
     e: SpacePlatformHubPrototype
@@ -2224,10 +2235,10 @@ function draw_transport_belt(
 }
 function draw_turret(e: TurretPrototype): (data: IDrawData) => readonly SpriteData[] {
     return (data: IDrawData) => {
-        if (e.folded_animation?.layers?.[0]) {
+        if (e.folded_animation && layersOf(e.folded_animation)[0]) {
             return [
                 duplicateAndSetPropertyUsing(
-                    e.folded_animation.layers[0],
+                    layersOf(e.folded_animation)[0],
                     'y',
                     'height',
                     data.dir / 4
@@ -2363,21 +2374,21 @@ function draw_wall(e: WallPrototype): (data: IDrawData) => readonly SpriteData[]
 
             const wall = (() => {
                 if (conn[1] && conn[2] && conn[3]) {
-                    return pictures.t_up.layers[0]
+                    return layersOf(pictures.t_up)[0]
                 } else if (conn[1] && conn[2]) {
-                    return pictures.corner_right_down.layers[0]
+                    return layersOf(pictures.corner_right_down)[0]
                 } else if (conn[2] && conn[3]) {
-                    return pictures.corner_left_down.layers[0]
+                    return layersOf(pictures.corner_left_down)[0]
                 } else if (conn[1] && conn[3]) {
-                    return pictures.straight_horizontal.layers[0]
+                    return layersOf(pictures.straight_horizontal)[0]
                 } else if (conn[1]) {
-                    return pictures.ending_right.layers[0]
+                    return layersOf(pictures.ending_right)[0]
                 } else if (conn[2]) {
-                    return pictures.straight_vertical.layers[0]
+                    return layersOf(pictures.straight_vertical)[0]
                 } else if (conn[3]) {
-                    return pictures.ending_left.layers[0]
+                    return layersOf(pictures.ending_left)[0]
                 } else {
-                    return pictures.single.layers[0]
+                    return layersOf(pictures.single)[0]
                 }
             })()
 
@@ -2445,7 +2456,7 @@ function draw_wall(e: WallPrototype): (data: IDrawData) => readonly SpriteData[]
             return sprites
         }
 
-        return pictures.single.layers
+        return layersOf(pictures.single)
     }
 }
 

--- a/packages/editor/src/core/spriteShape.test.ts
+++ b/packages/editor/src/core/spriteShape.test.ts
@@ -5,6 +5,7 @@ import {
     sheetsOf,
     fourWayAnimation,
     baseVisualisationLayers,
+    toSpriteArray,
 } from './spriteShape'
 
 describe('layersOf', () => {
@@ -89,5 +90,17 @@ describe('baseVisualisationLayers', () => {
             },
         }
         expect(baseVisualisationLayers(bv as never, 0)).toEqual([layer])
+    })
+})
+
+describe('toSpriteArray', () => {
+    it('returns an array of variations unchanged', () => {
+        const arr = [{ filename: 'a.png' }, { filename: 'b.png' }]
+        expect(toSpriteArray(arr as never)).toEqual(arr)
+    })
+
+    it('wraps a single sprite into an array', () => {
+        const one = { filename: 'a.png' }
+        expect(toSpriteArray(one as never)).toEqual([one])
     })
 })

--- a/packages/editor/src/core/spriteShape.test.ts
+++ b/packages/editor/src/core/spriteShape.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { layersOf, sheetOf } from './spriteShape'
+import { layersOf, sheetOf, sheetsOf } from './spriteShape'
 
 describe('layersOf', () => {
     it('returns the layers array when the value has a layers property', () => {
@@ -24,5 +24,17 @@ describe('sheetOf', () => {
     it('returns the value itself when it is a bare sheet/sprite', () => {
         const bare = { filename: 'bare.png', width: 1, height: 1 }
         expect(sheetOf(bare as never)).toBe(bare)
+    })
+})
+
+describe('sheetsOf', () => {
+    it('returns the sheets array from a struct', () => {
+        const s0 = { filename: 's0.png' }
+        expect(sheetsOf({ sheets: [s0] } as never)).toEqual([s0])
+    })
+
+    it('wraps a bare sprite into a single-element array', () => {
+        const bare = { filename: 'b.png' }
+        expect(sheetsOf(bare as never)).toEqual([bare])
     })
 })

--- a/packages/editor/src/core/spriteShape.test.ts
+++ b/packages/editor/src/core/spriteShape.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { layersOf } from './spriteShape'
+
+describe('layersOf', () => {
+    it('returns the layers array when the value has a layers property', () => {
+        const a = { filename: 'a.png' }
+        const b = { filename: 'b.png' }
+        const input = { layers: [a, b] }
+        expect(layersOf(input as never)).toEqual([a, b])
+    })
+
+    it('wraps a bare sprite (no layers) into a single-element array', () => {
+        const bare = { filename: 'c.png' }
+        expect(layersOf(bare as never)).toEqual([bare])
+    })
+})

--- a/packages/editor/src/core/spriteShape.test.ts
+++ b/packages/editor/src/core/spriteShape.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { layersOf, sheetOf, sheetsOf, fourWayAnimation } from './spriteShape'
+import {
+    layersOf,
+    sheetOf,
+    sheetsOf,
+    fourWayAnimation,
+    baseVisualisationLayers,
+} from './spriteShape'
 
 describe('layersOf', () => {
     it('returns the layers array when the value has a layers property', () => {
@@ -55,5 +61,33 @@ describe('fourWayAnimation', () => {
         const e0 = { filename: 'e.png' }
         const input = { north: { layers: [] }, east: { layers: [e0] } }
         expect(fourWayAnimation(input as never, 4)).toEqual([e0])
+    })
+})
+
+describe('baseVisualisationLayers', () => {
+    const layer = { filename: 'base.png' }
+
+    it('handles the object form (non-directional animation)', () => {
+        expect(baseVisualisationLayers({ animation: { layers: [layer] } } as never)).toEqual([
+            layer,
+        ])
+    })
+
+    it('handles the array form by taking the first element', () => {
+        expect(baseVisualisationLayers([{ animation: { layers: [layer] } }] as never)).toEqual([
+            layer,
+        ])
+    })
+
+    it('handles the directional form when dir is provided', () => {
+        const bv = {
+            animation: {
+                north: { layers: [layer] },
+                east: { layers: [] },
+                south: { layers: [] },
+                west: { layers: [] },
+            },
+        }
+        expect(baseVisualisationLayers(bv as never, 0)).toEqual([layer])
     })
 })

--- a/packages/editor/src/core/spriteShape.test.ts
+++ b/packages/editor/src/core/spriteShape.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { layersOf, sheetOf, sheetsOf } from './spriteShape'
+import { layersOf, sheetOf, sheetsOf, fourWayAnimation } from './spriteShape'
 
 describe('layersOf', () => {
     it('returns the layers array when the value has a layers property', () => {
@@ -36,5 +36,24 @@ describe('sheetsOf', () => {
     it('wraps a bare sprite into a single-element array', () => {
         const bare = { filename: 'b.png' }
         expect(sheetsOf(bare as never)).toEqual([bare])
+    })
+})
+
+describe('fourWayAnimation', () => {
+    it('returns the layers for the resolved direction (north = dir 0)', () => {
+        const n0 = { filename: 'n.png' }
+        const input = {
+            north: { layers: [n0] },
+            east: { layers: [] },
+            south: { layers: [] },
+            west: { layers: [] },
+        }
+        expect(fourWayAnimation(input as never, 0)).toEqual([n0])
+    })
+
+    it('resolves east for dir 4', () => {
+        const e0 = { filename: 'e.png' }
+        const input = { north: { layers: [] }, east: { layers: [e0] } }
+        expect(fourWayAnimation(input as never, 4)).toEqual([e0])
     })
 })

--- a/packages/editor/src/core/spriteShape.test.ts
+++ b/packages/editor/src/core/spriteShape.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { layersOf } from './spriteShape'
+import { layersOf, sheetOf } from './spriteShape'
 
 describe('layersOf', () => {
     it('returns the layers array when the value has a layers property', () => {
@@ -12,5 +12,17 @@ describe('layersOf', () => {
     it('wraps a bare sprite (no layers) into a single-element array', () => {
         const bare = { filename: 'c.png' }
         expect(layersOf(bare as never)).toEqual([bare])
+    })
+})
+
+describe('sheetOf', () => {
+    it('returns the sheet when the value is a struct with a sheet', () => {
+        const sheet = { filename: 's.png', width: 1, height: 1 }
+        expect(sheetOf({ sheet } as never)).toBe(sheet)
+    })
+
+    it('returns the value itself when it is a bare sheet/sprite', () => {
+        const bare = { filename: 'bare.png', width: 1, height: 1 }
+        expect(sheetOf(bare as never)).toBe(bare)
     })
 })

--- a/packages/editor/src/core/spriteShape.ts
+++ b/packages/editor/src/core/spriteShape.ts
@@ -5,6 +5,7 @@ import type {
     AnimationVariations,
     Animation4Way,
     RotatedAnimation8Way,
+    TurretBaseVisualisation,
 } from 'factorio:prototype'
 import util from '../common/util'
 
@@ -51,4 +52,18 @@ export function sheetsOf(x: Sprite4Way): readonly SpriteData[] {
 export function fourWayAnimation(x: Animation4Way, dir: number): readonly SpriteData[] {
     const directional = x as unknown as Record<string, Animation4Way>
     return layersOf(directional[util.getDirName(dir)])
+}
+
+/**
+ * Resolve a turret base_visualisation (array or object form) to its animation
+ * layers. Pass `dir` for the directional (fluid-turret) animation form;
+ * omit it for the flat (ammo/electric-turret) form.
+ */
+export function baseVisualisationLayers(
+    bv: TurretBaseVisualisation | readonly TurretBaseVisualisation[],
+    dir?: number
+): readonly SpriteData[] {
+    const base = Array.isArray(bv) ? bv[0] : (bv as TurretBaseVisualisation)
+    const anim = base.animation
+    return dir === undefined ? layersOf(anim) : fourWayAnimation(anim, dir)
 }

--- a/packages/editor/src/core/spriteShape.ts
+++ b/packages/editor/src/core/spriteShape.ts
@@ -35,3 +35,10 @@ export function layersOf(
 export function sheetOf(x: SpriteVariations | Sprite4Way | AnimationVariations): SpriteData {
     return 'sheet' in x ? (x.sheet as unknown as SpriteData) : (x as unknown as SpriteData)
 }
+
+/** `'sheets' in x ? x.sheets : [x]` — Sprite4Way's multi-sheet form. */
+export function sheetsOf(x: Sprite4Way): readonly SpriteData[] {
+    return 'sheets' in x && x.sheets
+        ? (x.sheets as unknown as readonly SpriteData[])
+        : [x as SpriteData]
+}

--- a/packages/editor/src/core/spriteShape.ts
+++ b/packages/editor/src/core/spriteShape.ts
@@ -67,3 +67,12 @@ export function baseVisualisationLayers(
     const anim = base.animation
     return dir === undefined ? layersOf(anim) : fourWayAnimation(anim, dir)
 }
+
+/**
+ * Coerce a SpriteVariations value to a SpriteData[] for array positions (e.g.
+ * util.getRandomItem). At runtime variations are either an array of sprites or
+ * a single sprite.
+ */
+export function toSpriteArray(x: SpriteVariations): readonly SpriteData[] {
+    return Array.isArray(x) ? (x as readonly SpriteData[]) : [x as unknown as SpriteData]
+}

--- a/packages/editor/src/core/spriteShape.ts
+++ b/packages/editor/src/core/spriteShape.ts
@@ -1,6 +1,8 @@
 import type {
     Sprite as SpriteData,
     SpriteVariations,
+    Sprite4Way,
+    AnimationVariations,
     Animation4Way,
     RotatedAnimation8Way,
 } from 'factorio:prototype'
@@ -22,4 +24,14 @@ export function layersOf(
     x: SpriteVariations | SpriteData | Animation4Way | RotatedAnimation8Way
 ): readonly SpriteData[] {
     return 'layers' in x ? (x.layers as readonly SpriteData[]) : [x as SpriteData]
+}
+
+/**
+ * `'sheet' in x ? x.sheet : x` — collapse a *Variations/4Way union to the
+ * single sheet sprite. Struct members (SpriteSheet) are structurally SpriteData
+ * at runtime. Returns SpriteData (never undefined) so results feed straight
+ * into duplicateAndSetPropertyUsing.
+ */
+export function sheetOf(x: SpriteVariations | Sprite4Way | AnimationVariations): SpriteData {
+    return 'sheet' in x ? (x.sheet as unknown as SpriteData) : (x as unknown as SpriteData)
 }

--- a/packages/editor/src/core/spriteShape.ts
+++ b/packages/editor/src/core/spriteShape.ts
@@ -6,6 +6,7 @@ import type {
     Animation4Way,
     RotatedAnimation8Way,
 } from 'factorio:prototype'
+import util from '../common/util'
 
 /**
  * Sprite-shape narrowing helpers.
@@ -41,4 +42,13 @@ export function sheetsOf(x: Sprite4Way): readonly SpriteData[] {
     return 'sheets' in x && x.sheets
         ? (x.sheets as unknown as readonly SpriteData[])
         : [x as SpriteData]
+}
+
+/**
+ * Resolve a directional Animation4Way to its layers for `dir`. Uses
+ * util.getDirName to pick the north/east/south/west key.
+ */
+export function fourWayAnimation(x: Animation4Way, dir: number): readonly SpriteData[] {
+    const directional = x as unknown as Record<string, Animation4Way>
+    return layersOf(directional[util.getDirName(dir)])
 }

--- a/packages/editor/src/core/spriteShape.ts
+++ b/packages/editor/src/core/spriteShape.ts
@@ -1,0 +1,25 @@
+import type {
+    Sprite as SpriteData,
+    SpriteVariations,
+    Animation4Way,
+    RotatedAnimation8Way,
+} from 'factorio:prototype'
+
+/**
+ * Sprite-shape narrowing helpers.
+ *
+ * typed-factorio models several sprite types as `Base | Struct` unions. The
+ * runtime data from data.json is always one concrete shape; these helpers
+ * collapse the union to `SpriteData` using `in`-operator guards.
+ *
+ * No defensive null-handling: malformed data still throws and is caught +
+ * logged by getSpriteData's try/catch in spriteDataBuilder.ts, which returns
+ * SPRITE_GENERATION_FAILED. Silent empty returns would hide that diagnostic.
+ */
+
+/** `'layers' in x ? x.layers : [x]` */
+export function layersOf(
+    x: SpriteVariations | SpriteData | Animation4Way | RotatedAnimation8Way
+): readonly SpriteData[] {
+    return 'layers' in x ? (x.layers as readonly SpriteData[]) : [x as SpriteData]
+}

--- a/packages/editor/vitest.config.ts
+++ b/packages/editor/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/*.test.ts'],
+    },
+})

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 59
+    "maxErrors": 12
 }


### PR DESCRIPTION
## Summary

Batch 2a of the editor type-error cleanup. Introduces `packages/editor/src/core/spriteShape.ts`, a unit-tested module of pure narrowing helpers that collapse typed-factorio `Base | Struct` sprite unions to `SpriteData` via `in`-operator guards. Call sites in `spriteDataBuilder.ts` now route union access through these helpers instead of reading struct-only members (`.layers`, `.sheet`, `.sheets`, `.animation`, `.north`) off the whole union. No runtime behavior change - every transformation is an identity coercion at runtime.

Helpers: `layersOf`, `sheetOf`, `sheetsOf`, `fourWayAnimation`, `baseVisualisationLayers`, `toSpriteArray`. Adds Vitest to `packages/editor` as the editor's unit-test home, with a new CI step (`Unit tests (editor)`) before the type-check gate.

Also removes the `(e as any)` + `Array.isArray` dance in `draw_electric_turret`, and widens `util.getRandomItem` to accept `readonly` arrays (it only reads).

## Type-check gate: 59 -> 12

All 49 mechanical sprite-shape/return-type errors are fixed. The baseline drops from 59 to **12** (not the originally-estimated 10): removing the broken-union accesses un-masked two latent `any`-suppressed gaps - `frames` on `Sprite` (storage tank) and `line_length` on `Sprite` (wall). Both are genuinely-absent typed-factorio fields, so they join Batch 2b rather than being augmented here.

Remaining 12 (all Batch 2b): 5x `'size'`, `tier`, `beacon_tint`, `horizontal_rail_base`, `vertical_rail_base`, 2x `line_length`, `frames`.

## Verification

- `npm run test:unit` - 13/13 green; every helper branch covered with inline fixtures
- `npm run type-check:gate` - passes at maxErrors 12; confirmed all 12 remaining errors are 2b items (no stray 2a)
- `npm run lint` clean; `npm run format` clean on all touched files
- `npx vite build` - succeeds; helpers integrate and the bundle compiles
- **Live render check (dev editor)**: loaded the EARN base book (14 blueprints, 60 entity types) plus the quick-start book - **zero** `Error generating sprites` / `SPRITE_GENERATION_FAILED` across all. Exercised every touched helper: all rail variants + heat-pipe (`toSpriteArray`/`sheetOf`), stone-wall + gate (`layersOf`), gun/flamethrower/laser/tesla/rocket/railgun/artillery turrets (`baseVisualisationLayers`), all transport belts + splitters (`sheetsOf`/`sheetOf`), locomotive + wagons (`sheetOf`), storage-tank (`sheetsOf` + the `frames` path), solar-panel/lab/accumulator/assembling-machine/furnaces (`layersOf`). Elevated rails confirmed visually. The one helper not hit by a live render is `fourWayAnimation` (pumpjack `.north`) - covered by unit tests; it composes `layersOf` (heavily exercised) + the existing `getDirName`.

Design spec: `docs/superpowers/specs/2026-06-27-batch-2a-sprite-shape-narrowing-design.md`
Implementation plan: `docs/superpowers/plans/2026-06-29-batch-2a-sprite-shape-narrowing-implementation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)