### PR TITLE
fix(deps): update worker lockfile to wrangler 4.114.0

### DIFF
--- a/packages/worker/package-lock.json
+++ b/packages/worker/package-lock.json
@@ -39,9 +39,9 @@
             }
         },
         "node_modules/@cloudflare/workerd-darwin-64": {
-            "version": "1.20260623.1",
-            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260623.1.tgz",
-            "integrity": "sha512-MvDoIsRTsUJRzAl1/4hDXL839piyyjCeYatBHWgMc12Go7nHxkgbRih+1GJImEiKACSentu410bOupcutqFbpg==",
+            "version": "1.20260722.1",
+            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260722.1.tgz",
+            "integrity": "sha512-vZOP8vIS3NwnuaO+gz0FZ7kIGeiO3bZmxV35Ph9zOXKSREhDFlH7wQ7mkCdhW3O4jnXsew+XT7b+DNEI2CcJGQ==",
             "cpu": [
                 "x64"
             ],
@@ -56,9 +56,9 @@
             }
         },
         "node_modules/@cloudflare/workerd-darwin-arm64": {
-            "version": "1.20260623.1",
-            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260623.1.tgz",
-            "integrity": "sha512-sNqHQvHPMOj5/BJOadtEZekRPSG5qQ0/ulC30ZRHRLnmx6tj5O4Wb3Nf0oznnI0pmjXhbv6b7+TOpDkaFMjbBg==",
+            "version": "1.20260722.1",
+            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260722.1.tgz",
+            "integrity": "sha512-EmIQymihDq6WNdER4+LF8Qn80yqayBUpJ+tkOO7wmY8pmgfyXjIUFNXotl21AHovTeu2seR7HdVUgeN/BilCWw==",
             "cpu": [
                 "arm64"
             ],
@@ -73,9 +73,9 @@
             }
         },
         "node_modules/@cloudflare/workerd-linux-64": {
-            "version": "1.20260623.1",
-            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260623.1.tgz",
-            "integrity": "sha512-XYTWqTlZlCXqG+Po6awjXtlxw73hb3C39B/PP0sb4H9NI3V0eynq8Q7rXNe7DHJs2pWRfDJihQzpayQvpwf5wQ==",
+            "version": "1.20260722.1",
+            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260722.1.tgz",
+            "integrity": "sha512-jvZ3k9fxcnEn04s80CgIYxQfpOyAiz/8qC42DP8EBa9tR27qWyg9wmm31zIobVlrgBZn/+8NfdP73avRGcQOjQ==",
             "cpu": [
                 "x64"
             ],
@@ -90,9 +90,9 @@
             }
         },
         "node_modules/@cloudflare/workerd-linux-arm64": {
-            "version": "1.20260623.1",
-            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260623.1.tgz",
-            "integrity": "sha512-PC5UDKA8oQB3Gek/Y+ysovdHNjp55CihOQZd7F9xPwpkv9qTBB0mhyHnfoG2YHtW1bb9CNhuwiThaNxegpE4mg==",
+            "version": "1.20260722.1",
+            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260722.1.tgz",
+            "integrity": "sha512-BOSB55SMNdy+DA5uj2WirgiNanpHGis5PVvXH1wSfvjRKr4JGgWK+EZzxz0RFUo6QjjQQC/NimEzNZ7va7jmKg==",
             "cpu": [
                 "arm64"
             ],
@@ -107,9 +107,9 @@
             }
         },
         "node_modules/@cloudflare/workerd-windows-64": {
-            "version": "1.20260623.1",
-            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260623.1.tgz",
-            "integrity": "sha512-OTHLCVYyN0pEfrajpjjnrGg5zA1GDnpNYmMz3x2ESFtH/oXRODsUQBllP7oJpJvMURF3rXSYwAhMojaftGry8w==",
+            "version": "1.20260722.1",
+            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260722.1.tgz",
+            "integrity": "sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==",
             "cpu": [
                 "x64"
             ],
@@ -137,9 +137,9 @@
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+            "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -600,9 +600,9 @@
             }
         },
         "node_modules/@img/sharp-darwin-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+            "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
             "cpu": [
                 "arm64"
             ],
@@ -613,19 +613,19 @@
                 "darwin"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-arm64": "1.2.4"
