### PR TITLE
chore(deps): upgrade Vite+ toolchain 0.2.1 -> 0.2.6

### DIFF
--- a/.github/actions/setup-vp/action.yml
+++ b/.github/actions/setup-vp/action.yml
@@ -11,7 +11,7 @@ runs:
       uses: actions/cache@v6
       with:
         path: ~/.vite-plus
-        key: vite-plus-${{ runner.os }}-0.2.1
+        key: vite-plus-${{ runner.os }}-0.2.6
 
     - name: Cache npm downloads
       uses: actions/cache@v6
@@ -31,6 +31,6 @@ runs:
         # when intentionally upgrading the toolchain.
         curl -fsSL https://vite.plus -o vp-install.sh
         echo "58bb052c6a007e662e99667d65686251b16d6b39aa21155487da6d51280b3d54  vp-install.sh" | sha256sum -c -
-        VP_VERSION=0.2.1 VP_NODE_MANAGER=yes bash vp-install.sh
+        VP_VERSION=0.2.6 VP_NODE_MANAGER=yes bash vp-install.sh
         echo "$HOME/.vite-plus/bin" >> "$GITHUB_PATH"
         rm -f vp-install.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ cd packages/website && npm run build:analyze
 
 ## Vite+ Toolchain
 
-`vp` is the unified CLI for this project (lint, format, test, build). Configuration lives in the root `vite.config.ts` (`lint`, `fmt`, and `test` blocks). The commands `npm run lint` and `npm run format` delegate to `vp` and require it on PATH - install with `VP_VERSION=0.2.1 VP_NODE_MANAGER=yes curl -fsSL https://vite.plus | bash` and add `~/.vite-plus/bin` to PATH.
+`vp` is the unified CLI for this project (lint, format, test, build). Configuration lives in the root `vite.config.ts` (`lint`, `fmt`, and `test` blocks). The commands `npm run lint` and `npm run format` delegate to `vp` and require it on PATH - install with `VP_VERSION=0.2.6 VP_NODE_MANAGER=yes curl -fsSL https://vite.plus | bash` and add `~/.vite-plus/bin` to PATH.
 
 ## Dev Server Setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@playwright/test": "^1.58.2",
                 "typed-factorio": "^3.35.0",
                 "typescript": "^7.0.2",
-                "vite-plus": "0.2.1"
+                "vite-plus": "0.2.6"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -73,19 +73,29 @@
             "license": "MIT"
         },
         "node_modules/@oxc-project/runtime": {
-            "version": "0.136.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.136.0.tgz",
-            "integrity": "sha512-u0EutjK5y6NHJkl5jNJCs8zbup1z6A/UEWgajrYzqcEU3UX05HjqybhMQOLhSM0eKGISyM6WfSMMuklYSmH2wA==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.141.0.tgz",
+            "integrity": "sha512-Z/6jQ0dyvE2fVjMUO7GoD4h+3q0G4lI4BWQNjaPhC4RPxaS4hF1b7/QYKB/Tl+KAQwqqKgMF54ukR/VvV5FILg==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
+        "node_modules/@oxc-project/types": {
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.141.0.tgz",
+            "integrity": "sha512-S4as7z0j0xQkXcJlyY5ehntwK8/wRkQb9Cyqw+J/N2rkWGQGK0SxD6X6DhQTc7qsxVTBxXbxZtBJh3mr3PtIzQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/@oxfmt/binding-android-arm-eabi": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.55.0.tgz",
-            "integrity": "sha512-+rFDOqQe5LOWgxrAJaZgLRudr6GQm0wGI6gtu7vVkrdLGjNMUSGbAlaCr8j7F2H2Er97vYQCU8WDb30onqMM1g==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.60.0.tgz",
+            "integrity": "sha512-1q4q4Jc8FlOMVojEisyFAVyl8h1yawNv6phjgmhGVEDeyeOdsSnSr9x0+D4mOnEKvpO5L4mxKZ/DP9X6U3A/Mw==",
             "cpu": [
                 "arm"
             ],
@@ -100,9 +110,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm64": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.55.0.tgz",
-            "integrity": "sha512-ctulLq8s3x8Zmvw6+iccB09TIKERAklRSmbJ10gk8mlAn05qZxoyo52dj3Hi9IJcmDSwF54fQaTVh2CbL6PInw==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.60.0.tgz",
+            "integrity": "sha512-tD41I6nCt9k8SQXft0CSjjU9jg6SwG7uMu7PxodSEHXl+GDW0868oy6tTtoJkyUze8YKFgTpz/k5LuPUnFiGLw==",
             "cpu": [
                 "arm64"
             ],
@@ -117,9 +127,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-arm64": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.55.0.tgz",
-            "integrity": "sha512-xDQczLH9pw/RBk1h/GH0qcGMm8hQtmtVHBNLSH3lk1gEIR09hZ4L+mJQl4VqiVAvPK9VG9PYrWWuSQLt7xTbiA==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.60.0.tgz",
+            "integrity": "sha512-TTpzPug96Zxdyb46KvTyIUQDdsqbumXh2TKG9C23PCT0kF7JkW56Z/quPuG9rqOFKQIi1gpRNZ7DX18LwxXPnw==",
             "cpu": [
                 "arm64"
             ],
@@ -134,9 +144,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-x64": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.55.0.tgz",
-            "integrity": "sha512-JaNoFCkF2CJdGgpPSMbuO9HVyXyoNGIhMHPvp6NYAjeVKw9XEYc0HcUWJLPQa3Q69WV5wMa9m5jPMJPtbLtcRg==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.60.0.tgz",
+            "integrity": "sha512-CnOoWgQ7L+JL/YQaRJ+NyATciSfcftncm7y3kqyte1cGtFEGnStaCd1TAyrinkfQ7nRBfHrTs1/vTwUJr3WF2Q==",
             "cpu": [
                 "x64"
             ],
@@ -151,9 +161,9 @@
             }
         },
         "node_modules/@oxfmt/binding-freebsd-x64": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.55.0.tgz",
-            "integrity": "sha512-DNbszhpg6S2MIzax5azdHFTTBIVkR5xr8yyRZuA4yoDAwOkzIp3tmldgKZM2+VlT+hJIG0xUksA+elISzMEAfA==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.60.0.tgz",
+            "integrity": "sha512-ychJo7S3hZxdO6eDZ9zM6F2lM9fpJS3EKS5CAUSWyprdLYxTu4gbaUKV/VBPTcMJwQa2Bpo+643y3OJ537pihA==",
             "cpu": [
                 "x64"
             ],
@@ -168,9 +178,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.55.0.tgz",
-            "integrity": "sha512-2snoaoRfFFyGnbOcKUK36rREBYxe/Xgz3uHbiA5zbCB/s6R4DQj4mHqYAaWWhgizCUSDxV8cE9zAZ0XleNpKGw==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.60.0.tgz",
+            "integrity": "sha512-36IH5o55T2Fx7E0feDttt+mifxN6yk9pWv4KfhAIsP0dFnUq27331OwbpOsZdoXF9soOLWm7mQUz5+UUmyec4g==",
             "cpu": [
                 "arm"
             ],
@@ -185,9 +195,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.55.0.tgz",
-            "integrity": "sha512-q1aktHF/WRpSK81BX1dE/9vWrS2jGw1Nax2kb4DBLGAewubCLcoNyp4Zl/NSMgbv3vUS46Z33wIQkBVYOP3PYg==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.60.0.tgz",
+            "integrity": "sha512-G1Ve7lAa6sFBolVI2LWHfEAqy0YKh4vnioH8uYO9kAEdgM7mR40IksIx9/Zk4+vbYew/sGa4J9Q4tZ3n9gXDHA==",
             "cpu": [
                 "arm"
             ],
@@ -202,9 +212,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.55.0.tgz",
-            "integrity": "sha512-VD0y36aENezl/3tsclA/4G53Cc7iV+7Uoh7gz4yvcOTaEYBtJpQsE6PKDGTtUtOvGS4kv51ybfXY/nWZejO5IA==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.60.0.tgz",
+            "integrity": "sha512-LTQdRBf6uzj/h7Xk6lKzbGD2hrF/fK4YI9LIN1c0509tPUn8wRa3mCmrFQpEWJPLYGFrLFFMTYW1Ljj6VqW2Hw==",
             "cpu": [
                 "arm64"
             ],
@@ -222,9 +232,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-musl": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.55.0.tgz",
-            "integrity": "sha512-r8xlKJFcsRmn0H5jZrdORae6RX9jDBrZVvOoxF+bCQtampQJClv80aZEHsv+NsLsp2KCE5ql79O7DpPVzYWpXA==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.60.0.tgz",
+            "integrity": "sha512-2JMo3XPxMPx3hiqddSZYyaH+fKJm6cz0u8n1naYjP/CdOQOZW34i8lKBUfmbWiuFvd6KoYXLmhAyBuvojsYS7Q==",
             "cpu": [
                 "arm64"
             ],
