### PR TITLE
chore(deps): update typed-factorio to 3.36.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3716,9 +3716,9 @@
             }
         },
         "node_modules/typed-factorio": {
-            "version": "3.35.0",
-            "resolved": "https://registry.npmjs.org/typed-factorio/-/typed-factorio-3.35.0.tgz",
-            "integrity": "sha512-k4Eg229lBU6ogWx1Q76MfC7D9V8ZorVW1Y8LPDJty60SPBu03+DR2VFXVAu3il/WpipW9IidTXVrriuhpu7T/A==",
+            "version": "3.36.0",
+            "resolved": "https://registry.npmjs.org/typed-factorio/-/typed-factorio-3.36.0.tgz",
+            "integrity": "sha512-gUrENjoV8M9H9CDAZrJwU7pRXEuo2voeYgwm6/ZNFVtrCjbQOjwYw1C6Qm3PiEDCGL0FEJobwo3k0XVqtLCIBA==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {


### PR DESCRIPTION
package.json already declares `^3.35.0` in both the root and the editor, so 3.36.0 was in range - the lockfile had gone stale, the same pattern as the wrangler bump. `npm update typed-factorio`, no manifest change.

typed-factorio is types-only, so the risk here is new type errors. There are none: `tsc -p packages/editor/tsconfig.json` is clean, the type-check gate holds at 0 against baseline 0, and root `tsc` reports the same 13 pre-existing errors before and after (all in tests/, outside the gate's project scope).

Verified: 29 unit tests pass, lint output unchanged, format clean, website build succeeds.


Claude-Session: https://claude.ai/code/session_01YUChwtXCYpvaDb2Kj8F2rg