+                "@img/sharp-libvips-darwin-arm64": "1.3.1"
             }
         },
         "node_modules/@img/sharp-darwin-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+            "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
             "cpu": [
                 "x64"
             ],
@@ -636,19 +636,39 @@
                 "darwin"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-x64": "1.2.4"
+                "@img/sharp-libvips-darwin-x64": "1.3.1"
+            }
+        },
+        "node_modules/@img/sharp-freebsd-wasm32": {
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+            "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "dependencies": {
+                "@img/sharp-wasm32": "0.35.2"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-darwin-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+            "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
             "cpu": [
                 "arm64"
             ],
@@ -663,9 +683,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-darwin-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+            "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
             "cpu": [
                 "x64"
             ],
@@ -680,9 +700,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+            "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
             "cpu": [
                 "arm"
             ],
@@ -700,9 +720,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+            "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
             "cpu": [
                 "arm64"
             ],
@@ -720,9 +740,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-ppc64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-            "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+            "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
             "cpu": [
                 "ppc64"
             ],
@@ -740,9 +760,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-riscv64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-            "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+            "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
             "cpu": [
                 "riscv64"
             ],
@@ -760,9 +780,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-s390x": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-            "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+            "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
             "cpu": [
                 "s390x"
             ],
@@ -780,9 +800,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+            "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
             "cpu": [
                 "x64"
             ],
@@ -800,9 +820,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+            "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
             "cpu": [
                 "arm64"
             ],
@@ -820,9 +840,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+            "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
             "cpu": [
                 "x64"
             ],
@@ -840,9 +860,9 @@
             }
         },
         "node_modules/@img/sharp-linux-arm": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+            "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
             "cpu": [
                 "arm"
             ],
@@ -856,19 +876,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm": "1.2.4"
+                "@img/sharp-libvips-linux-arm": "1.3.1"
             }
         },
         "node_modules/@img/sharp-linux-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+            "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
             "cpu": [
                 "arm64"
             ],
@@ -882,19 +902,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm64": "1.2.4"
+                "@img/sharp-libvips-linux-arm64": "1.3.1"
             }
         },
         "node_modules/@img/sharp-linux-ppc64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-            "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+            "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
             "cpu": [
                 "ppc64"
             ],
@@ -908,19 +928,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-ppc64": "1.2.4"
+                "@img/sharp-libvips-linux-ppc64": "1.3.1"
             }
         },
         "node_modules/@img/sharp-linux-riscv64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-            "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+            "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
             "cpu": [
                 "riscv64"
             ],
@@ -934,19 +954,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-riscv64": "1.2.4"
+                "@img/sharp-libvips-linux-riscv64": "1.3.1"
             }
         },
         "node_modules/@img/sharp-linux-s390x": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-            "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+            "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
             "cpu": [
                 "s390x"
             ],
@@ -960,19 +980,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-s390x": "1.2.4"
+                "@img/sharp-libvips-linux-s390x": "1.3.1"
             }
         },
         "node_modules/@img/sharp-linux-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+            "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
             "cpu": [
                 "x64"
             ],
@@ -986,19 +1006,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-x64": "1.2.4"
+                "@img/sharp-libvips-linux-x64": "1.3.1"
             }
         },
         "node_modules/@img/sharp-linuxmusl-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+            "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
             "cpu": [
                 "arm64"
             ],
@@ -1012,19 +1032,19 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
             }
         },
         "node_modules/@img/sharp-linuxmusl-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+            "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
             "cpu": [
                 "x64"
             ],
@@ -1038,39 +1058,56 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
             }
         },
         "node_modules/@img/sharp-wasm32": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-            "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-            "cpu": [
-                "wasm32"
-            ],
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+            "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
             "dev": true,
             "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/runtime": "^1.7.0"