@@ -242,9 +252,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.55.0.tgz",
-            "integrity": "sha512-GRKv/HXHcwIVld/WU61rF0g0R16hl5EJ+ScKdpjevT57lnLnagj/U2YUbXf2mT+2Pg1uCzWC+mvGicPV3CDdLQ==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.60.0.tgz",
+            "integrity": "sha512-L3C+nBD13lr306tr/PjM3RMll+BVqgFrIgUyoeHuai5oueJrRLgO3j+GO5/Cbhtkf5PSlHYTI1JY7iqBd1qa6A==",
             "cpu": [
                 "ppc64"
             ],
@@ -262,9 +272,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.55.0.tgz",
-            "integrity": "sha512-rdv57enTiPtpSYRMKfAiEbQb0Puw5t9N7isVinDoo5qeLDScro2gznmZqSgSWbVZRzLisTeCTW8Qwgw0bOHv3A==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.60.0.tgz",
+            "integrity": "sha512-M4MsmvqlxFiPtSRGyBYQSZxchEf463AOyd+Dh4/9xDpjWBsRtDUTDMFN5EdHinjVK1/eDJQ8MLpcYjpYayaCnA==",
             "cpu": [
                 "riscv64"
             ],
@@ -282,9 +292,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.55.0.tgz",
-            "integrity": "sha512-7v1nNrlD43VY6+sYQ6efYyb3lE6QY182304PD/768ZxTjOmFd/3dQa3u/nGBUAXYdGSWOQc5N3PnS0QzUXyEIA==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.60.0.tgz",
+            "integrity": "sha512-OH+9UskYuxRB+GxqdGkVN8f5UpwhqG8YscNo1wl8+KJ62cd7wZdGga6iGLJIf8kibF1WBwvlfDUx3cez/VXwFg==",
             "cpu": [
                 "riscv64"
             ],
@@ -302,9 +312,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.55.0.tgz",
-            "integrity": "sha512-f4lJLUSPOgScjFl9LiflKCTocyNRwE25JmTMbN4XQdDjoZzEHjqf3wA3VESF1/csg7i8m7+EQLbrZyYDqe10UQ==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.60.0.tgz",
+            "integrity": "sha512-y7AAFutt9wFWBFOAn6+BHaV39usZmcr3YYH2385f+NHgPNpIF9HpqKp0jgUxPaUOCyG3oaX5VhJduL1Nw164rw==",
             "cpu": [
                 "s390x"
             ],
@@ -322,9 +332,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-gnu": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.55.0.tgz",
-            "integrity": "sha512-MihqiPziJNoWy4MqNSV+jVA1g+07iQDjZiR0vaCaDoPgFEiJpCMsxamktzLV07cEeQsSJ04vQaU4CzCQwIvtDA==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.60.0.tgz",
+            "integrity": "sha512-yKZ9+CXAI+1RO5nH/4Z/9M6DAsfOzd5bw/gtWk81KB4mpalMaRRSXfouc5/tHxazDmBek55HNPepNYBgaCew0Q==",
             "cpu": [
                 "x64"
             ],
@@ -342,9 +352,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-musl": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.55.0.tgz",
-            "integrity": "sha512-Yqghym7KYAVjP9MmSrNZiDeerMuoejNjo0r3ox5H3GDKk8eAfl8VyJm9i+pWCLDCTnAbcTUMMN2ZKjUYXH1v3g==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.60.0.tgz",
+            "integrity": "sha512-bCUGaF6hJOYnQzLJdHLZbvGsOd5oSvGAyJhPAKum2uyLYUuXmP8vqg690DWi2hqcnIoYpqSqCrjzE5aiUAgwQg==",
             "cpu": [
                 "x64"
             ],
@@ -362,9 +372,9 @@
             }
         },
         "node_modules/@oxfmt/binding-openharmony-arm64": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.55.0.tgz",
-            "integrity": "sha512-s5SDvVVSbyQl1V5UU3Yl12M+XLUQ3rl5SglNqgAA2K4PXUtQhyNSS00wivONPEnNo5W01rCou8WkDNyvI/RGHg==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.60.0.tgz",
+            "integrity": "sha512-GrUeZOvzP30ExxfCuQiyofuUGI+OmvAgFwOO5w5p9mGPlxcyuqI+6Sy9fAKFFfLQrqKYWFgc5sYA2Unj/29nPg==",
             "cpu": [
                 "arm64"
             ],
@@ -379,9 +389,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.55.0.tgz",
-            "integrity": "sha512-7p9FB5R32tw2KyyNX3wpQrR2WHwEHvMEiBlGXxeTCaRMCVNx3UtFMAUbaQ/pRNWIrEUZmYhJ6tcUH52uPTRYjQ==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.60.0.tgz",
+            "integrity": "sha512-WD4Q954kUl2TDJV/6q7UnE2rlKk047kXLJsr4bJ2mXRaAqNXcmV3nwKUsGCc3mz/jYDBnXtJEaBErJEybK8iQQ==",
             "cpu": [
                 "arm64"
             ],
@@ -396,9 +406,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.55.0.tgz",
-            "integrity": "sha512-ZYqj3fDnOT1IaVGMP5kpmkQl4F3tQIm2ZyAxvqkJYmI0xgWWak4ss4XYwv3VDfM+TWXeC9K4uQ/wW5jm/5XABA==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.60.0.tgz",
+            "integrity": "sha512-HqDekjr8JXzVDUP1YthDZ1Y3CBEcuZT4WX3B+1kaxj8CvZA8Y2YhcEsXqoSop3tVsgjACxjnFQFDkBo0r/jq1Q==",
             "cpu": [
                 "ia32"
             ],
@@ -413,9 +423,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-x64-msvc": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.55.0.tgz",
-            "integrity": "sha512-eEYT5tivGnGbPHuOHuQpi6CGLObhh0re/5jcNQHihD2GRYkTM85dyi5a19zjP8Q00t1uqAx+/QGLUGdHeqzWyg==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.60.0.tgz",
+            "integrity": "sha512-tz78yhmGPKboTMHCHSaUqXK8JrmoSejgDcWeqAtg2s07ZGKQ3rH5Jn8NuXPGNG33CDbY2e9NoQWXIVEmKO21Rw==",
             "cpu": [
                 "x64"
             ],
@@ -430,9 +440,9 @@
             }
         },
         "node_modules/@oxlint-tsgolint/darwin-arm64": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.23.0.tgz",
-            "integrity": "sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==",
+            "version": "7.0.2001",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-7.0.2001.tgz",
+            "integrity": "sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w==",
             "cpu": [
                 "arm64"
             ],
@@ -444,9 +454,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/darwin-x64": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.23.0.tgz",
-            "integrity": "sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==",
+            "version": "7.0.2001",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-7.0.2001.tgz",
+            "integrity": "sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw==",
             "cpu": [
                 "x64"
             ],
@@ -458,9 +468,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/linux-arm64": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.23.0.tgz",
-            "integrity": "sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==",
+            "version": "7.0.2001",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-7.0.2001.tgz",
+            "integrity": "sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A==",
             "cpu": [
                 "arm64"
             ],
@@ -472,9 +482,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/linux-x64": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.23.0.tgz",
-            "integrity": "sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==",
+            "version": "7.0.2001",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-7.0.2001.tgz",
+            "integrity": "sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ==",
             "cpu": [
                 "x64"
             ],
@@ -486,9 +496,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/win32-arm64": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.23.0.tgz",
-            "integrity": "sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==",
+            "version": "7.0.2001",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-7.0.2001.tgz",
+            "integrity": "sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q==",
             "cpu": [
                 "arm64"
             ],
@@ -500,9 +510,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/win32-x64": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.23.0.tgz",
-            "integrity": "sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==",
+            "version": "7.0.2001",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-7.0.2001.tgz",
+            "integrity": "sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog==",
             "cpu": [
                 "x64"
             ],
@@ -514,9 +524,9 @@
             ]
         },
         "node_modules/@oxlint/binding-android-arm-eabi": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.70.0.tgz",
-            "integrity": "sha512-zFh0P4cswmRvw6nkyb89dr18rRanuaCPAsEXsFDoQY8WdaquI8Pt4NWFjaMJg6L23cy5NeN8J9cBnREbWzZhaw==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.75.0.tgz",
+            "integrity": "sha512-lutovtFzJqlRaqpZrCqSSGaHZzl9nIxxpjLzhSRLunN6dCLylj0uzlCyQGaQDIys7rrv8kVXiFO+R4Zpn0bX7g==",
             "cpu": [
                 "arm"
             ],
@@ -531,9 +541,9 @@
             }
         },
         "node_modules/@oxlint/binding-android-arm64": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.70.0.tgz",
-            "integrity": "sha512-qI8o4HZjeGiBrWv+pJv4lH0Yi2Gl/JSp/EumBUApezJprIKa5PS4nU0lQsQngtky8k+SplQIOjv6hwu0SSxeyg==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.75.0.tgz",
+            "integrity": "sha512-hXI0hDgHkw4w5nfru72aG7y+2iQJmC4waH/KV6H/hbgA6yAP5jYNx0P9yug15Hs0tWl/+mda3Jjn/2gmDT48tw==",
             "cpu": [
                 "arm64"
             ],
