### PR TITLE
chore: fix markdown lint in CONTRIBUTING and README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,23 @@
 
 First of all, thanks for your interest in helping out! 😃
 
-# Submitting an Issue
+## Submitting an Issue
 
-Before you submit an issue, please search the issue tracker, maybe an issue for your problem already exists and the discussion might inform you of workarounds readily available.
+Before you submit an issue, please search the issue tracker, maybe an issue for
+your problem already exists and the discussion might inform you of workarounds
+readily available.
 
-We want to fix all the issues as soon as possible and a minimal reproduction scenario allows us to quickly confirm a bug (or point out a coding problem) as well as confirm that we are fixing the right problem.
+We want to fix all the issues as soon as possible and a minimal reproduction scenario
+allows us to quickly confirm a bug (or point out a coding problem) as well as confirm
+that we are fixing the right problem.
 
-You can file new issues by selecting from our [new issue templates](https://github.com/Teoxoy/factorio-blueprint-editor/issues/new/choose) and filling out the issue template.
+You can file new issues by selecting from our
+[new issue templates](https://github.com/Teoxoy/factorio-blueprint-editor/issues/new/choose)
+and filling out the issue template.
 
-# Submitting a Pull Request
+## Submitting a Pull Request
 
-## Prerequisites
+### Prerequisites
 
 - [git](https://git-scm.com/)
 - [node](https://nodejs.org/en/)
@@ -21,7 +27,11 @@ You can file new issues by selecting from our [new issue templates](https://gith
 
 ### Note
 
-This project uses `eslint` and `prettier` to lint and format code. I would recommend that you use `vscode` for this project because the repo already contains the extension settings for autofixing linting errors and formatting code on save. So, make sure to **download the recommended workspace extensions** in vscode after cloning the repo.
+This project uses `eslint` and `prettier` to lint and format code. I would
+recommend thatyou use `vscode` for this project because the repo already contains
+the extension settings for autofixing linting errors and formatting code on save.
+So, make sure to **download the recommended workspace extensions** in vscode
+after cloning the repo.
 
 ## Steps
 
@@ -29,7 +39,8 @@ This project uses `eslint` and `prettier` to lint and format code. I would recom
 1. Clone your fork
 1. Download the recommended workspace extensions in vscode
 1. Create a new git branch (`git checkout -b my-fix-branch master`)
-1. Create a new file at the path `packages/exporter/.env` and configure the exporter (see options below)
+1. Create a new file at the path `packages/exporter/.env` and configure the
+exporter (see options below)
 1. Run `npm i --legacy-peer-deps`
 1. Run `npm run start:website` and `npm run start:exporter`
 1. Open the link in a browser or use the vscode debugger
@@ -40,25 +51,29 @@ This project uses `eslint` and `prettier` to lint and format code. I would recom
 
 ### Exporter setup options
 
-**Option A: Local Factorio installation (recommended - includes Space Age support)**
+### Option A: Local Factorio installation (recommended - includes Space Age support)
 
-If you have Factorio installed locally (including any DLC like Space Age), set `FACTORIO_DIR` in `packages/exporter/.env`:
+If you have Factorio installed locally (including any DLC like Space Age),
+set `FACTORIO_DIR` in `packages/exporter/.env`:
 
-```
+``` shell
 FACTORIO_DIR=/path/to/your/factorio/installation
 ```
 
-| Platform        | Example path                                                               |
+| Platform| Example path |
 | --------------- | -------------------------------------------------------------------------- |
 | macOS (Steam)   | `/Users/<you>/Library/Application Support/Steam/steamapps/common/Factorio` |
-| Linux (Steam)   | `~/.steam/steam/steamapps/common/Factorio`                                 |
-| Windows (Steam) | `C:\Program Files (x86)\Steam\steamapps\common\Factorio`                   |
+| Linux (Steam)   | `~/.steam/steam/steamapps/common/Factorio`|
+| Windows (Steam) | `C:\Program Files (x86)\Steam\steamapps\common\Factorio`|
 
 When `FACTORIO_DIR` is set, `FACTORIO_USERNAME` and `FACTORIO_TOKEN` are not needed.
 
-**Option B: Download base game data (no DLC support)**
+#### Option B: Download base game data (no DLC support)
 
-Add your `FACTORIO_USERNAME` and `FACTORIO_TOKEN` to `packages/exporter/.env` (you can get those [here](https://factorio.com/profile)). The exporter will download the base game data automatically. This option only supports base game items.
+Add your `FACTORIO_USERNAME` and `FACTORIO_TOKEN` to `packages/exporter/.env`
+(you can get those [here](https://factorio.com/profile)).
+The exporter will download the base game data automatically.
+This option only supports base game items.
 
 That's it! 🎉 Thank you for your contribution! 😃
 
@@ -66,4 +81,5 @@ That's it! 🎉 Thank you for your contribution! 😃
 
 Check out this [tutorial](https://github.com/firstcontributions/first-contributions/blob/master/github-windows-vs-code-tutorial.md)
 
-Also, [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github) for a more in depth (video) tutorial
+Also, [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github)
+for a more in depth (video) tutorial

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ after cloning the repo.
 1. Download the recommended workspace extensions in vscode
 1. Create a new git branch (`git checkout -b my-fix-branch master`)
 1. Create a new file at the path `packages/exporter/.env` and configure the
-exporter (see options below)
+   exporter (see options below)
 1. Run `npm i --legacy-peer-deps`
 1. Run `npm run start:website` and `npm run start:exporter`
 1. Open the link in a browser or use the vscode debugger
@@ -56,15 +56,15 @@ exporter (see options below)
 If you have Factorio installed locally (including any DLC like Space Age),
 set `FACTORIO_DIR` in `packages/exporter/.env`:
 
-``` shell
+```shell
 FACTORIO_DIR=/path/to/your/factorio/installation
 ```
 
-| Platform| Example path |
+| Platform        | Example path                                                               |
 | --------------- | -------------------------------------------------------------------------- |
 | macOS (Steam)   | `/Users/<you>/Library/Application Support/Steam/steamapps/common/Factorio` |
-| Linux (Steam)   | `~/.steam/steam/steamapps/common/Factorio`|
-| Windows (Steam) | `C:\Program Files (x86)\Steam\steamapps\common\Factorio`|
+| Linux (Steam)   | `~/.steam/steam/steamapps/common/Factorio`                                 |
+| Windows (Steam) | `C:\Program Files (x86)\Steam\steamapps\common\Factorio`                   |
 
 When `FACTORIO_DIR` is set, `FACTORIO_USERNAME` and `FACTORIO_TOKEN` are not needed.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blue.svg?style=flat-square)](./CONTRIBUTING.md)
 &nbsp;&nbsp;_Badges are clickable!_
 
-A feature-rich [Factorio](https://www.factorio.com) Blueprint Editor. 
+A feature-rich [Factorio](https://www.factorio.com) Blueprint Editor.
 You can now edit your blueprints in the browser!
 
 ![Preview](./.github/preview.png)
@@ -22,8 +22,8 @@ Example blueprint book: <https://fbe.teoxoy.com/?source=https://pastebin.com/Xp9
 - history (undo/redo)
 - copy and delete selections
 - import blueprints and books from multiple sources
-(direct bp string, pastebin, hastebin, gist, gitlab, factorioprints,
-factorio.school, google docs)
+  (direct bp string, pastebin, hastebin, gist, gitlab, factorioprints,
+  factorio.school, google docs)
 - generating blueprint images
 - oil outpost generator
 - customizable keybinds

--- a/README.md
+++ b/README.md
@@ -1,36 +1,39 @@
-<img src="./.github/logo.svg" width="100%" align="right">
-
 # factorio-blueprint-editor
+
+![Factorio Blueprint Editor logo](./.github/logo.svg)
 
 [![Website](https://img.shields.io/website-up-down-brightgreen-red/https/fbe.teoxoy.com.svg?style=flat-square)](https://fbe.teoxoy.com)
 [![Discord](https://img.shields.io/discord/540738973413408809.svg?style=flat-square&color=7289da&logo=discord&logoColor=white)](https://discord.gg/c5eXyBU)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blue.svg?style=flat-square)](./CONTRIBUTING.md)
 &nbsp;&nbsp;_Badges are clickable!_
 
-A feature-rich [Factorio](https://www.factorio.com) Blueprint Editor. You can now edit your blueprints in the browser!
+A feature-rich [Factorio](https://www.factorio.com) Blueprint Editor. 
+You can now edit your blueprints in the browser!
 
 ![Preview](./.github/preview.png)
 
-Sample blueprint: https://fbe.teoxoy.com/?source=https://pastebin.com/uc4n81GP
+Sample blueprint: <https://fbe.teoxoy.com/?source=https://pastebin.com/uc4n81GP>
 
-Example blueprint book: https://fbe.teoxoy.com/?source=https://pastebin.com/Xp9u7NaA&index=1
+Example blueprint book: <https://fbe.teoxoy.com/?source=https://pastebin.com/Xp9u7NaA&index=1>
 
-# Features
+## Features
 
 - rendering and editing blueprints
 - history (undo/redo)
 - copy and delete selections
-- import blueprints and books from multiple sources (direct bp string, pastebin, hastebin, gist, gitlab, factorioprints, factorio.school, google docs)
+- import blueprints and books from multiple sources
+(direct bp string, pastebin, hastebin, gist, gitlab, factorioprints,
+factorio.school, google docs)
 - generating blueprint images
 - oil outpost generator
 - customizable keybinds
 - "creative" entities
 
-# Contributing
+## Contributing
 
 Check out [this readme](./CONTRIBUTING.md) if you are interested in contributing.
 
-# Credits
+## Credits
 
 Thanks to all contributors!
 


### PR DESCRIPTION
Markdown lint fixes for `CONTRIBUTING.md` and `README.md`.

- `CONTRIBUTING.md` - 50 lines touched (formatting/lint)
- `README.md` - 21 lines touched (formatting/lint)

No content/meaning changes; formatting only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)