+                "@emnapi/runtime": "^1.11.1"
             },
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-webcontainers-wasm32": {
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+            "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@img/sharp-wasm32": "0.35.2"
+            },
+            "engines": {
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-win32-arm64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+            "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1081,16 +1118,16 @@
                 "win32"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-win32-ia32": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-            "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+            "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
             "cpu": [
                 "ia32"
             ],
@@ -1101,16 +1138,16 @@
                 "win32"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": "^20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-win32-x64": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+            "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
             "cpu": [
                 "x64"
             ],
@@ -1121,7 +1158,7 @@
                 "win32"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
@@ -1653,16 +1690,16 @@
             }
         },
         "node_modules/miniflare": {
-            "version": "4.20260623.0",
-            "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260623.0.tgz",
-            "integrity": "sha512-p2YTeH01jMiMOjO4v9hb/+GJndja5LCxecGOWCaT9F414PRXgdddLDsK6MnqhGBB5tlU/WoBYIG1XZte5pQzOQ==",
+            "version": "4.20260722.0",
+            "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260722.0.tgz",
+            "integrity": "sha512-LW6ABMhCx/yIEFBLC/DO4yAhdm2T/G7jp7pr5T2kj895+CCIaHZqpMXdW9O6YE48LcYcCJChwWc8aEs1vpbTXw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@cspotcode/source-map-support": "0.8.1",
-                "sharp": "0.34.5",
+                "sharp": "0.35.2",
                 "undici": "7.28.0",
-                "workerd": "1.20260623.1",
+                "workerd": "1.20260722.1",
                 "ws": "8.21.0",
                 "youch": "4.1.0-beta.10"
             },