@@ -548,9 +558,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-arm64": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.70.0.tgz",
-            "integrity": "sha512-8KjgVVHI5F9nVwHCRwwA78Ty7zNKP4Wd9OeN5PSv3iu/F/u1RVXoOCgLhWqust6HmwQG6xc8c+RCyaWENy24+w==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.75.0.tgz",
+            "integrity": "sha512-D91BWbK/dMYfCcrghspPIuKs2D9LF4Z/OabVSQjw1AO6PWxArD7teDA48bm0ySFqWDaPVqmQRl5GMWNglTXyrQ==",
             "cpu": [
                 "arm64"
             ],
@@ -565,9 +575,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-x64": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.70.0.tgz",
-            "integrity": "sha512-WVydssv5PSUBXFJTdNBWlmGkbNmvPGaFt/2SUT/EZRB6bq6bEOHmMlbnupZD5jmlEvi9+mZJHi8TCw15lyfSfQ==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.75.0.tgz",
+            "integrity": "sha512-02mpwzf12BonZ6PT0TuQoomvEh2kVl2WGBIKWezCyToIS+rYkQZ6GXnARBAl9A4Ovm2V+Xe7M4KretyqmmcnJQ==",
             "cpu": [
                 "x64"
             ],
@@ -582,9 +592,9 @@
             }
         },
         "node_modules/@oxlint/binding-freebsd-x64": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.70.0.tgz",
-            "integrity": "sha512-hJucmUf8OlinHNb1R7fI4Fw6WsAstOz7i8nmkWQfiHoZXtbufNm+MxiDTIMk1ggh2Ro4vLzgQ+bKvRY54MZoRA==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.75.0.tgz",
+            "integrity": "sha512-qZJgLnDaBsiL5YESx2t/TZ8eXkL9fEkKoXEdzegROhlz9A0lgyGnZ0dAzJrh7LJAHQl2K9RdRueN2s/9N7+odg==",
             "cpu": [
                 "x64"
             ],
@@ -599,9 +609,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.70.0.tgz",
-            "integrity": "sha512-1BnS7wbCYDSXwWzJJ+mc3NURoha6m6m6RT5c6vgAY3oz7C3OVXP+S0awo2mRq97arrJkVvO3qRQfyAHL+76xtQ==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.75.0.tgz",
+            "integrity": "sha512-7XlaWA5BJD3XpCfrEqjEe6Zseeb14S7QGa304XfwKignRaKQ+eIj775BQ7nIslggWickl4IsPUFqJ+/gAyNHVg==",
             "cpu": [
                 "arm"
             ],
@@ -616,9 +626,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.70.0.tgz",
-            "integrity": "sha512-yKy/UdbR55+M2yEcuiV5DCNC/gdQAjr/GioUy50QwBzSrKm8ueWADqyRLS9Xk+qjNeCYGg6A8FvUBds56ttfqg==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.75.0.tgz",
+            "integrity": "sha512-av6Tpv8yrcMMMOadOqENBhlsLRcGFXXwoQ0hzHhsmS9FJ4Wioy8we427GbcMe2XTxmL2e60T67H1Dyr3up+tAA==",
             "cpu": [
                 "arm"
             ],
@@ -633,9 +643,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-gnu": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.70.0.tgz",
-            "integrity": "sha512-0A5XJ4alvmqFUFP/4oYSyaO+qLto/HrKEWTSaegiVl+HOufFngK2BjYw9x4RbwBt/du5QG6l5q1zeWiJYYG5yg==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.75.0.tgz",
+            "integrity": "sha512-WcUhd8fHT5plrA14lANevl+hOl815mVI5t2hU21oFWrZKFXIVV/Sr4rWQV0NzSvzBupbMLNc5ErEA6Ehxh5jMg==",
             "cpu": [
                 "arm64"
             ],
@@ -653,9 +663,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-musl": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.70.0.tgz",
-            "integrity": "sha512-JiylyurlB0CLSedNtx1gzv3FvfWPF1h/2Y3BJszPLNt5XQFlBsH5ke0Jle3iJb3uqu5m2e7A/DwzpuCAHdiU+A==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.75.0.tgz",
+            "integrity": "sha512-UWzp5wRHFe/ESO3+eEaxXsTkYTGLYjnTsi/I5neEacXSItQ6WNleapfOAeA4x2b8nyhJ4uQxqvtv9pHv8kWJtQ==",
             "cpu": [
                 "arm64"
             ],
@@ -673,9 +683,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.70.0.tgz",
-            "integrity": "sha512-J8VPG7I3/HmgaU4u8pNU2kFx2+0U+vPLS1dXFxXOaR/2TQ0f8AC7DRz0SRGRI1bfphnX2hVYTTtLuhL4nYKL+Q==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.75.0.tgz",
+            "integrity": "sha512-XEVRwGMLKCUKrvhLAz4F6AIh8MJrQVdSZtAmPpRZt9tGPsUnamPOcl3dS/ZQzJnar/Ymgc//+xho0L60Emzuxg==",
             "cpu": [
                 "ppc64"
             ],
@@ -693,9 +703,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.70.0.tgz",
-            "integrity": "sha512-N2+4lV2KLN+oXTIIIwmWDhwkrnvqf5oX7Hw0zPjk+RuIVgiBQSOlJWF7uQoFx2siEYX0ZQ5cfSbEAHm+J3t7Wg==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.75.0.tgz",
+            "integrity": "sha512-mAG4DUXqfLC8cTjMD2kt3jDmVzFREYtDyeLNdLdsCcBc4Zbl2EMuiFektGBilQwkNjYnMvCqJs55U+Hyb+b+jw==",
             "cpu": [
                 "riscv64"
             ],
@@ -713,9 +723,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-musl": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.70.0.tgz",
-            "integrity": "sha512-1e2L7cFCvx9QDzq6NPP+0tABKb5z6nWHyddWTNKprEsjO9xNrAtPowuCGpjNXxkTdsMiZ4jc8YQ5SstZd4XK6g==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.75.0.tgz",
+            "integrity": "sha512-95hrAvriAlI+pekSomTFIn0+bawMDlDwTNVmdjsFusTHyL2JWh7TWvRNG/Lkim72uN8OiCcO9wcaC6omLP5E3w==",
             "cpu": [
                 "riscv64"
             ],
@@ -733,9 +743,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-s390x-gnu": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.70.0.tgz",
-            "integrity": "sha512-Kwu/l/8GcYibCWA9m9N5pRXMIKVSsL/YbgpLzYkqDhWTiqdRfnNJ/+nqIKRKQiFbHWsdlHEhzMwruJK+qcEruA==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.75.0.tgz",
+            "integrity": "sha512-4b6f2+FrtruAESrCqIKcrarzfrSx+wk2QNcp+RT91/Prc+pMQMAfyZ1rG1c3tFQNl8Bc616tx40uNXyxNBRPbQ==",
             "cpu": [
                 "s390x"
             ],
@@ -753,9 +763,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-gnu": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.70.0.tgz",
-            "integrity": "sha512-tap04CsHYOl0nSAQJfPNIuBxqEPB2HnhQqwaOXLg1jnp2XfRo8Fa814dA4QC4zpvTWXCjAAaCY1W5LOORkEQuQ==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.75.0.tgz",
+            "integrity": "sha512-nshAhrUvXFUWOvqQ2soIw7HFNWvpvEV4o0cYSqPtzLiPF5gKyYTDOOTJ6Rn8g8K/iGvPIrbDA4v8+5MvnjJrrg==",
             "cpu": [
                 "x64"
             ],
@@ -773,9 +783,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-musl": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.70.0.tgz",
-            "integrity": "sha512-hzJa/WgvtJpbBD9rgfy0qe+MjbxOXNUT0bfR1S6EQQzfTtBFA9xg5q8KSwRrQ2QfSS+TaP4j+4mVPQrfNc6UNg==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.75.0.tgz",
+            "integrity": "sha512-e4jNxLKnxLC6sYBQRxrI2pgIIxnmMtF8U/VwNYcjTT/CLS+spH624cYVnj07bTKwaEWT37/e025isOs6j/0xqA==",
             "cpu": [
                 "x64"
             ],
@@ -793,9 +803,9 @@
             }
         },
         "node_modules/@oxlint/binding-openharmony-arm64": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.70.0.tgz",
-            "integrity": "sha512-xbsaNSNzVSnaJACCUYr1HQMyY/Q/Q1LkePmHG3UvZPvGCYGNxrsZp9OmtA6ick8xH47ltRRbRrPCM1YXYcyC+A==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.75.0.tgz",
+            "integrity": "sha512-hZ2lH+1qLf/DiEP9UWuQTK2JWj/BgvMB4jhIV4SmNU1wfEiYYX4TynQyAZXx0j9X4qRYizAL042SKaV+8ynh4w==",
             "cpu": [
                 "arm64"
             ],
