### PR TITLE
fix(website): handle rejections on three floating promises

### DIFF
--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -207,7 +207,7 @@ function registerActions(): void {
         modifiers: { shift: true },
         callbacks: {
             onPress: () => {
-                loadBp(new Blueprint())
+                loadBp(new Blueprint()).catch(error => createBPImportError(error))
                 return true
             },
         },
@@ -252,10 +252,16 @@ function registerActions(): void {
             onPress: () => {
                 if (bp.isEmpty()) return
 
-                editor.getPicture().then(blob => {
-                    FileSaver.saveAs(blob, `${bp.name}.png`)
-                    createToast({ text: 'Blueprint image successfully generated', type: 'success' })
-                })
+                editor
+                    .getPicture()
+                    .then(blob => {
+                        FileSaver.saveAs(blob, `${bp.name}.png`)
+                        createToast({
+                            text: 'Blueprint image successfully generated',
+                            type: 'success',
+                        })
+                    })
+                    .catch(error => createErrorMessage('Failed to generate the image.', error))
                 return true
             },
         },

--- a/packages/website/src/toasts.ts
+++ b/packages/website/src/toasts.ts
@@ -43,7 +43,8 @@ export function initToasts(): (options: IToastsOptions) => void {
             promises.push(new Promise(resolve => setTimeout(resolve, options.timeout || 5000)))
         }
 
-        Promise.race(promises).then(() => {
+        // Never rejects: both racers settle from a click listener or a timeout.
+        void Promise.race(promises).then(() => {
             toast.classList.add('toasts-toast-fadeOut')
             toast.addEventListener(
                 'transitionend',


### PR DESCRIPTION
Clears the three `no-floating-promises` lint warnings, the only warnings in the repo pointing at a real unhandled-rejection path. Each is handled the way the surrounding code already handles that kind of failure rather than with a blanket `void`:

- `clear` action: loadBp() rejections now route to createBPImportError, which is where every other loadBp/getBlueprintOrBookFromSource failure already goes.
- `takePicture` action: getPicture() rejections now route to createErrorMessage, which logs to the console and toasts. Previously a failed screenshot was silent - no file, no message.
- toasts: the dismissal race genuinely cannot reject, since both racers settle from a click listener or a timeout, so `void` is the honest fix. Commented so the next reader does not have to re-derive it.

Lint warnings 112 -> 109, no floating promises remaining. Type-check gate still 0 at baseline 0, root tsc unchanged at its 13 pre-existing errors, 29 unit tests pass, format clean, website build succeeds.


Claude-Session: https://claude.ai/code/session_01YUChwtXCYpvaDb2Kj8F2rg