@@ -1701,48 +1738,48 @@
             }
         },
         "node_modules/sharp": {
-            "version": "0.34.5",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-            "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+            "version": "0.35.2",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+            "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
             "dev": true,
-            "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@img/colour": "^1.0.0",
+                "@img/colour": "^1.1.0",
                 "detect-libc": "^2.1.2",
-                "semver": "^7.7.3"
+                "semver": "^7.8.4"
             },
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-darwin-arm64": "0.34.5",
-                "@img/sharp-darwin-x64": "0.34.5",
-                "@img/sharp-libvips-darwin-arm64": "1.2.4",
-                "@img/sharp-libvips-darwin-x64": "1.2.4",
-                "@img/sharp-libvips-linux-arm": "1.2.4",
-                "@img/sharp-libvips-linux-arm64": "1.2.4",
-                "@img/sharp-libvips-linux-ppc64": "1.2.4",
-                "@img/sharp-libvips-linux-riscv64": "1.2.4",
-                "@img/sharp-libvips-linux-s390x": "1.2.4",
-                "@img/sharp-libvips-linux-x64": "1.2.4",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-                "@img/sharp-linux-arm": "0.34.5",
-                "@img/sharp-linux-arm64": "0.34.5",
-                "@img/sharp-linux-ppc64": "0.34.5",
-                "@img/sharp-linux-riscv64": "0.34.5",
-                "@img/sharp-linux-s390x": "0.34.5",
-                "@img/sharp-linux-x64": "0.34.5",
-                "@img/sharp-linuxmusl-arm64": "0.34.5",
-                "@img/sharp-linuxmusl-x64": "0.34.5",
-                "@img/sharp-wasm32": "0.34.5",
-                "@img/sharp-win32-arm64": "0.34.5",
-                "@img/sharp-win32-ia32": "0.34.5",
-                "@img/sharp-win32-x64": "0.34.5"
+                "@img/sharp-darwin-arm64": "0.35.2",
+                "@img/sharp-darwin-x64": "0.35.2",
+                "@img/sharp-freebsd-wasm32": "0.35.2",
+                "@img/sharp-libvips-darwin-arm64": "1.3.1",
+                "@img/sharp-libvips-darwin-x64": "1.3.1",
+                "@img/sharp-libvips-linux-arm": "1.3.1",
+                "@img/sharp-libvips-linux-arm64": "1.3.1",
+                "@img/sharp-libvips-linux-ppc64": "1.3.1",
+                "@img/sharp-libvips-linux-riscv64": "1.3.1",
+                "@img/sharp-libvips-linux-s390x": "1.3.1",
+                "@img/sharp-libvips-linux-x64": "1.3.1",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+                "@img/sharp-linux-arm": "0.35.2",
+                "@img/sharp-linux-arm64": "0.35.2",
+                "@img/sharp-linux-ppc64": "0.35.2",
+                "@img/sharp-linux-riscv64": "0.35.2",
+                "@img/sharp-linux-s390x": "0.35.2",
+                "@img/sharp-linux-x64": "0.35.2",
+                "@img/sharp-linuxmusl-arm64": "0.35.2",
+                "@img/sharp-linuxmusl-x64": "0.35.2",
+                "@img/sharp-webcontainers-wasm32": "0.35.2",
+                "@img/sharp-win32-arm64": "0.35.2",
+                "@img/sharp-win32-ia32": "0.35.2",
+                "@img/sharp-win32-x64": "0.35.2"
             }
         },
         "node_modules/supports-color": {
@@ -1822,9 +1859,9 @@
             }
         },
         "node_modules/workerd": {
-            "version": "1.20260623.1",
-            "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260623.1.tgz",
-            "integrity": "sha512-9SJsdTSsehhqc26TUJIzyi1XgyYeqFym4hinZnWoAP1BkhEoMQ5Ygz7Xw9T+2ecU+y409JBEScBgWTdZ06mBrg==",
+            "version": "1.20260722.1",
+            "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260722.1.tgz",
+            "integrity": "sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==",
             "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
@@ -1835,17 +1872,17 @@
                 "node": ">=16"
             },
             "optionalDependencies": {
-                "@cloudflare/workerd-darwin-64": "1.20260623.1",
-                "@cloudflare/workerd-darwin-arm64": "1.20260623.1",
-                "@cloudflare/workerd-linux-64": "1.20260623.1",
-                "@cloudflare/workerd-linux-arm64": "1.20260623.1",
-                "@cloudflare/workerd-windows-64": "1.20260623.1"
+                "@cloudflare/workerd-darwin-64": "1.20260722.1",
+                "@cloudflare/workerd-darwin-arm64": "1.20260722.1",
+                "@cloudflare/workerd-linux-64": "1.20260722.1",
+                "@cloudflare/workerd-linux-arm64": "1.20260722.1",
+                "@cloudflare/workerd-windows-64": "1.20260722.1"
             }
         },
         "node_modules/wrangler": {
-            "version": "4.104.0",
-            "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.104.0.tgz",
-            "integrity": "sha512-xCfbg2Oj93Bc7EMryFaSeRGDgV96dzrWoaK5q2q5XLEvumO4mysNP/1MDue0GUozEJAI6Z6vrGyYPLmfET/0sg==",
+            "version": "4.114.0",
+            "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.114.0.tgz",
+            "integrity": "sha512-M65P25t5UHA1TIJfgZXDcj+YzVobgKdRguM2QPz0xnxLFuOcuE3ErgllDht0iaho7MS4o0g/Bb4YK2+GT+bibg==",
             "dev": true,
             "license": "MIT OR Apache-2.0",
             "dependencies": {
@@ -1853,10 +1890,10 @@
                 "@cloudflare/unenv-preset": "2.16.1",
                 "blake3-wasm": "2.1.5",
                 "esbuild": "0.28.1",
-                "miniflare": "4.20260623.0",
+                "miniflare": "4.20260722.0",
                 "path-to-regexp": "6.3.0",
                 "unenv": "2.0.0-rc.24",
-                "workerd": "1.20260623.1"
+                "workerd": "1.20260722.1"
             },
             "bin": {
                 "cf-wrangler": "bin/cf-wrangler.js",
@@ -1870,7 +1907,7 @@
                 "fsevents": "2.3.3"
             },
             "peerDependencies": {
-                "@cloudflare/workers-types": "^4.20260623.1"
+                "@cloudflare/workers-types": "^5.20260722.1"
             },
             "peerDependenciesMeta": {
                 "@cloudflare/workers-types": {


### PR DESCRIPTION
Clears Dependabot alert #57 (sharp inherited libvips CVEs: CVE-2026-33327, CVE-2026-33328, CVE-2026-35590, CVE-2026-35591), the last open alert.

sharp reaches the worker only through miniflare, which pins it exactly:

  wrangler 4.104.0 -> miniflare 4.20260623.0 -> sharp 0.34.5  (vulnerable)
  wrangler 4.114.0 -> miniflare 4.20260722.0 -> sharp 0.35.2  (patched)

Since package.json already declares `wrangler: ^4.75.0`, 4.114.0 was always in range - the lockfile had simply gone stale. `npm update wrangler` is all this took, so no manifest change and no override forcing sharp past the exact version miniflare asks for.

Verified: `npm ci` succeeds, `wrangler deploy --dry-run` reads the assets directory and resolves the ASSETS binding, `npm audit` reports 0 vulnerabilities.


Claude-Session: https://claude.ai/code/session_01YUChwtXCYpvaDb2Kj8F2rg