@@ -810,9 +820,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-arm64-msvc": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.70.0.tgz",
-            "integrity": "sha512-icAEsUI7JbW1TMRdEXV83mVAInhRVQYuuAlPpxdGwJ95chNdnCzjloRW8GglT0WvzOEZSio6fnYSk2DJ2Hv7LQ==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.75.0.tgz",
+            "integrity": "sha512-Ilj6PNzGDS3bCU0MSJH7Msh0NhH+T/mRp2shwg+q+GHeVlPwP5LEboW96aW+3kVKFk6zYZy1Xi5pZkqZh6X8KQ==",
             "cpu": [
                 "arm64"
             ],
@@ -827,9 +837,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-ia32-msvc": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.70.0.tgz",
-            "integrity": "sha512-FHMSWbVsPVs/f+Jcl04ws4JJ2wUnauyTzlpxWRG/lSO/8GpX08Fo2gQZqdA6CrRFI+zvkxl+N/KwJGWfUwYVZA==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.75.0.tgz",
+            "integrity": "sha512-QVit2nOEOiPhkmsrksPSkoGCdnZRNkspt8fwoYyP09te1VEbnSj4LAxua4rc8FKTmWkySVe05j8iz9GXYfF1AQ==",
             "cpu": [
                 "ia32"
             ],
@@ -844,9 +854,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-x64-msvc": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.70.0.tgz",
-            "integrity": "sha512-ptOlKwCz7n4AKs5VweMqG6DAg677FmKOK+vBkkL9DMNgFATIQ+upqUYBTOEwRQyRAx1ncGlPlXleV2hIcm3z4g==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.75.0.tgz",
+            "integrity": "sha512-DSxnNkBUAYARPwJtR12Ig3deWr8w0H997xP6jy33i+e0SyYJw8FKuz4+cZtpmPEhQmvlPJE3X/2vNxDmLkd/rA==",
             "cpu": [
                 "x64"
             ],
@@ -861,9 +871,9 @@
             }
         },
         "node_modules/@oxlint/plugins": {
-            "version": "1.68.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/plugins/-/plugins-1.68.0.tgz",
-            "integrity": "sha512-titLmukUt/h8ho7Svlf0xSBjoy2ccZKrXjpXpZCj+v6V4CJccC2KyP45BLSCMx8YIpifMyiDyUptM4+5sruKbQ==",
+            "version": "1.73.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/plugins/-/plugins-1.73.0.tgz",
+            "integrity": "sha512-OhgMQeMmZA0dcFcX4/priaJZWdFECxiClgq6mRX6aatZEcV9PbKC3P3/v8U1hVjviT1i5U+vR8lAtBV6m4FXAA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1350,15 +1360,15 @@
             }
         },
         "node_modules/@vitest/browser": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.9.tgz",
-            "integrity": "sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.10.tgz",
+            "integrity": "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@blazediff/core": "1.9.1",
-                "@vitest/mocker": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "magic-string": "^0.30.21",
                 "pngjs": "^7.0.0",
                 "sirv": "^3.0.2",
@@ -1369,38 +1379,38 @@
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "vitest": "4.1.9"
+                "vitest": "4.1.10"
             }
         },
         "node_modules/@vitest/browser-preview": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/browser-preview/-/browser-preview-4.1.9.tgz",
-            "integrity": "sha512-a4/OrkMDb/WUnE4OOB/4FJbK3rYVO7YykqtUgcTKG4p2a0R3XcjPVu7SLRHFBs2+NIYhv5yxp1Lz3dbdGBjIow==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/browser-preview/-/browser-preview-4.1.10.tgz",
+            "integrity": "sha512-14MJrL59ZFkqXLjwfSk6RzTDy5Czf9UG4+8q8L6Gxjs2aPjEce/cVNYV14bXAc2BvMjUNu904+ZEZA1Xc1wtvQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@testing-library/dom": "^10.4.1",
                 "@testing-library/user-event": "^14.6.1",
-                "@vitest/browser": "4.1.9"
+                "@vitest/browser": "4.1.10"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "vitest": "4.1.9"
+                "vitest": "4.1.10"
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
-            "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -1409,13 +1419,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-            "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.9",
+                "@vitest/spy": "4.1.10",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -1436,9 +1446,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
-            "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1449,13 +1459,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
-            "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.9",
+                "@vitest/utils": "4.1.10",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -1463,14 +1473,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
-            "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -1479,9 +1489,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
-            "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1489,13 +1499,13 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
-            "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.9",
+                "@vitest/pretty-format": "4.1.10",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
@@ -1504,16 +1514,18 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-core": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.1.tgz",
-            "integrity": "sha512-iWdtOlLezgYcDqIzxZx1yOUhY93vUB+ob+mRYBNr7/3Hf80uRyTQbqVD1WtsYaANbzeUi81SQ1ZoUraXHO+u8A==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.6.tgz",
+            "integrity": "sha512-vqDuuLJWS2JHWkFO7r8Z6AehtKnurpnYtw2XEQtjIfwE2GgSAO3zJdPIeaEZiovS6CqfQa+iOMn3kzVzeTSpTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/runtime": "=0.136.0",
-                "@oxc-project/types": "=0.136.0",
-                "lightningcss": "^1.30.2",
-                "postcss": "^8.5.6"
+                "@oxc-project/runtime": "=0.141.0",
+                "@oxc-project/types": "=0.141.0",
+                "lightningcss": "^1.33.0",
+                "postcss": "^8.5.6",
+                "yuku-codegen": "^0.5.44",
+                "yuku-parser": "^0.5.44"
             },
             "engines": {
                 "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
@@ -1523,10 +1535,8 @@
             },
             "peerDependencies": {
                 "@arethetypeswrong/core": "^0.18.1",
-                "@tsdown/css": "0.22.3",
-                "@tsdown/exe": "0.22.3",
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.18",
+                "@vitejs/devtools": "^0.3.0",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -1537,19 +1547,13 @@
                 "sugarss": "^5.0.0",
                 "terser": "^5.16.0",
                 "tsx": "^4.8.1",
-                "typescript": "^5.0.0 || ^6.0.0",
+                "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0",
                 "unplugin-unused": "^0.5.0",
                 "unrun": "*",
                 "yaml": "^2.4.2"
             },
             "peerDependenciesMeta": {
                 "@arethetypeswrong/core": {
-                    "optional": true
-                },
-                "@tsdown/css": {
-                    "optional": true
-                },
-                "@tsdown/exe": {
                     "optional": true
                 },
                 "@types/node": {
@@ -1602,16 +1606,6 @@
                 }
             }
         },
-        "node_modules/@voidzero-dev/vite-plus-core/node_modules/@oxc-project/types": {
-            "version": "0.136.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.136.0.tgz",
-            "integrity": "sha512-39Al/B3v9esnHCX7S8l9Se2+s2tb9b2jcMd+bZ2L659VG73kNyGPpPrL5Zi/p0ty7p4pTTU2/Dd+g27hv94XCg==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/Boshen"
-            }
-        },
         "node_modules/@voidzero-dev/vite-plus-core/node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1628,9 +1622,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-darwin-arm64": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.1.tgz",
-            "integrity": "sha512-9AfN/5LKRks8gbTaHPiQHT0L4yboy2xB6x6vvCRWxQMWxPS6/ZJLf5kUIZeE7I1z33AEyLKKkDscsZZVMgMLgg==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.6.tgz",
+            "integrity": "sha512-QSZWgfqPx5lrIKZ0vwgVRujRqo7gORcc9Oq4fI1UDjKZFgYz9gXVMibSjEqYU3R1webN6FKTOCnzFmrfXchWYw==",
             "cpu": [
                 "arm64"
             ],
@@ -1641,13 +1635,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@voidzero-dev/vite-plus-darwin-x64": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.1.tgz",
-            "integrity": "sha512-Q1vyimRbf4M82qIQSWRyr7NJaH9ag5G7vVEfGVVJlQHNprI+Q8zj2Phcs/PGf6QcyjcL8UclLznQTHU9NgnKZw==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.6.tgz",
+            "integrity": "sha512-pMQZGCQO0s+akuxbjgh31hOUgrdDndCmfbP7BciJuts436qrBb8KaVzBhNjJQtxD6H8yY21CIOjD8nlrp4eDIw==",
             "cpu": [
                 "x64"
             ],
@@ -1658,13 +1652,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@voidzero-dev/vite-plus-linux-arm64-gnu": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.1.tgz",
-            "integrity": "sha512-WHW3DziqedRfhJ2upq6kC4y/pmdQWYt322DVB7+4Xb4oOa/CT9GtnSrWIiXVJ4PSO42v54+YsSTKPH2HC5RbtA==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.6.tgz",
+            "integrity": "sha512-0e6nrJgUDN5WwoDRjyh7KV/jbL7WDUhTEWslI64KGpuvD7M6OoPBXYo8Et176O2ENwf52CKVDjXwuvMMNIAzAA==",
             "cpu": [
                 "arm64"
             ],
@@ -1678,13 +1672,13 @@
                 "linux"
             ],
             "engines": {
-                "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@voidzero-dev/vite-plus-linux-arm64-musl": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.1.tgz",
-            "integrity": "sha512-vUY7hYycZW0qEevpl7ImzZJFnOEKRYCaCOX4TBW0vk6MJZ+zj/xW7e0LOggzJcz2wbYAgLDqp5h+b8wV9dguDA==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.6.tgz",
+            "integrity": "sha512-j2yvyv3r2ZEuJG73rWlXFrYrxA7u5+bFSlWTqhsfHZhdb1FKMkklfYRuLtBBdBRLXJ+YMNt9GZT6VTVPJDZnnQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1698,13 +1692,13 @@
                 "linux"
             ],
             "engines": {
-                "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@voidzero-dev/vite-plus-linux-x64-gnu": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.1.tgz",
-            "integrity": "sha512-tFxpToEaykBGxMQHp8M/qmr1yruRRED+c9gA1h9kmplqot04OxuqzRCWu/IiIvMJ0v3JFdOP3gqkyjXLLJhxIA==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.6.tgz",
+            "integrity": "sha512-5vqldBBnRjIAUmQ88oKli+wPd5vSQaA2AZ2xs+omRlZfeJhC8chlud6DyJV6fVZCC9GI4otK2zSGpfQZx8Kc3A==",
             "cpu": [
                 "x64"
             ],
@@ -1718,13 +1712,13 @@
                 "linux"
             ],
             "engines": {
-                "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@voidzero-dev/vite-plus-linux-x64-musl": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.1.tgz",
-            "integrity": "sha512-2scSS7wEbLO2758fqr1/bAULg7nLCFa5V8LO2b5w3g1CrTYdMTDt2WX1ghPesIi+70pYGydRbXo6iaaN43zfMg==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.6.tgz",
+            "integrity": "sha512-29ned+euDKAl+BmCigzGrPykQ/kxTjtsPGV6G3hkImwakHNUnmLRayqmsWKHSwXmBk5xo5m+wqjMbo3G0npJQg==",
             "cpu": [
                 "x64"
             ],
@@ -1738,13 +1732,13 @@
                 "linux"
             ],
             "engines": {
-                "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@voidzero-dev/vite-plus-win32-arm64-msvc": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.1.tgz",
-            "integrity": "sha512-3+5FJYhi9SqBszjngI2LBmvoiqEwxJWyQ5UsOUtNz6/d+yDrDw+tOgHLl4OKIh5aVNZeIGXzxvP6h24kcEqIyg==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.6.tgz",
+            "integrity": "sha512-4b5ASpQlkxSXDYzuM6MYsOc1GnYkqG9CbSA1QzobXm87V/Q+MGPn57eILyacgfbmNNLrO2HQ5hasoLvd2BXaSg==",
             "cpu": [
                 "arm64"
             ],
@@ -1755,13 +1749,13 @@
                 "win32"
             ],
             "engines": {
-                "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@voidzero-dev/vite-plus-win32-x64-msvc": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.1.tgz",
-            "integrity": "sha512-5sOEwEoU5PW7ObmJ5VCakU09Oh14rYCoLQJkFqvOph6PK30lN5iqWGk0KigEyfcd7Zv+fZg9EmcERDol/3Xl9w==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.6.tgz",
+            "integrity": "sha512-rvGkm4WmVkCKPhvUbLkRtlVhi7EYb8GU8KaqIGJ0dVfNQHDEqnFboaiUHuPN1npFNwB+80Ulzz9AkQ/Q8MswQA==",
             "cpu": [
                 "x64"
             ],
@@ -1772,7 +1766,7 @@
                 "win32"
             ],
             "engines": {
-                "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@webgpu/types": {
@@ -1789,6 +1783,335 @@
             "engines": {
                 "node": ">=10.0.0"
             }
+        },
+        "node_modules/@yuku-codegen/binding-darwin-arm64": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-darwin-arm64/-/binding-darwin-arm64-0.5.48.tgz",
+            "integrity": "sha512-yo96Oef12WzqnphInfz/eexVse3+kWgfGS5g2S3rFS3dcGn1ENW9xLFDZUP9rh+yP76DOq38wBoFi1+I9+6qBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@yuku-codegen/binding-darwin-x64": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-darwin-x64/-/binding-darwin-x64-0.5.48.tgz",
+            "integrity": "sha512-aRCTw0EZC4bVosmw//0OMYP5tGWFE0Cu5yUBFkUbhXx/iBzvORcJ2xPNlOp/vtCCo9Ys4vp8b0DigJV6uOVb2g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@yuku-codegen/binding-freebsd-x64": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-freebsd-x64/-/binding-freebsd-x64-0.5.48.tgz",
+            "integrity": "sha512-CA0AQAEApDkbw51PdLWMtKPJ41/7rvXsS3SJs+phG7fHJI+MuFzWuLbkucZfZoEOiDscmcsfYIdgL8BsfuyKKQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@yuku-codegen/binding-linux-arm-gnu": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-arm-gnu/-/binding-linux-arm-gnu-0.5.48.tgz",
+            "integrity": "sha512-DuSQlk8bH4gpmW3/00P0NLagAcMv8jOxjT40cQmxKRkktr+SUOALCfkT89tdDq3qtY95NR2GXOZ7AjNh7KKqCw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@yuku-codegen/binding-linux-arm-musl": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-arm-musl/-/binding-linux-arm-musl-0.5.48.tgz",
+            "integrity": "sha512-bxj4Ee+wlaJcWJwft2ReJXWw5sfl1qavDz6+dlRdU1xfTEtjPSNiAWhiCHnJR0R4Ygd57DnzSQmAVGvFv6RcGw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@yuku-codegen/binding-linux-arm64-gnu": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.5.48.tgz",
+            "integrity": "sha512-mk5JVWh+0JOe5ue8k17kbYX8uGBoKt3ZqoCyxNh4nYAAcX7+X1tFUiU7jbjctu4vHeejCBFSTdQ021+V31cUCQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@yuku-codegen/binding-linux-arm64-musl": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.5.48.tgz",
+            "integrity": "sha512-4q3vkrNghbllyxOm2KesFLxCPKHF7r3JyQ7BWZccY1j2Y05yKoIFhoWCqIuQ2W/dpte9RI0+OVfwyxnrKg6fkA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@yuku-codegen/binding-linux-x64-gnu": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.5.48.tgz",
+            "integrity": "sha512-csd4M1EVrGaohM8acM6gq1zpUA/Rwe2ulUMBKUcwQXm/k6n7cq1A++qdew78SOVb4do3JH1WE+WFwoGQAcWc1w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@yuku-codegen/binding-linux-x64-musl": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-linux-x64-musl/-/binding-linux-x64-musl-0.5.48.tgz",
+            "integrity": "sha512-KcDuEOT+GFoVKdvAWOv1v9iYjwnmvMZlO+j1Rw+5PYdeFLGWGzv/DD11y4SAAdwXIFcil4T0hibeIaF82WStMg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@yuku-codegen/binding-win32-arm64": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-win32-arm64/-/binding-win32-arm64-0.5.48.tgz",
+            "integrity": "sha512-HI8qNrI8dWM5BuqIMKsqornRvTNFrE6sm5zToIJ9YIa9zt5+29P7fJ7Nr39EVf6dAWSb6q7JSpScJnRsQ+FgZA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@yuku-codegen/binding-win32-x64": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-win32-x64/-/binding-win32-x64-0.5.48.tgz",
+            "integrity": "sha512-X5YWJLO6EfBZpeBqO0AYESnUizbpFDWArcvVD61w0PEWQ3CaFRLnbQXs+kpM4ZZfGMfIE22zfA08QSY67q7TNQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@yuku-parser/binding-darwin-arm64": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.5.48.tgz",
+            "integrity": "sha512-If8mb7HH3vqghJ2NNZ8SuHfhsnjVzOxJpB8xcNOXS5WjYrs2mUhHIh5KOIvK13hDOzh0htGeGK3A6MsiEqE7HQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@yuku-parser/binding-darwin-x64": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-parser/binding-darwin-x64/-/binding-darwin-x64-0.5.48.tgz",
+            "integrity": "sha512-EimvPXfspzxf1K11eB6tCW5oiQEXB8g84T2wP1TwzQagdDKo33bkmmVF0B32vTIpXnk/Ifu5IB61izZ1MylljA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@yuku-parser/binding-freebsd-x64": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.5.48.tgz",
+            "integrity": "sha512-0GcUMrumLHheThY9r5Tp46gaZYzn0irWPS1Zba6WY+vVQfhUtzGiWgXxI6tuXX0N32kEaaEVRpkKctvo6Kx3aQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@yuku-parser/binding-linux-arm-gnu": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-arm-gnu/-/binding-linux-arm-gnu-0.5.48.tgz",
+            "integrity": "sha512-8S5T5wjCC73dmmpQeZ49aYsSunIUM3D4Fc6rdK96c+Ayg/p3FmeSPF3xuLZHejcTmqJIIvnbfPlUF+rB6DITjQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@yuku-parser/binding-linux-arm-musl": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-arm-musl/-/binding-linux-arm-musl-0.5.48.tgz",
+            "integrity": "sha512-tTmbxvnUHcK2/crS9547vk2SMmsajH1yqJ8ltXhIuHJgqR1v+d9n9KT+kSayo/5CS76LegeYxhMFjEivBH2hFA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@yuku-parser/binding-linux-arm64-gnu": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.5.48.tgz",
+            "integrity": "sha512-KGYCBMqI2zfwyhgq5tpPVNe7jpUeYTBm8DhjdS+zqWNumde/PEC170QE5RHxcOAlsirIDeIUk0jqx+r/axoFSw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@yuku-parser/binding-linux-arm64-musl": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.5.48.tgz",
+            "integrity": "sha512-2wTSMsCSXLTc2lZUjMAuU5X4cje55u205WJqfV5NWNF6j9pW/tXyxr15dJeekj8ziLqBXzIsj4DbRh4sY/WcjA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@yuku-parser/binding-linux-x64-gnu": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.5.48.tgz",
+            "integrity": "sha512-d/6v9UnGglVu1WC2JQyv/5aWSi5fXZeGSlidCfmHp4+N65N1GDKUnFtys5MK5eAPeAjTgSHGGtOc/yCcKTlv3A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@yuku-parser/binding-linux-x64-musl": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.5.48.tgz",
+            "integrity": "sha512-gX19gw6u4ApPy7SYMPKfFlEkrtj6WlORvrTKK3sBQqjyV+8+mUAkQgxXNjHw4RnOiAmVYg7TOlZcg8d+Qqod9A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@yuku-parser/binding-win32-arm64": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-parser/binding-win32-arm64/-/binding-win32-arm64-0.5.48.tgz",
+            "integrity": "sha512-w6cQQLbqj3Jcom5Q7ifm103NUOQ9d+Cb4VU5lkrZDjMnwVJ9Hzzg1vCQR7miJuF44vhCXldbme5UryE3giEKlA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@yuku-parser/binding-win32-x64": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/@yuku-parser/binding-win32-x64/-/binding-win32-x64-0.5.48.tgz",
+            "integrity": "sha512-4gO0HmG7fzFxrw1rs0dUdnnaY9YgennjETqDWrTSp7x9fmTUOAoN4VsMfP7YyliQeG1WJJHc55O+rOhmsLppow==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@yuku-toolchain/types": {
+            "version": "0.5.43",
+            "resolved": "https://registry.npmjs.org/@yuku-toolchain/types/-/types-0.5.43.tgz",
+            "integrity": "sha512-kSpvPntnXw5+lYjO71ffBEnQ5ycQ74KGIYknh0TS4xeyCuBkOqxyJumxZkMhLBBUCLjDAbx2+Icnr3Zh4ftjpQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/ansi-regex": {
             "version": "6.2.2",
@@ -2118,9 +2441,9 @@
             "license": "MIT"
         },
         "node_modules/es-module-lexer": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
-            "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
             "dev": true,
             "license": "MIT"
         },
@@ -2421,9 +2744,9 @@
             "license": "MIT"
         },
         "node_modules/lightningcss": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+            "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
             "dev": true,
             "license": "MPL-2.0",
             "dependencies": {
@@ -2437,23 +2760,23 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "lightningcss-android-arm64": "1.32.0",
-                "lightningcss-darwin-arm64": "1.32.0",
-                "lightningcss-darwin-x64": "1.32.0",
-                "lightningcss-freebsd-x64": "1.32.0",
-                "lightningcss-linux-arm-gnueabihf": "1.32.0",
-                "lightningcss-linux-arm64-gnu": "1.32.0",
-                "lightningcss-linux-arm64-musl": "1.32.0",
-                "lightningcss-linux-x64-gnu": "1.32.0",
-                "lightningcss-linux-x64-musl": "1.32.0",
-                "lightningcss-win32-arm64-msvc": "1.32.0",
-                "lightningcss-win32-x64-msvc": "1.32.0"
+                "lightningcss-android-arm64": "1.33.0",
+                "lightningcss-darwin-arm64": "1.33.0",
+                "lightningcss-darwin-x64": "1.33.0",
+                "lightningcss-freebsd-x64": "1.33.0",
+                "lightningcss-linux-arm-gnueabihf": "1.33.0",
+                "lightningcss-linux-arm64-gnu": "1.33.0",
+                "lightningcss-linux-arm64-musl": "1.33.0",
+                "lightningcss-linux-x64-gnu": "1.33.0",
+                "lightningcss-linux-x64-musl": "1.33.0",
+                "lightningcss-win32-arm64-msvc": "1.33.0",
+                "lightningcss-win32-x64-msvc": "1.33.0"
             }
         },
         "node_modules/lightningcss-android-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+            "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
             "cpu": [
                 "arm64"
             ],
@@ -2472,9 +2795,9 @@
             }
         },
         "node_modules/lightningcss-darwin-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+            "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
             "cpu": [
                 "arm64"
             ],
@@ -2493,9 +2816,9 @@
             }
         },
         "node_modules/lightningcss-darwin-x64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+            "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
             "cpu": [
                 "x64"
             ],
@@ -2514,9 +2837,9 @@
             }
         },
         "node_modules/lightningcss-freebsd-x64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+            "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
             "cpu": [
                 "x64"
             ],
@@ -2535,9 +2858,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm-gnueabihf": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+            "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
             "cpu": [
                 "arm"
             ],
@@ -2556,9 +2879,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+            "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
             "cpu": [
                 "arm64"
             ],
@@ -2580,9 +2903,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+            "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2604,9 +2927,9 @@
             }
         },
         "node_modules/lightningcss-linux-x64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+            "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
             "cpu": [
                 "x64"
             ],
@@ -2628,9 +2951,9 @@
             }
         },
         "node_modules/lightningcss-linux-x64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+            "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
             "cpu": [
                 "x64"
             ],
@@ -2652,9 +2975,9 @@
             }
         },
         "node_modules/lightningcss-win32-arm64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+            "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
             "cpu": [
                 "arm64"
             ],
@@ -2673,9 +2996,9 @@
             }
         },
         "node_modules/lightningcss-win32-x64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+            "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
             "cpu": [
                 "x64"
             ],
@@ -2753,9 +3076,9 @@
             }
         },
         "node_modules/obug": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+            "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
             "dev": true,
             "funding": [
                 "https://github.com/sponsors/sxzz",
@@ -2788,9 +3111,9 @@
             }
         },
         "node_modules/oxfmt": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.55.0.tgz",
-            "integrity": "sha512-jSj2wCTakwgPMxkfiVZX0jf+nX+Nz6xlyAZjqNE0qXTFdCBPYlP6JAN+ODjmealw7DXBjOzYbdsqwBMAZnPZ6A==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.60.0.tgz",
+            "integrity": "sha512-fViX6i+gJuZWY+jI/fnR6WRbRj70GZ9RlCd30MygJrHTUNc4DxvKHWw8vBjMjffv3PgU5qWDR0AzmojQByqaZA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2806,25 +3129,25 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxfmt/binding-android-arm-eabi": "0.55.0",
-                "@oxfmt/binding-android-arm64": "0.55.0",
-                "@oxfmt/binding-darwin-arm64": "0.55.0",
-                "@oxfmt/binding-darwin-x64": "0.55.0",
-                "@oxfmt/binding-freebsd-x64": "0.55.0",
-                "@oxfmt/binding-linux-arm-gnueabihf": "0.55.0",
-                "@oxfmt/binding-linux-arm-musleabihf": "0.55.0",
-                "@oxfmt/binding-linux-arm64-gnu": "0.55.0",
-                "@oxfmt/binding-linux-arm64-musl": "0.55.0",
-                "@oxfmt/binding-linux-ppc64-gnu": "0.55.0",
-                "@oxfmt/binding-linux-riscv64-gnu": "0.55.0",
-                "@oxfmt/binding-linux-riscv64-musl": "0.55.0",
-                "@oxfmt/binding-linux-s390x-gnu": "0.55.0",
-                "@oxfmt/binding-linux-x64-gnu": "0.55.0",
-                "@oxfmt/binding-linux-x64-musl": "0.55.0",
-                "@oxfmt/binding-openharmony-arm64": "0.55.0",
-                "@oxfmt/binding-win32-arm64-msvc": "0.55.0",
-                "@oxfmt/binding-win32-ia32-msvc": "0.55.0",
-                "@oxfmt/binding-win32-x64-msvc": "0.55.0"
+                "@oxfmt/binding-android-arm-eabi": "0.60.0",
+                "@oxfmt/binding-android-arm64": "0.60.0",
+                "@oxfmt/binding-darwin-arm64": "0.60.0",
+                "@oxfmt/binding-darwin-x64": "0.60.0",
+                "@oxfmt/binding-freebsd-x64": "0.60.0",
+                "@oxfmt/binding-linux-arm-gnueabihf": "0.60.0",
+                "@oxfmt/binding-linux-arm-musleabihf": "0.60.0",
+                "@oxfmt/binding-linux-arm64-gnu": "0.60.0",
+                "@oxfmt/binding-linux-arm64-musl": "0.60.0",
+                "@oxfmt/binding-linux-ppc64-gnu": "0.60.0",
+                "@oxfmt/binding-linux-riscv64-gnu": "0.60.0",
+                "@oxfmt/binding-linux-riscv64-musl": "0.60.0",
+                "@oxfmt/binding-linux-s390x-gnu": "0.60.0",
+                "@oxfmt/binding-linux-x64-gnu": "0.60.0",
+                "@oxfmt/binding-linux-x64-musl": "0.60.0",
+                "@oxfmt/binding-openharmony-arm64": "0.60.0",
+                "@oxfmt/binding-win32-arm64-msvc": "0.60.0",
+                "@oxfmt/binding-win32-ia32-msvc": "0.60.0",
+                "@oxfmt/binding-win32-x64-msvc": "0.60.0"
             },
             "peerDependencies": {
                 "svelte": "^5.0.0",
@@ -2840,9 +3163,9 @@
             }
         },
         "node_modules/oxlint": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.70.0.tgz",
-            "integrity": "sha512-D6JgHtzkhRwvEC+A0Nw5AEc5bk8x5i1pHzvZIEf/a0C4hOzmAACNGtkDGPyFaxxX3ZVGxCPeig3P3rMM8XU3/g==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.75.0.tgz",
+            "integrity": "sha512-m9WzjRcRYA/uqIZDa9tclrieoPJ/ln1QYTKdFx6NUOs8uY5DiHlIwRQoCrHT6OM6O3ww3l2skY5gO7G7ZphE7g==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2855,28 +3178,28 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxlint/binding-android-arm-eabi": "1.70.0",
-                "@oxlint/binding-android-arm64": "1.70.0",
-                "@oxlint/binding-darwin-arm64": "1.70.0",
-                "@oxlint/binding-darwin-x64": "1.70.0",
-                "@oxlint/binding-freebsd-x64": "1.70.0",
-                "@oxlint/binding-linux-arm-gnueabihf": "1.70.0",
-                "@oxlint/binding-linux-arm-musleabihf": "1.70.0",
-                "@oxlint/binding-linux-arm64-gnu": "1.70.0",
-                "@oxlint/binding-linux-arm64-musl": "1.70.0",
-                "@oxlint/binding-linux-ppc64-gnu": "1.70.0",
-                "@oxlint/binding-linux-riscv64-gnu": "1.70.0",
-                "@oxlint/binding-linux-riscv64-musl": "1.70.0",
-                "@oxlint/binding-linux-s390x-gnu": "1.70.0",
-                "@oxlint/binding-linux-x64-gnu": "1.70.0",
-                "@oxlint/binding-linux-x64-musl": "1.70.0",
-                "@oxlint/binding-openharmony-arm64": "1.70.0",
-                "@oxlint/binding-win32-arm64-msvc": "1.70.0",
-                "@oxlint/binding-win32-ia32-msvc": "1.70.0",
-                "@oxlint/binding-win32-x64-msvc": "1.70.0"
+                "@oxlint/binding-android-arm-eabi": "1.75.0",
+                "@oxlint/binding-android-arm64": "1.75.0",
+                "@oxlint/binding-darwin-arm64": "1.75.0",
+                "@oxlint/binding-darwin-x64": "1.75.0",
+                "@oxlint/binding-freebsd-x64": "1.75.0",
+                "@oxlint/binding-linux-arm-gnueabihf": "1.75.0",
+                "@oxlint/binding-linux-arm-musleabihf": "1.75.0",
+                "@oxlint/binding-linux-arm64-gnu": "1.75.0",
+                "@oxlint/binding-linux-arm64-musl": "1.75.0",
+                "@oxlint/binding-linux-ppc64-gnu": "1.75.0",
+                "@oxlint/binding-linux-riscv64-gnu": "1.75.0",
+                "@oxlint/binding-linux-riscv64-musl": "1.75.0",
+                "@oxlint/binding-linux-s390x-gnu": "1.75.0",
+                "@oxlint/binding-linux-x64-gnu": "1.75.0",
+                "@oxlint/binding-linux-x64-musl": "1.75.0",
+                "@oxlint/binding-openharmony-arm64": "1.75.0",
+                "@oxlint/binding-win32-arm64-msvc": "1.75.0",
+                "@oxlint/binding-win32-ia32-msvc": "1.75.0",
+                "@oxlint/binding-win32-x64-msvc": "1.75.0"
             },
             "peerDependencies": {
-                "oxlint-tsgolint": ">=0.22.1",
+                "oxlint-tsgolint": ">=7.0.2001",
                 "vite-plus": "*"
             },
             "peerDependenciesMeta": {
@@ -2889,21 +3212,21 @@
             }
         },
         "node_modules/oxlint-tsgolint": {
-            "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.23.0.tgz",
-            "integrity": "sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==",
+            "version": "7.0.2001",
+            "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-7.0.2001.tgz",
+            "integrity": "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "tsgolint": "bin/tsgolint.js"
             },
             "optionalDependencies": {
-                "@oxlint-tsgolint/darwin-arm64": "0.23.0",
-                "@oxlint-tsgolint/darwin-x64": "0.23.0",
-                "@oxlint-tsgolint/linux-arm64": "0.23.0",
-                "@oxlint-tsgolint/linux-x64": "0.23.0",
-                "@oxlint-tsgolint/win32-arm64": "0.23.0",
-                "@oxlint-tsgolint/win32-x64": "0.23.0"
+                "@oxlint-tsgolint/darwin-arm64": "7.0.2001",
+                "@oxlint-tsgolint/darwin-x64": "7.0.2001",
+                "@oxlint-tsgolint/linux-arm64": "7.0.2001",
+                "@oxlint-tsgolint/linux-x64": "7.0.2001",
+                "@oxlint-tsgolint/win32-arm64": "7.0.2001",
+                "@oxlint-tsgolint/win32-x64": "7.0.2001"
             }
         },
         "node_modules/p-map": {
@@ -3266,9 +3589,9 @@
             "license": "MIT"
         },
         "node_modules/std-env": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
             "dev": true,
             "license": "MIT"
         },
@@ -3449,16 +3772,18 @@
         },
         "node_modules/vite": {
             "name": "@voidzero-dev/vite-plus-core",
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.1.tgz",
-            "integrity": "sha512-iWdtOlLezgYcDqIzxZx1yOUhY93vUB+ob+mRYBNr7/3Hf80uRyTQbqVD1WtsYaANbzeUi81SQ1ZoUraXHO+u8A==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.6.tgz",
+            "integrity": "sha512-vqDuuLJWS2JHWkFO7r8Z6AehtKnurpnYtw2XEQtjIfwE2GgSAO3zJdPIeaEZiovS6CqfQa+iOMn3kzVzeTSpTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/runtime": "=0.136.0",
-                "@oxc-project/types": "=0.136.0",
-                "lightningcss": "^1.30.2",
-                "postcss": "^8.5.6"
+                "@oxc-project/runtime": "=0.141.0",
+                "@oxc-project/types": "=0.141.0",
+                "lightningcss": "^1.33.0",
+                "postcss": "^8.5.6",
+                "yuku-codegen": "^0.5.44",
+                "yuku-parser": "^0.5.44"
             },
             "engines": {
                 "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
@@ -3468,10 +3793,8 @@
             },
             "peerDependencies": {
                 "@arethetypeswrong/core": "^0.18.1",
-                "@tsdown/css": "0.22.3",
-                "@tsdown/exe": "0.22.3",
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.18",
+                "@vitejs/devtools": "^0.3.0",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -3482,19 +3805,13 @@
                 "sugarss": "^5.0.0",
                 "terser": "^5.16.0",
                 "tsx": "^4.8.1",
-                "typescript": "^5.0.0 || ^6.0.0",
+                "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0",
                 "unplugin-unused": "^0.5.0",
                 "unrun": "*",
                 "yaml": "^2.4.2"
             },
             "peerDependenciesMeta": {
                 "@arethetypeswrong/core": {
-                    "optional": true
-                },
-                "@tsdown/css": {
-                    "optional": true
-                },
-                "@tsdown/exe": {
                     "optional": true
                 },
                 "@types/node": {
@@ -3571,50 +3888,51 @@
             }
         },
         "node_modules/vite-plus": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.1.tgz",
-            "integrity": "sha512-q5q/Y38UkWFsNg1JO+RyRdPUqoewaSqIlMyK2p83GKNUvf4D38Ntb3PToRTDZbTRh7mWt+B+d0DQBv4nCDpMcQ==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.6.tgz",
+            "integrity": "sha512-fFX8GLENhtzvnE4NmTPC8INRxjD2kZKcqUW0p7jOdawmHTNZqM5FiieyWOG6WH1a/axu9FCsbUNb918grfzDTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.136.0",
-                "@oxlint/plugins": "=1.68.0",
-                "@vitest/browser": "4.1.9",
-                "@vitest/browser-preview": "4.1.9",
-                "@vitest/expect": "4.1.9",
-                "@vitest/mocker": "4.1.9",
-                "@vitest/pretty-format": "4.1.9",
-                "@vitest/runner": "4.1.9",
-                "@vitest/snapshot": "4.1.9",
-                "@vitest/spy": "4.1.9",
-                "@vitest/utils": "4.1.9",
-                "@voidzero-dev/vite-plus-core": "0.2.1",
-                "oxfmt": "=0.55.0",
-                "oxlint": "=1.70.0",
-                "oxlint-tsgolint": "=0.23.0",
-                "vitest": "4.1.9"
+                "@oxc-project/types": "=0.141.0",
+                "@oxlint/plugins": "=1.73.0",
+                "@vitest/browser": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "@voidzero-dev/vite-plus-core": "0.2.6",
+                "oxfmt": "=0.60.0",
+                "oxlint": "=1.75.0",
+                "oxlint-tsgolint": "=7.0.2001",
+                "vitest": "4.1.10"
             },
             "bin": {
                 "oxfmt": "bin/oxfmt",
                 "oxlint": "bin/oxlint",
-                "vp": "bin/vp"
+                "vp": "bin/vp",
+                "vpr": "bin/vpr"
             },
             "engines": {
                 "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
             },
             "optionalDependencies": {
-                "@voidzero-dev/vite-plus-darwin-arm64": "0.2.1",
-                "@voidzero-dev/vite-plus-darwin-x64": "0.2.1",
-                "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.1",
-                "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.1",
-                "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.1",
-                "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.1",
-                "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.1",
-                "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.1"
+                "@voidzero-dev/vite-plus-darwin-arm64": "0.2.6",
+                "@voidzero-dev/vite-plus-darwin-x64": "0.2.6",
+                "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.6",
+                "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.6",
+                "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.6",
+                "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.6",
+                "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.6",
+                "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.6"
             },
             "peerDependencies": {
-                "@vitest/browser-playwright": "4.1.9",
-                "@vitest/browser-webdriverio": "4.1.9"
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10"
             },
             "peerDependenciesMeta": {
                 "@vitest/browser-playwright": {
@@ -3623,26 +3941,6 @@
                 "@vitest/browser-webdriverio": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/vite-plus/node_modules/@oxc-project/types": {
-            "version": "0.136.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.136.0.tgz",
-            "integrity": "sha512-39Al/B3v9esnHCX7S8l9Se2+s2tb9b2jcMd+bZ2L659VG73kNyGPpPrL5Zi/p0ty7p4pTTU2/Dd+g27hv94XCg==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/Boshen"
-            }
-        },
-        "node_modules/vite/node_modules/@oxc-project/types": {
-            "version": "0.136.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.136.0.tgz",
-            "integrity": "sha512-39Al/B3v9esnHCX7S8l9Se2+s2tb9b2jcMd+bZ2L659VG73kNyGPpPrL5Zi/p0ty7p4pTTU2/Dd+g27hv94XCg==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/Boshen"
             }
         },
         "node_modules/vite/node_modules/fsevents": {
@@ -3661,19 +3959,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
-            "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.9",
-                "@vitest/mocker": "4.1.9",
-                "@vitest/pretty-format": "4.1.9",
-                "@vitest/runner": "4.1.9",
-                "@vitest/snapshot": "4.1.9",
-                "@vitest/spy": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -3701,12 +3999,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.9",
-                "@vitest/browser-preview": "4.1.9",
-                "@vitest/browser-webdriverio": "4.1.9",
-                "@vitest/coverage-istanbul": "4.1.9",
-                "@vitest/coverage-v8": "4.1.9",
-                "@vitest/ui": "4.1.9",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -3786,9 +4084,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3862,6 +4160,52 @@
                 "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         },
+        "node_modules/yuku-codegen": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/yuku-codegen/-/yuku-codegen-0.5.48.tgz",
+            "integrity": "sha512-p7HxD5Xl4jzDzqMrGePAOeSHmRY4g58h4HuGq15weQFPxuPWd/W6e7nqp/+Lea6JfpOdBwJOAyXFqIZ/J9Zfnw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@yuku-toolchain/types": "0.5.43"
+            },
+            "optionalDependencies": {
+                "@yuku-codegen/binding-darwin-arm64": "0.5.48",
+                "@yuku-codegen/binding-darwin-x64": "0.5.48",
+                "@yuku-codegen/binding-freebsd-x64": "0.5.48",
+                "@yuku-codegen/binding-linux-arm-gnu": "0.5.48",
+                "@yuku-codegen/binding-linux-arm-musl": "0.5.48",
+                "@yuku-codegen/binding-linux-arm64-gnu": "0.5.48",
+                "@yuku-codegen/binding-linux-arm64-musl": "0.5.48",
+                "@yuku-codegen/binding-linux-x64-gnu": "0.5.48",
+                "@yuku-codegen/binding-linux-x64-musl": "0.5.48",
+                "@yuku-codegen/binding-win32-arm64": "0.5.48",
+                "@yuku-codegen/binding-win32-x64": "0.5.48"
+            }
+        },
+        "node_modules/yuku-parser": {
+            "version": "0.5.48",
+            "resolved": "https://registry.npmjs.org/yuku-parser/-/yuku-parser-0.5.48.tgz",
+            "integrity": "sha512-OWBfhrpgK9+/4+IXG9oT8Bao4AhViQA7vdyNNH7EUg8dQYgwa70XtIBWTpCEme1P1ECyoDNYkn0wT63f8XRcVA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@yuku-toolchain/types": "0.5.43"
+            },
+            "optionalDependencies": {
+                "@yuku-parser/binding-darwin-arm64": "0.5.48",
+                "@yuku-parser/binding-darwin-x64": "0.5.48",
+                "@yuku-parser/binding-freebsd-x64": "0.5.48",
+                "@yuku-parser/binding-linux-arm-gnu": "0.5.48",
+                "@yuku-parser/binding-linux-arm-musl": "0.5.48",
+                "@yuku-parser/binding-linux-arm64-gnu": "0.5.48",
+                "@yuku-parser/binding-linux-arm64-musl": "0.5.48",
+                "@yuku-parser/binding-linux-x64-gnu": "0.5.48",
+                "@yuku-parser/binding-linux-x64-musl": "0.5.48",
+                "@yuku-parser/binding-win32-arm64": "0.5.48",
+                "@yuku-parser/binding-win32-x64": "0.5.48"
+            }
+        },
         "packages/editor": {
             "name": "@fbe/editor",
             "version": "1.0.0",
@@ -3880,7 +4224,7 @@
                 "@types/delaunator": "5.0.3",
                 "@types/pathfinding": "0.1.0",
                 "typed-factorio": "^3.35.0",
-                "vite-plus": "0.2.1"
+                "vite-plus": "0.2.6"
             }
         },
         "packages/editor/node_modules/ajv": {
@@ -3919,7 +4263,7 @@
                 "@types/file-saver": "2.0.7",
                 "rollup-plugin-visualizer": "^7.0.1",
                 "vite-plugin-static-copy": "^4.1.1",
-                "vite-plus": "0.2.1"
+                "vite-plus": "0.2.6"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@playwright/test": "^1.58.2",
         "typed-factorio": "^3.35.0",
         "typescript": "^7.0.2",
-        "vite-plus": "0.2.1"
+        "vite-plus": "0.2.6"
     },
     "devEngines": {
         "packageManager": {
@@ -33,6 +33,6 @@
         }
     },
     "overrides": {
-        "vite": "npm:@voidzero-dev/vite-plus-core@0.2.1"
+        "vite": "npm:@voidzero-dev/vite-plus-core@0.2.6"
     }
 }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -29,6 +29,6 @@
         "@types/delaunator": "5.0.3",
         "@types/pathfinding": "0.1.0",
         "typed-factorio": "^3.35.0",
-        "vite-plus": "0.2.1"
+        "vite-plus": "0.2.6"
     }
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -19,6 +19,6 @@
         "@types/file-saver": "2.0.7",
         "rollup-plugin-visualizer": "^7.0.1",
         "vite-plugin-static-copy": "^4.1.1",
-        "vite-plus": "0.2.1"
+        "vite-plus": "0.2.6"
     }
 }


### PR DESCRIPTION
Clears the last open Dependabot alert (#53, GHSA-p63j-vcc4-9vmv, critical): vite-plus 0.2.6 pins the vitest stack at 4.1.10, which patches the Browser Mode path-traversal issue. `npm audit` now reports 0 vulnerabilities.

Note this required dropping the root `overrides.vitest` pin first (previous commit) - left in place it would have forced the vulnerable 4.1.9 back over the version 0.2.6 ships.

Bumped in every place the version appears, since they must move together: package.json (devDep + the vite-plus-core alias in overrides), the editor and website devDeps, the setup-vp action (VP_VERSION + cache key), and the install command in CLAUDE.md. The vite.plus installer checksum is unchanged and stays pinned.

Toolchain moves: oxfmt 0.55 -> 0.60, oxlint 1.73 -> 1.75, oxlint-tsgolint 0.23 -> 7.0.2001. No formatting or lint churn resulted: `vp fmt . --check` is clean across all 119 files and `vp lint` output is byte-for-byte unchanged.


Claude-Session: https://claude.ai/code/session_01YUChwtXCYpvaDb2Kj8F2rg