### PR TITLE
Enable strictNullChecks and work it down 760 -> 639

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,12 @@ npx serve packages/exporter/data/output -l 8081 --cors
 # Build
 cd packages/website && vp build
 
-# Type check (has pre-existing errors from Space Age work)
+# Type check (strictNullChecks is on and still being worked down - see issue #22)
 npx tsc --noEmit -p packages/editor/tsconfig.json
 
 # CI type-check gate: fails only if the error count exceeds the committed
-# baseline in scripts/type-check-baseline.json (currently 0). As errors are
-# fixed, lower maxErrors to lock the gain. Runs in CI via .github/workflows/ci.yml
+# baseline in scripts/type-check-baseline.json. As errors are fixed, lower
+# maxErrors to lock the gain. Runs in CI via .github/workflows/ci.yml
 # (oxfmt + oxlint + vitest gate + tsc gate) on PRs/pushes to wormeyman-space-age-support.
 npm run type-check:gate
 
@@ -71,6 +71,8 @@ Vite dev server runs on port 8080. In dev mode, `/data` is proxied to `http://12
 - `packages/editor/src/core/bpString.ts` - Blueprint string decode/encode, AJV schema validation. Validation is lenient - warns on unknown items/signals but only strips unknown entities.
 - `packages/editor/src/core/blueprintSchema.json` - AJV schema for blueprint validation. Signal types enum must include Space Age types.
 - `packages/editor/src/core/Blueprint.ts` - Blueprint data model, entity creation, wire connections.
+- `packages/editor/src/core/PositionGrid.ts` - Spatial index behind placement, overlap rules and neighbour lookups. It stores entity numbers, not entities: `setTileData`/`removeTileData` keep it in lockstep with `Blueprint.entities` via `onCreateOrRemoveEntity`, and `entityAt()` throws if the two ever drift.
+- `packages/editor/src/core/generators/` - Oil outpost generators (pipe, beacon, pole). Untested geometry until recently; `generators.test.ts` pins their output against a committed fixture, so a diff there means a refactor changed generated layouts.
 - `packages/editor/src/containers/EntitySprite.ts` - Creates PixiJS sprites from sprite data. `getParts()` is the main entry point.
 - `packages/editor/src/containers/BlueprintContainer.ts` - Main rendering container. `spawnPaintContainer()` handles entity placement from inventory.
 - `packages/editor/src/containers/EntityContainer.ts` - Per-entity container, calls `EntitySprite.getParts()` in `redraw()`.
@@ -138,6 +140,7 @@ Automated tests that load blueprint `.txt` files from `wormeyman-tests/` against
 
 - `playwright.config.ts` - Config (base URL localhost:8080, 120s timeout, single worker)
 - `tests/blueprint-loading.spec.ts` - Main test file - iterates blueprints, uses `window.__fbe_test` API to load directly
+- `tests/position-grid.spec.ts` - Exercises `PositionGrid` queries and the setTileData/removeTileData round trip against a real loaded blueprint (the class is core to placement and cannot be unit tested without FD data loaded)
 - `tests/helpers/blueprint-files.ts` - Discovers `.txt` files from `wormeyman-tests/{collection}/`
 - `tests/helpers/report-generator.ts` - Generates JSON + markdown reports to `diagnostic-reports/`
 
@@ -177,5 +180,5 @@ Mobile devices get a read-only viewer with touch gestures (single-finger pan, pi
 - Complex visualizations (crane arms, plasma effects, thruster flames) show only static base sprites
 - Blueprint book icons using planet names show no icon
 - Some entity types may have missing or incorrectly mapped textures
-- TypeScript has pre-existing type errors in Space Age code (`as any` casts used where prototype types don't match runtime data from data.json)
+- TypeScript has pre-existing type errors in Space Age code (`as any` casts used where prototype types don't match runtime data from data.json). Most of what is left sits in `spriteDataBuilder.ts` and is the same problem viewed through `strictNullChecks` - see issue #22 for the plan and the current count
 - Mobile is view-only - no editing, inventory, or keyboard shortcuts

--- a/packages/editor/src/core/PositionGrid.ts
+++ b/packages/editor/src/core/PositionGrid.ts
@@ -15,7 +15,8 @@ interface IArea {
 
 interface INeighbourData extends IPoint {
     relDir: number
-    entity: Entity
+    /** undefined when the neighbouring cell is empty */
+    entity: Entity | undefined
 }
 
 /** Moves X and Y to top left corner from middle (anchor 0.5 0.5 => 0 0) */
@@ -33,11 +34,36 @@ export class PositionGrid {
         this.bp = bp
     }
 
+    /**
+     * Resolves an entity number held in the grid.
+     *
+     * The grid is an index into `bp.entities`, not an independent store: numbers
+     * only enter it through setTileData and leave through removeTileData, both of
+     * which Blueprint drives from the single onCreateOrRemoveEntity hook. So a
+     * number sitting in a cell always has a live entity behind it, and a miss means
+     * the two have drifted apart rather than that the caller asked for something
+     * reasonable.
+     */
+    private entityAt(entityNumber: number): Entity {
+        const entity = this.bp.entities.get(entityNumber)
+        if (entity === undefined) {
+            throw new Error(
+                `Position grid references entity ${entityNumber}, which is not in the blueprint`
+            )
+        }
+        return entity
+    }
+
+    /**
+     * Visits the occupied cells of an area, stopping early if fn returns true.
+     *
+     * Empty cells are skipped, which is what lets every caller here treat a cell as
+     * present. The one caller that needs to see the gaps uses eachCellIncludingEmpty.
+     */
     private tileDataAction(
         area: IArea,
         // oxlint-disable-next-line @typescript-eslint/no-invalid-void-type -- callback returns true to stop iteration, or nothing to continue
-        fn: (key: string, cell: number | number[]) => boolean | void,
-        returnEmptyCells = false
+        fn: (key: string, cell: number | number[]) => boolean | void
     ): void {
         const A = processArea(area)
 
@@ -46,7 +72,7 @@ export class PositionGrid {
             for (let y = A.y, maxY = A.y + A.h; y < maxY; y++) {
                 const key = `${x},${y}`
                 const cell = this.grid.get(key)
-                if (cell || returnEmptyCells) {
+                if (cell) {
                     stop = !!fn(key, cell)
                 }
                 if (stop) {
@@ -59,18 +85,38 @@ export class PositionGrid {
         }
     }
 
-    public getEntityAtPosition(position: IPoint): Entity {
-        const cell = this.grid.get(`${Math.floor(position.x)},${Math.floor(position.y)}`)
-        if (cell) {
-            if (typeof cell === 'number') {
-                return this.bp.entities.get(cell)
-            } else {
-                return this.bp.entities.get(cell[cell.length - 1])
+    /** Visits every cell of an area, handing over undefined for the empty ones */
+    private eachCellIncludingEmpty(
+        area: IArea,
+        fn: (key: string, cell: number | number[] | undefined) => void
+    ): void {
+        const A = processArea(area)
+
+        for (let x = A.x, maxX = A.x + A.w; x < maxX; x++) {
+            for (let y = A.y, maxY = A.y + A.h; y < maxY; y++) {
+                const key = `${x},${y}`
+                fn(key, this.grid.get(key))
             }
         }
     }
 
-    public getConnectionPointAtPosition(position: IPoint, color: string): IConnectionPoint {
+    /** Returns the topmost entity covering the position, or undefined if it is empty */
+    public getEntityAtPosition(position: IPoint): Entity | undefined {
+        const cell = this.grid.get(`${Math.floor(position.x)},${Math.floor(position.y)}`)
+        if (cell) {
+            if (typeof cell === 'number') {
+                return this.entityAt(cell)
+            } else {
+                return this.entityAt(cell[cell.length - 1])
+            }
+        }
+        return undefined
+    }
+
+    public getConnectionPointAtPosition(
+        position: IPoint,
+        color: string
+    ): IConnectionPoint | undefined {
         const entity = this.getEntityAtPosition(position)
         if (entity === undefined) return undefined
         const rel_position = util.sumprod(position, -1, entity.position)
@@ -85,6 +131,7 @@ export class PositionGrid {
                 entitySide: side,
             }
         }
+        return undefined
     }
 
     public setTileData(entity: Entity, position: IPoint = entity.position): void {
@@ -92,7 +139,7 @@ export class PositionGrid {
         //     return
         // }
 
-        this.tileDataAction(
+        this.eachCellIncludingEmpty(
             {
                 x: position.x,
                 y: position.y,
@@ -107,8 +154,8 @@ export class PositionGrid {
                     ]
                         // Sort entities by their size
                         .sort((a, b) => {
-                            const sA = this.bp.entities.get(a).size
-                            const sB = this.bp.entities.get(b).size
+                            const sA = this.entityAt(a).size
+                            const sB = this.entityAt(b).size
                             return sB.x * sB.y - sA.x * sA.y
                         })
 
@@ -116,8 +163,7 @@ export class PositionGrid {
                 } else {
                     this.grid.set(key, entity.entityNumber)
                 }
-            },
-            true
+            }
         )
     }
 
@@ -140,10 +186,8 @@ export class PositionGrid {
                         if (cell.length === 1) {
                             this.grid.delete(key)
                         } else if (cell.length === 2) {
-                            this.grid.set(
-                                key,
-                                cell.find((_, k) => k !== res)
-                            )
+                            // the pair collapses to whichever of the two is not `res`
+                            this.grid.set(key, cell[res === 0 ? 1 : 0])
                         } else {
                             this.grid.set(
                                 key,
@@ -168,9 +212,9 @@ export class PositionGrid {
 
         const straightRails: Entity[] = []
         const halfDiagonalRails: Entity[] = []
-        let gate: Entity
-        let curvedRail: Entity
-        let signal: Entity
+        let gate: Entity | undefined
+        let curvedRail: Entity | undefined
+        let signal: Entity | undefined
         let otherEntities = false
 
         const area = {
@@ -271,7 +315,11 @@ export class PositionGrid {
         return false
     }
 
-    public checkFastReplaceableGroup(name: string, direction: number, pos: IPoint): Entity {
+    public checkFastReplaceableGroup(
+        name: string,
+        direction: number,
+        pos: IPoint
+    ): Entity | undefined {
         const fd = FD.entities[name]
         const size = getEntitySize(fd, direction)
         const area = {
@@ -281,16 +329,13 @@ export class PositionGrid {
             h: size.y,
         }
 
-        if (this.sharesCell(area)) return
-        const entity = this.findInArea(
-            area,
-            entity =>
-                entity.name !== name &&
-                entity.entityData.fast_replaceable_group &&
-                fd.fast_replaceable_group &&
-                entity.entityData.fast_replaceable_group === fd.fast_replaceable_group
-        )
-        if (!entity || pos.x !== entity.position.x || pos.y !== entity.position.y) return
+        if (this.sharesCell(area)) return undefined
+        const entity = this.findInArea(area, entity => {
+            const group = entity.entityData.fast_replaceable_group
+            // both being absent must not read as a match, hence the truthiness check
+            return entity.name !== name && !!group && group === fd.fast_replaceable_group
+        })
+        if (!entity || pos.x !== entity.position.x || pos.y !== entity.position.y) return undefined
         return entity
     }
 
@@ -344,7 +389,7 @@ export class PositionGrid {
             const cell = this.grid.get(`${X},${Y}`)
 
             if (typeof cell === 'number') {
-                const entity = this.bp.entities.get(cell)
+                const entity = this.entityAt(cell)
                 if (entity.name === name) {
                     if (entity.direction === direction) return cell
                     if ((entity.direction + 8) % 16 === direction) return undefined
@@ -376,18 +421,19 @@ export class PositionGrid {
         return empty
     }
 
-    public findInArea(area: IArea, fn: (entity: Entity) => boolean): Entity {
-        let entity: Entity
+    /** Returns the first entity in the area matching fn, or undefined if none does */
+    public findInArea(area: IArea, fn: (entity: Entity) => boolean): Entity | undefined {
+        let entity: Entity | undefined
         this.tileDataAction(area, (_, cell) => {
             if (typeof cell === 'number') {
-                const ent = this.bp.entities.get(cell)
+                const ent = this.entityAt(cell)
                 if (fn(ent)) {
                     entity = ent
                     return true
                 }
             } else {
                 for (const v of cell) {
-                    const ent = this.bp.entities.get(v)
+                    const ent = this.entityAt(v)
                     if (fn(ent)) {
                         entity = ent
                         return true
@@ -403,10 +449,10 @@ export class PositionGrid {
         const entities = new Set<Entity>()
         this.tileDataAction(area, (_, cell) => {
             if (typeof cell === 'number') {
-                entities.add(this.bp.entities.get(cell))
+                entities.add(this.entityAt(cell))
             } else {
                 for (const v of cell) {
-                    entities.add(this.bp.entities.get(v))
+                    entities.add(this.entityAt(v))
                 }
             }
         })
@@ -446,7 +492,7 @@ export class PositionGrid {
                     return acc
                 }, [])
             )
-            .map(entNr => this.bp.entities.get(entNr))
+            .map(entNr => this.entityAt(entNr))
     }
 
     public getNeighbourData(point: IPoint): INeighbourData[] {
@@ -460,7 +506,7 @@ export class PositionGrid {
             const y = Math.floor(point.y) + o.y
             const cell = this.grid.get(`${x},${y}`)
             const entity = cell
-                ? this.bp.entities.get(typeof cell === 'number' ? cell : cell[cell.length - 1])
+                ? this.entityAt(typeof cell === 'number' ? cell : cell[cell.length - 1])
                 : undefined
             return { x, y, relDir: i * 4, entity }
         })

--- a/packages/editor/src/core/generators/__fixtures__/expected-output.json
+++ b/packages/editor/src/core/generators/__fixtures__/expected-output.json
@@ -1,0 +1,1795 @@
+{
+    "pair": {
+        "pipes": {
+            "pumpjacksToRotate": [
+                {
+                    "entity_number": 1,
+                    "direction": 0
+                },
+                {
+                    "entity_number": 2,
+                    "direction": 0
+                }
+            ],
+            "pipes": [
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 2.5,
+                        "y": -0.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 11.5,
+                        "y": -0.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 3.5,
+                        "y": -0.5
+                    },
+                    "direction": 12
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 10.5,
+                        "y": -0.5
+                    },
+                    "direction": 4
+                }
+            ],
+            "info": {
+                "nrOfPipes": 2,
+                "nrOfUPipes": 2,
+                "nrOfPipesReplacedByUPipes": 8
+            }
+        },
+        "beacons": {
+            "beacons": [
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 5.5,
+                        "y": -3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 5.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 5.5,
+                        "y": -0.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 5.5,
+                        "y": 2.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -3.5,
+                        "y": -3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -3.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 15.5,
+                        "y": -3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 15.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 8.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 12.5,
+                        "y": -3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 12.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 15.5,
+                        "y": -0.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 15.5,
+                        "y": 3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -3.5,
+                        "y": -0.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -3.5,
+                        "y": 3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -0.5,
+                        "y": -3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -0.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 8.5,
+                        "y": -3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 2.5,
+                        "y": -3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 2.5,
+                        "y": 6.5
+                    }
+                }
+            ],
+            "info": {
+                "totalBeacons": 20,
+                "effectsGiven": 24
+            }
+        },
+        "poles": {
+            "poles": [
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 3.5,
+                        "y": -1.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": -0.5,
+                        "y": -1.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": -1.5,
+                        "y": 3.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 8.5,
+                        "y": 4.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 13.5,
+                        "y": 4.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 12.5,
+                        "y": -0.5
+                    }
+                }
+            ],
+            "info": {
+                "totalPoles": 6
+            }
+        }
+    },
+    "row": {
+        "pipes": {
+            "pumpjacksToRotate": [
+                {
+                    "entity_number": 2,
+                    "direction": 0
+                },
+                {
+                    "entity_number": 3,
+                    "direction": 0
+                },
+                {
+                    "entity_number": 1,
+                    "direction": 0
+                }
+            ],
+            "pipes": [
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 2.5,
+                        "y": -0.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 9.5,
+                        "y": -0.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 16.5,
+                        "y": -0.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 10.5,
+                        "y": -0.5
+                    },
+                    "direction": 12
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 15.5,
+                        "y": -0.5
+                    },
+                    "direction": 4
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 3.5,
+                        "y": -0.5
+                    },
+                    "direction": 12
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 8.5,
+                        "y": -0.5
+                    },
+                    "direction": 4
+                }
+            ],
+            "info": {
+                "nrOfPipes": 3,
+                "nrOfUPipes": 4,
+                "nrOfPipesReplacedByUPipes": 12
+            }
+        },
+        "beacons": {
+            "beacons": [
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 12.5,
+                        "y": -0.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 5.5,
+                        "y": 0.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 3.5,
+                        "y": -3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 10.5,
+                        "y": -3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 11.5,
+                        "y": 2.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 6.5,
+                        "y": -3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 13.5,
+                        "y": -3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 3.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 6.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 10.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 13.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 4.5,
+                        "y": 3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -3.5,
+                        "y": -3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -3.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 20.5,
+                        "y": -3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 20.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -0.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 17.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 20.5,
+                        "y": 3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -3.5,
+                        "y": -0.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -0.5,
+                        "y": -3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 20.5,
+                        "y": -0.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -3.5,
+                        "y": 3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 17.5,
+                        "y": -3.5
+                    }
+                }
+            ],
+            "info": {
+                "totalBeacons": 24,
+                "effectsGiven": 36
+            }
+        },
+        "poles": {
+            "poles": [
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": -0.5,
+                        "y": 3.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 6.5,
+                        "y": 4.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": -1.5,
+                        "y": -1.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 7.5,
+                        "y": -0.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 16.5,
+                        "y": 3.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 16.5,
+                        "y": -1.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 10.5,
+                        "y": -1.5
+                    }
+                }
+            ],
+            "info": {
+                "totalPoles": 7
+            }
+        }
+    },
+    "scattered": {
+        "pipes": {
+            "pumpjacksToRotate": [
+                {
+                    "entity_number": 2,
+                    "direction": 12
+                },
+                {
+                    "entity_number": 1,
+                    "direction": 8
+                },
+                {
+                    "entity_number": 5,
+                    "direction": 0
+                },
+                {
+                    "entity_number": 4,
+                    "direction": 8
+                },
+                {
+                    "entity_number": 3,
+                    "direction": 0
+                }
+            ],
+            "pipes": [
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 1.5,
+                        "y": 4.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 8.5,
+                        "y": 4.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 9.5,
+                        "y": 4.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 10.5,
+                        "y": 4.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 10.5,
+                        "y": 5.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 18.5,
+                        "y": 5.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 18.5,
+                        "y": 13.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 19.5,
+                        "y": 13.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 2.5,
+                        "y": 4.5
+                    },
+                    "direction": 12
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 7.5,
+                        "y": 4.5
+                    },
+                    "direction": 4
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 19.5,
+                        "y": 14.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 19.5,
+                        "y": 20.5
+                    },
+                    "direction": 8
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 18.5,
+                        "y": 6.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 18.5,
+                        "y": 12.5
+                    },
+                    "direction": 8
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 11.5,
+                        "y": 5.5
+                    },
+                    "direction": 12
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 17.5,
+                        "y": 5.5
+                    },
+                    "direction": 4
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 8.5,
+                        "y": 5.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 8.5,
+                        "y": 11.5
+                    },
+                    "direction": 8
+                }
+            ],
+            "info": {
+                "nrOfPipes": 8,
+                "nrOfUPipes": 10,
+                "nrOfPipesReplacedByUPipes": 34
+            }
+        },
+        "beacons": {
+            "beacons": [
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 7.5,
+                        "y": 7.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 15.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 7.5,
+                        "y": 2.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 7.5,
+                        "y": -1.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 10.5,
+                        "y": 8.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -2.5,
+                        "y": -2.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -2.5,
+                        "y": 7.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 2.5,
+                        "y": 8.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 2.5,
+                        "y": 18.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 12.5,
+                        "y": 18.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 13.5,
+                        "y": 27.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 15.5,
+                        "y": 16.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 17.5,
+                        "y": -1.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 23.5,
+                        "y": 17.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 23.5,
+                        "y": 27.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 25.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 25.5,
+                        "y": 14.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -2.5,
+                        "y": 0.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -2.5,
+                        "y": 4.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 0.5,
+                        "y": -2.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 2.5,
+                        "y": 11.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 2.5,
+                        "y": 15.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 4.5,
+                        "y": -2.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 5.5,
+                        "y": 18.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 9.5,
+                        "y": 18.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 10.5,
+                        "y": -1.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 12.5,
+                        "y": 11.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 12.5,
+                        "y": 15.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 13.5,
+                        "y": 24.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 14.5,
+                        "y": -1.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 15.5,
+                        "y": 9.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 15.5,
+                        "y": 13.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 16.5,
+                        "y": 27.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 17.5,
+                        "y": 1.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 18.5,
+                        "y": 16.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 20.5,
+                        "y": 27.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 22.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 23.5,
+                        "y": 20.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 23.5,
+                        "y": 24.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 25.5,
+                        "y": 9.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 13.5,
+                        "y": 21.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 4.5,
+                        "y": 5.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 5.5,
+                        "y": 10.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 16.5,
+                        "y": 19.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 18.5,
+                        "y": 8.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 22.5,
+                        "y": 14.5
+                    }
+                }
+            ],
+            "info": {
+                "totalBeacons": 46,
+                "effectsGiven": 51
+            }
+        },
+        "poles": {
+            "poles": [
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 11.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 9.5,
+                        "y": 14.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 14.5,
+                        "y": 0.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 18.5,
+                        "y": 11.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 19.5,
+                        "y": 18.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 22.5,
+                        "y": 10.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 0.5,
+                        "y": 11.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 4.5,
+                        "y": 16.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 16.5,
+                        "y": 25.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 21.5,
+                        "y": 25.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 4.5,
+                        "y": -0.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 0.5,
+                        "y": 1.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 9.5,
+                        "y": 2.5
+                    }
+                }
+            ],
+            "info": {
+                "totalPoles": 13
+            }
+        }
+    },
+    "grid": {
+        "pipes": {
+            "pumpjacksToRotate": [
+                {
+                    "entity_number": 1,
+                    "direction": 4
+                },
+                {
+                    "entity_number": 3,
+                    "direction": 4
+                },
+                {
+                    "entity_number": 6,
+                    "direction": 12
+                },
+                {
+                    "entity_number": 5,
+                    "direction": 0
+                },
+                {
+                    "entity_number": 2,
+                    "direction": 8
+                },
+                {
+                    "entity_number": 4,
+                    "direction": 0
+                }
+            ],
+            "pipes": [
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 4.5,
+                        "y": 1.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 4.5,
+                        "y": 2.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 4.5,
+                        "y": 3.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 4.5,
+                        "y": 4.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 4.5,
+                        "y": 10.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 4.5,
+                        "y": 21.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 10.5,
+                        "y": 4.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 11.5,
+                        "y": 4.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 12.5,
+                        "y": 4.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe",
+                    "position": {
+                        "x": 21.5,
+                        "y": 4.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 4.5,
+                        "y": 5.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 4.5,
+                        "y": 9.5
+                    },
+                    "direction": 8
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 4.5,
+                        "y": 11.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 4.5,
+                        "y": 20.5
+                    },
+                    "direction": 8
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 13.5,
+                        "y": 4.5
+                    },
+                    "direction": 12
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 20.5,
+                        "y": 4.5
+                    },
+                    "direction": 4
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 5.5,
+                        "y": 4.5
+                    },
+                    "direction": 12
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 9.5,
+                        "y": 4.5
+                    },
+                    "direction": 4
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 12.5,
+                        "y": 5.5
+                    },
+                    "direction": 0
+                },
+                {
+                    "name": "pipe-to-ground",
+                    "position": {
+                        "x": 12.5,
+                        "y": 9.5
+                    },
+                    "direction": 8
+                }
+            ],
+            "info": {
+                "nrOfPipes": 10,
+                "nrOfUPipes": 10,
+                "nrOfPipesReplacedByUPipes": 33
+            }
+        },
+        "beacons": {
+            "beacons": [
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 6.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 15.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 6.5,
+                        "y": 16.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 12.5,
+                        "y": 7.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 7.5,
+                        "y": 3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 3.5,
+                        "y": 7.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 9.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -2.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 6.5,
+                        "y": -2.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 6.5,
+                        "y": 10.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 15.5,
+                        "y": 3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 6.5,
+                        "y": 0.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 6.5,
+                        "y": 13.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 11.5,
+                        "y": 15.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 15.5,
+                        "y": 11.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 1.5,
+                        "y": 15.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 0.5,
+                        "y": 6.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -2.5,
+                        "y": -2.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -2.5,
+                        "y": 16.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 1.5,
+                        "y": 25.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 11.5,
+                        "y": 25.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 16.5,
+                        "y": -2.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 16.5,
+                        "y": 16.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 25.5,
+                        "y": 1.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 25.5,
+                        "y": 11.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -2.5,
+                        "y": 0.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -2.5,
+                        "y": 9.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -2.5,
+                        "y": 13.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 0.5,
+                        "y": -2.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 1.5,
+                        "y": 18.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 1.5,
+                        "y": 22.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 4.5,
+                        "y": 25.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 8.5,
+                        "y": 25.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 9.5,
+                        "y": -2.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 11.5,
+                        "y": 18.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 11.5,
+                        "y": 22.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 13.5,
+                        "y": -2.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 16.5,
+                        "y": 0.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 18.5,
+                        "y": 11.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 22.5,
+                        "y": 1.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 22.5,
+                        "y": 11.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 25.5,
+                        "y": 4.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 25.5,
+                        "y": 8.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": -2.5,
+                        "y": 3.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 3.5,
+                        "y": -2.5
+                    }
+                },
+                {
+                    "name": "beacon",
+                    "position": {
+                        "x": 19.5,
+                        "y": 1.5
+                    }
+                }
+            ],
+            "info": {
+                "totalBeacons": 46,
+                "effectsGiven": 67
+            }
+        },
+        "poles": {
+            "poles": [
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 23.5,
+                        "y": 8.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 22.5,
+                        "y": 3.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 18.5,
+                        "y": 3.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 14.5,
+                        "y": 0.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 9.5,
+                        "y": -0.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 4.5,
+                        "y": 23.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 9.5,
+                        "y": 23.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 4.5,
+                        "y": 14.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": -0.5,
+                        "y": 4.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": -0.5,
+                        "y": 13.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 9.5,
+                        "y": 8.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": 14.5,
+                        "y": 14.5
+                    }
+                },
+                {
+                    "name": "medium-electric-pole",
+                    "position": {
+                        "x": -0.5,
+                        "y": -0.5
+                    }
+                }
+            ],
+            "info": {
+                "totalPoles": 13
+            }
+        }
+    }
+}

--- a/packages/editor/src/core/generators/beacon.ts
+++ b/packages/editor/src/core/generators/beacon.ts
@@ -106,10 +106,7 @@ export function generateBeacons(
     const pointToBeaconCount = possibleBeaconAreas
         .flat()
         .map(U.hashPoint)
-        .reduce<Map<string, number>>(
-            (map, key) => map.set(key, map.has(key) ? map.get(key) + 1 : 1),
-            new Map()
-        )
+        .reduce<Map<string, number>>((map, key) => map.set(key, (map.get(key) ?? 0) + 1), new Map())
 
     const pointToEntityArea = entityAreas
         .filter(area => area.every(p => p.effect))
@@ -143,8 +140,10 @@ export function generateBeacons(
                     .map(p => U.manhattenDistance(p, mid))
                     .reduce((acc, distance) => acc + distance, 0) / effectsGiven.length
 
+            // every point of a collision area was counted into pointToBeaconCount
+            // above, so the fallback is unreachable
             const nrOfOverlaps = collisionArea
-                .map(p => pointToBeaconCount.get(U.hashPoint(p)))
+                .map(p => pointToBeaconCount.get(U.hashPoint(p)) ?? 0)
                 .reduce((acc, v) => acc + v, 0)
 
             return {
@@ -172,7 +171,7 @@ export function generateBeacons(
     }, new Map())
 
     // GENERATE BEACONS
-    const beacons = []
+    const beacons: IBeacon[] = []
     while (possibleBeacons.length) {
         possibleBeacons = possibleBeacons
             .sort((a, b) => {
@@ -183,7 +182,7 @@ export function generateBeacons(
             })
             .sort((a, b) => b.effectsGiven - a.effectsGiven)
 
-        const beacon = possibleBeacons.shift()
+        const beacon = U.shiftFirst(possibleBeacons, 'a candidate beacon position')
         beacons.push(beacon)
 
         const toRemove = new Set(

--- a/packages/editor/src/core/generators/generators.test.ts
+++ b/packages/editor/src/core/generators/generators.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vite-plus/test'
+import { IPoint } from '../../types'
+import { generatePipes } from './pipe'
+import { generateBeacons } from './beacon'
+import { generatePoles } from './pole'
+import EXPECTED from './__fixtures__/expected-output.json'
+
+/*
+    Characterization tests for the oil outpost generators.
+
+    These do not assert that the generated layouts are *good* - nobody has written
+    down what "good" means for these algorithms. They assert that the output does
+    not change, which is what makes the generators safe to refactor. The fixture in
+    __fixtures__/expected-output.json was captured from the generators before the
+    strictNullChecks cleanup (issue #22) and must be treated as a fixed point: a
+    diff here means a refactor changed behaviour, not that the fixture is stale.
+
+    Regenerating it is only correct when a change to the algorithms is intended, and
+    the new output should be reviewed as a layout change rather than accepted blind.
+
+    All three generators run in sequence because that is how Blueprint.generatePipes
+    calls them - beacons are placed around the pumpjacks and pipes, and poles around
+    all three. Chaining them means a pipe-stage regression also shows up downstream.
+*/
+
+const LAYOUTS: Record<string, { entity_number: number; position: IPoint }[]> = {
+    // two pumpjacks in a straight line: the simplest group, no group merging
+    pair: [
+        { entity_number: 1, position: { x: 1.5, y: 1.5 } },
+        { entity_number: 2, position: { x: 10.5, y: 1.5 } },
+    ],
+    // three collinear pumpjacks: exercises the collinear branch of pointsToLines
+    row: [
+        { entity_number: 1, position: { x: 1.5, y: 1.5 } },
+        { entity_number: 2, position: { x: 8.5, y: 1.5 } },
+        { entity_number: 3, position: { x: 15.5, y: 1.5 } },
+    ],
+    // no two pumpjacks share an axis, so lines are sparse and the generator has to
+    // fall back on pathfinding, group merging and the leftover-pumpjack pass
+    scattered: [
+        { entity_number: 1, position: { x: 2.5, y: 2.5 } },
+        { entity_number: 2, position: { x: 12.5, y: 3.5 } },
+        { entity_number: 3, position: { x: 7.5, y: 13.5 } },
+        { entity_number: 4, position: { x: 20.5, y: 11.5 } },
+        { entity_number: 5, position: { x: 18.5, y: 22.5 } },
+    ],
+    // aligned on both axes plus two outliers: many candidate lines to sort between,
+    // and multiple groups that have to be connected to each other
+    grid: [
+        { entity_number: 1, position: { x: 2.5, y: 2.5 } },
+        { entity_number: 2, position: { x: 11.5, y: 2.5 } },
+        { entity_number: 3, position: { x: 2.5, y: 11.5 } },
+        { entity_number: 4, position: { x: 11.5, y: 11.5 } },
+        { entity_number: 5, position: { x: 20.5, y: 6.5 } },
+        { entity_number: 6, position: { x: 6.5, y: 20.5 } },
+    ],
+}
+
+function runGenerators(pumpjacks: { entity_number: number; position: IPoint }[]): unknown {
+    const pipes = generatePipes(pumpjacks, 1)
+
+    const entitiesForBeaconGen = [
+        ...pumpjacks.map(p => ({ ...p, name: 'pumpjack', size: 3, effect: true })),
+        ...pipes.pipes.map(p => ({ ...p, size: 1, effect: false })),
+    ]
+    const beacons = generateBeacons(entitiesForBeaconGen, 1)
+
+    const entitiesForPoleGen = [
+        ...pumpjacks.map(p => ({ ...p, name: 'pumpjack', size: 3, power: true })),
+        ...pipes.pipes.map(p => ({ ...p, size: 1, power: false })),
+        ...beacons.beacons.map(p => ({ ...p, size: 3, power: true })),
+    ]
+    const poles = generatePoles(entitiesForPoleGen)
+
+    // visualizations are debug overlays, not output - left out so cosmetic changes
+    // to them do not fail the test
+    return {
+        pipes: {
+            pumpjacksToRotate: pipes.pumpjacksToRotate,
+            pipes: pipes.pipes,
+            info: pipes.info,
+        },
+        beacons: { beacons: beacons.beacons, info: beacons.info },
+        poles: { poles: poles.poles, info: poles.info },
+    }
+}
+
+describe('oil outpost generators', () => {
+    for (const [name, pumpjacks] of Object.entries(LAYOUTS)) {
+        it(`produces unchanged output for the "${name}" layout`, () => {
+            // compared through JSON so key order is part of the contract and
+            // undefined-vs-missing properties cannot slip through unnoticed
+            const actual = JSON.parse(JSON.stringify(runGenerators(pumpjacks)))
+            expect(actual).toEqual((EXPECTED as Record<string, unknown>)[name])
+        })
+    }
+
+    it('covers every layout in the fixture', () => {
+        expect(Object.keys(LAYOUTS).sort()).toEqual(Object.keys(EXPECTED).sort())
+    })
+
+    it('is deterministic across repeated runs', () => {
+        const first = JSON.stringify(runGenerators(LAYOUTS.scattered))
+        const second = JSON.stringify(runGenerators(LAYOUTS.scattered))
+        expect(second).toBe(first)
+    })
+})

--- a/packages/editor/src/core/generators/pipe.ts
+++ b/packages/editor/src/core/generators/pipe.ts
@@ -37,12 +37,23 @@ interface ILine {
 interface IPumpjack extends IPoint {
     entity_number: number
     plugs: IPlug[]
-    plug?: IPlug
-    dir?: number
+}
+
+/**
+ * A pumpjack that has been committed to a group, and so has had one of its
+ * candidate `plugs` chosen as the `plug` the pipe network actually connects to.
+ *
+ * Keeping this separate from `IPumpjack` is what lets the later stages - choosing
+ * underground pipe positions, and rotating the pumpjacks to face their pipe - read
+ * `plug` without re-checking it. A pumpjack only ever reaches those stages through
+ * a group, and joining a group is exactly when the plug gets picked.
+ */
+interface IPlacedPumpjack extends IPumpjack {
+    plug: IPlug
 }
 
 interface IGroup extends IPoint {
-    entities: IPumpjack[]
+    entities: IPlacedPumpjack[]
     paths: IPoint[][]
 }
 
@@ -154,7 +165,7 @@ function generatePipes(
 
     // GENERATE GROUPS
     let groups: IGroup[] = []
-    const addedPumpjacks: IPumpjack[] = []
+    const addedPumpjacks: IPlacedPumpjack[] = []
     while (LINES.length) {
         LINES = LINES.sort((a, b) => a.avgDistance - b.avgDistance)
             .sort((a, b) => a.connections.length - b.connections.length)
@@ -185,7 +196,7 @@ function generatePipes(
                 return 0
             })
 
-        const l = LINES.shift()
+        const l = U.shiftFirst(LINES, 'a line to form a group from')
         const addedEnt1 = addedPumpjacks.find(e => e.entity_number === l.endpoints[0].entity_number)
         const addedEnt2 = addedPumpjacks.find(e => e.entity_number === l.endpoints[1].entity_number)
 
@@ -199,7 +210,7 @@ function generatePipes(
             .sort((a, b) => a.distance - b.distance)
 
         for (const t of l.connections) {
-            const entities = [
+            const entities: IPlacedPumpjack[] = [
                 { ...l.endpoints[0], plug: t.plugs[0] },
                 { ...l.endpoints[1], plug: t.plugs[1] },
             ]
@@ -208,15 +219,23 @@ function generatePipes(
                 addedPumpjacks.push(...entities)
                 break
             }
+            // every pumpjack in addedPumpjacks was pushed there together with the
+            // group that holds it, so the group lookups below always succeed
             if (!addedEnt1 && addedEnt2 && addedEnt2.plug.dir === t.plugs[1].dir) {
-                const g = groups.find(g => g.entities.includes(addedEnt2))
+                const g = U.expectFound(
+                    groups.find(g => g.entities.includes(addedEnt2)),
+                    'the group holding an already added pumpjack'
+                )
                 g.entities.push(entities[0])
                 g.paths.push(t.path)
                 addedPumpjacks.push(entities[0])
                 break
             }
             if (!addedEnt2 && addedEnt1 && addedEnt1.plug.dir === t.plugs[0].dir) {
-                const g = groups.find(g => g.entities.includes(addedEnt1))
+                const g = U.expectFound(
+                    groups.find(g => g.entities.includes(addedEnt1)),
+                    'the group holding an already added pumpjack'
+                )
                 g.entities.push(entities[1])
                 g.paths.push(t.path)
                 addedPumpjacks.push(entities[1])
@@ -264,7 +283,7 @@ function generatePipes(
     // CONNECT GROUPS
     let tries = MAX_TRIES
     let aloneGroups: IGroup[] = []
-    let finalGroup: IGroup
+    let finalGroup: IGroup | undefined
     while (groups.length) {
         for (const g of groups) {
             g.x = g.entities.reduce((acc, e) => acc + e.x, 0) / g.entities.length
@@ -277,7 +296,7 @@ function generatePipes(
         )
 
         const groupsCopy = [...groups]
-        const group = groups.shift()
+        const group = U.shiftFirst(groups, 'a group to connect')
         if (!groups.length) {
             if (aloneGroups.length && tries) {
                 groups.push(...aloneGroups, group)
@@ -293,7 +312,11 @@ function generatePipes(
             grid,
             U.pointsToLines(groupsCopy)
                 .filter(l => l.includes(group))
-                .map(l => l.find(g => g !== group)),
+                // a line whose two ends are the same group contributes no other
+                // group to connect to - pointsToLines does produce those when
+                // groups share a centre point and get deduplicated down to one
+                .map(l => l.find(g => g !== group))
+                .filter(g => g !== undefined),
             group,
             2 + MAX_TRIES - tries
         )
@@ -309,13 +332,18 @@ function generatePipes(
         addVisualization(conn.path, 16, 0.5)
     }
 
+    // The loop above only ends by draining `groups`, and the single path that
+    // drains it assigns finalGroup. `groups` is never empty on entry either: a
+    // group is seeded above when the line stage produced none.
+    const mainGroup = U.expectFound(finalGroup, 'a pumpjack group to attach the pipe network to')
+
     // ADD LEFTOVER PUMPJACKS TO GROUP
     const leftoverPumpjacks = dataset
         .filter(ent => !addedPumpjacks.find(e => e.entity_number === ent.entity_number))
         .sort((a, b) => U.manhattenDistance(a, middle) - U.manhattenDistance(b, middle))
 
     while (leftoverPumpjacks.length) {
-        const ent = leftoverPumpjacks.shift()
+        const ent = U.shiftFirst(leftoverPumpjacks, 'a leftover pumpjack')
 
         const conn = getPathBetweenGroups(
             grid,
@@ -326,27 +354,36 @@ function generatePipes(
                 paths: [[{ x: p.x, y: p.y }]],
                 entities: [{ x: 0, y: 0, entity_number: 0, plugs: [p], plug: p }],
             })),
-            finalGroup
+            mainGroup
         )
 
-        finalGroup.entities.push({ ...ent, plug: conn.toGroup.entities[0].plug })
-        finalGroup.paths.push(conn.path)
+        // A leftover pumpjack with no route to the main group has no pipe layout at
+        // all. That already ended the generation run, just as an opaque TypeError a
+        // line further down; this says which pumpjack is unreachable.
+        if (!conn) {
+            throw new Error(
+                `No pipe path from pumpjack ${ent.entity_number} to the main pipe group`
+            )
+        }
+
+        mainGroup.entities.push({ ...ent, plug: conn.toGroup.entities[0].plug })
+        mainGroup.paths.push(conn.path)
 
         addVisualization(conn.path, 8, 0.5)
     }
 
-    let pipePositions = U.uniqPoints(finalGroup.paths.flat())
+    let pipePositions = U.uniqPoints(mainGroup.paths.flat())
 
     // GENERATE ALL INTERSECTION POINTS (WILL INCLUDE ALL PUMPJACKS PLUGS TOO)
     const intersectionPositions = U.uniqPoints(
-        finalGroup.paths.flatMap(p =>
+        mainGroup.paths.flatMap(p =>
             PF.Util.compressPath(p.map(U.pointToArray)).map(U.arrayToPoint)
         )
     )
     // addVisualization(intersectionPositions)
 
     // GENERATE ALL VALID POSITIONS (THAT COINCIDE WITH PLUGS) WHERE AN UNDERGROUND PIPE CAN SPAWN
-    const validCoordsForUPipes = finalGroup.entities
+    const validCoordsForUPipes = mainGroup.entities
         .map(e => e.plug)
         // filter out overlapping plugs
         .sort((a, b) => (a.x - b.x ? a.x - b.x : a.y - b.y))
@@ -371,13 +408,18 @@ function generatePipes(
                         return { x: plug.x, y: plug.y + 1 }
                     case 12:
                         return { x: plug.x - 1, y: plug.y }
+                    default:
+                        // plug directions come from PUMPJACK_PLUGS as `i * 4` and the
+                        // callers only pass 4 or 12, so the sum is always a multiple
+                        // of 4 and the four cases above are exhaustive
+                        throw new Error(`Unexpected pipe direction ${(plug.dir + dir) % 16}`)
                 }
             }
         })
     // addVisualization(validStraightPipeEnds)
 
     // GENERATE ALL STRAIGHT PATHS
-    const straightPaths = finalGroup.paths
+    const straightPaths = mainGroup.paths
         // not length - 4 because one of the ends might be in validStraightPipeEnds
         .filter(p => p.length - 3 >= MIN_GAP_BETWEEN_UNDERGROUNDS)
         .flatMap(p =>
@@ -395,7 +437,7 @@ function generatePipes(
         .map(path =>
             path.filter((pos, i, arr) => {
                 if (i > 0 && i < arr.length - 1) return true
-                return validCoordsForUPipes.find(U.equalPoints(pos))
+                return validCoordsForUPipes.some(U.equalPoints(pos))
             })
         )
         .filter(p => p.length - 2 >= MIN_GAP_BETWEEN_UNDERGROUNDS)
@@ -430,7 +472,7 @@ function generatePipes(
         .filter(coord => !straightPathsCoords.find(U.equalPoints(coord)))
         .map(localToGlobal)
 
-    const pumpjacksToRotate = finalGroup.entities.map(e => ({
+    const pumpjacksToRotate = mainGroup.entities.map(e => ({
         entity_number: e.entity_number,
         direction: e.plug.dir,
     }))
@@ -493,20 +535,25 @@ function generatePathFromLine(l: IPoint[]): {
     }
 }
 
-/** Returns the shortest path between the given group and one group from the given array */
+/**
+ * Returns the shortest path between the given group and one group from the given
+ * array, or `undefined` when none of them can be reached within `maxTurns`.
+ */
 function getPathBetweenGroups(
     grid: number[][],
     GROUPS: IGroup[],
     group: IGroup,
     maxTurns = 2
-): {
-    path: IPoint[]
-    toGroup: IGroup
-} {
+):
+    | {
+          path: IPoint[]
+          toGroup: IGroup
+      }
+    | undefined {
     const ret = GROUPS.map(g => connect2Groups(grid, g, group, maxTurns))
         .filter(p => p.lines.length)
         .sort((a, b) => a.minDistance - b.minDistance)[0]
-    if (!ret) return
+    if (!ret) return undefined
     return {
         toGroup: ret.firstGroup,
         path: ret.lines[0].path,

--- a/packages/editor/src/core/generators/pole.ts
+++ b/packages/editor/src/core/generators/pole.ts
@@ -166,7 +166,7 @@ export function generatePoles(entities: { position: IPoint; size: number; power:
             .sort((a, b) => a.distFromMidOfConsumers - b.distFromMidOfConsumers)
             .sort((a, b) => b.powerGiven - a.powerGiven)
 
-        const pole = possiblePoles.shift()
+        const pole = U.shiftFirst(possiblePoles, 'a candidate pole position')
         poles.push(pole)
 
         const toRemove = pole.poweredEntityAreas.flatMap(area => {
@@ -195,7 +195,7 @@ export function generatePoles(entities: { position: IPoint; size: number; power:
     let groups: IGroup[] = []
     const addedPoles: IPole[] = []
     while (lines.length) {
-        const l = lines.shift()
+        const l = U.shiftFirst(lines, 'a line to form a pole group from')
         const g1 = groups.find(g => g.poles.includes(l[0]))
         const g2 = groups.find(g => g.poles.includes(l[1]))
 
@@ -249,7 +249,7 @@ export function generatePoles(entities: { position: IPoint; size: number; power:
 
     // CONNECT GROUPS
     const connectionPoles: IPoint[] = []
-    let finalGroup: IGroup
+    let finalGroup: IGroup | undefined
     while (groups.length) {
         for (const g of groups) {
             g.x = g.poles.reduce((acc, e) => acc + e.x, 0) / g.poles.length
@@ -258,7 +258,7 @@ export function generatePoles(entities: { position: IPoint; size: number; power:
         groups = groups.sort((a, b) => a.poles.length - b.poles.length)
 
         const groupsCopy = [...groups]
-        const group = groups.shift()
+        const group = U.shiftFirst(groups, 'a pole group to connect')
         if (!groups.length) {
             finalGroup = group
             break
@@ -266,7 +266,10 @@ export function generatePoles(entities: { position: IPoint; size: number; power:
 
         const DATA = U.pointsToLines(groupsCopy)
             .filter(l => l.includes(group))
+            // a line whose two ends are the same group offers nothing to connect to,
+            // which pointsToLines produces when groups share a centre point
             .map(l => l.find(g => g !== group))
+            .filter(g => g !== undefined)
             .map(otherGroup => {
                 const shortestLine = U.pointsToLines([...group.poles, ...otherGroup.poles])
                     // filter out lines that are in the same group
@@ -283,8 +286,16 @@ export function generatePoles(entities: { position: IPoint; size: number; power:
                     }))
                     .sort((a, b) => a.dist - b.dist)[0]
 
-                const g1pole = shortestLine.poles.find(p => group.poles.includes(p))
-                const g2pole = shortestLine.poles.find(p => otherGroup.poles.includes(p))
+                // same-group lines were filtered out above, so the shortest line has
+                // exactly one end in each group
+                const g1pole = U.expectFound(
+                    shortestLine.poles.find(p => group.poles.includes(p)),
+                    'the end of the shortest line belonging to the current group'
+                )
+                const g2pole = U.expectFound(
+                    shortestLine.poles.find(p => otherGroup.poles.includes(p)),
+                    'the end of the shortest line belonging to the other group'
+                )
 
                 const betweenG1AndG2Poles = {
                     x: (g1pole.x + g2pole.x) / 2,
@@ -325,12 +336,17 @@ export function generatePoles(entities: { position: IPoint; size: number; power:
 
     addVisualization(connectionPoles, 16, 1, 0x8a2be2)
 
+    // The loop above only ends by draining `groups`, and the one path that drains it
+    // assigns finalGroup. `groups` is non-empty on entry because every pole that did
+    // not join a line group is added above as a group of its own.
+    const mainGroup = U.expectFound(finalGroup, 'a pole group to draw the power network from')
+
     const info = {
-        totalPoles: finalGroup.poles.length,
+        totalPoles: mainGroup.poles.length,
     }
 
     return {
-        poles: finalGroup.poles.map(p => ({
+        poles: mainGroup.poles.map(p => ({
             name: 'medium-electric-pole',
             position: { x: p.x + 0.5, y: p.y + 0.5 },
         })),

--- a/packages/editor/src/core/generators/util.ts
+++ b/packages/editor/src/core/generators/util.ts
@@ -32,6 +32,25 @@ const pointInCircle = (point: IPoint, origin: IPoint, r: number): boolean =>
 const range = (from: number, to: number): number[] =>
     [...Array(to - from).keys()].map(i => from + i)
 
+/**
+ * Asserts that a lookup the algorithm treats as infallible really did find something.
+ *
+ * The generators are full of `find` and `shift` calls whose success is guaranteed by
+ * a surrounding loop guard or by how the data was built, but which `strictNullChecks`
+ * still widens to `T | undefined`. Naming the invariant is better than a non-null
+ * assertion: if one is ever wrong it fails immediately and says which, rather than
+ * letting `undefined` travel into the geometry and surface as an unrelated TypeError.
+ */
+const expectFound = <T>(value: T | undefined, what: string): T => {
+    if (value === undefined) {
+        throw new Error(`${what} was expected to exist but was not found`)
+    }
+    return value
+}
+
+/** Removes and returns the first element of an array that is known to be non-empty. */
+const shiftFirst = <T>(list: T[], what: string): T => expectFound(list.shift(), what)
+
 // https://stackoverflow.com/a/38024982
 /** Returns the angle (0-360) anticlockwise from the horizontal for a point on a circle */
 const getAngle = (cX: number, cY: number, pX: number, pY: number): number => {
@@ -142,6 +161,8 @@ export default {
     pointsToLines,
     pointsToTriangles,
     range,
+    expectFound,
+    shiftFirst,
     getAngle,
     getReflectedPoint,
     findSide,

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 0
+    "maxErrors": 760
 }

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 760
+    "maxErrors": 664
 }

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 664
+    "maxErrors": 639
 }

--- a/tests/position-grid.spec.ts
+++ b/tests/position-grid.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test'
+import { discoverBlueprintFiles, readBlueprintString } from './helpers/blueprint-files'
+
+/*
+    PositionGrid is the spatial index behind entity placement, overlap rules and
+    the neighbour lookups the sprite builder uses, and nothing exercised it. The
+    blueprint-loading suite covers decode and render; this covers the query and
+    mutation surface, against a real blueprint rather than a hand-built fixture,
+    because the interesting invariant is one that only holds in a real one: the
+    grid stores entity numbers and trusts every one of them to still resolve
+    against bp.entities.
+
+    Runs against the dev server like the rest of tests/ - see CLAUDE.md for the
+    two servers that have to be up.
+*/
+
+// a mid-sized blueprint with enough variety to cover multi-cell and shared cells
+const BLUEPRINT = 'EARN/power-blocks-v22-0-8.rev-1'
+
+test('PositionGrid answers queries and stays consistent through a mutation', async ({ page }) => {
+    const blueprint = discoverBlueprintFiles().find(f => f.name === BLUEPRINT)
+    if (!blueprint) throw new Error(`test blueprint ${BLUEPRINT} not found in wormeyman-tests/`)
+
+    const errors: string[] = []
+    page.on('pageerror', e => errors.push(String(e)))
+    page.on('console', m => {
+        if (m.type() === 'error') errors.push(m.text())
+    })
+
+    await page.goto('/')
+    await page.waitForFunction(() => (window as any).__fbe_test !== undefined, { timeout: 60_000 })
+
+    const bpString = readBlueprintString(blueprint.filePath)
+
+    const result = await page.evaluate(async (str: string) => {
+        const api = (window as any).__fbe_test
+        let bp = await api.getBlueprintOrBookFromSource(str)
+        if (bp.selectBlueprint) bp = bp.selectBlueprint(0)
+
+        const grid = bp.entityPositionGrid
+        const entities = [...bp.entities.values()]
+        const first = entities[0]
+
+        // Every entity must be findable at its own position. This also asserts the
+        // grid/bp.entities invariant end to end: resolving a stored number that has
+        // no entity behind it throws rather than returning undefined.
+        const unfindable = entities.filter(
+            (e: any) => grid.getEntityAtPosition(e.position) === undefined
+        ).length
+
+        const farAway = { x: 99999, y: 99999 }
+        const firstArea = {
+            x: first.position.x,
+            y: first.position.y,
+            w: first.size.x,
+            h: first.size.y,
+        }
+
+        // remove/re-add must leave the cell exactly as it was
+        const before = grid.getEntityAtPosition(first.position)?.entityNumber
+        grid.removeTileData(first)
+        const whileRemoved = grid.getEntityAtPosition(first.position)?.entityNumber
+        grid.setTileData(first)
+        const after = grid.getEntityAtPosition(first.position)?.entityNumber
+
+        return {
+            entityCount: entities.length,
+            unfindable,
+            emptyPositionIsUndefined: grid.getEntityAtPosition(farAway) === undefined,
+            neighbours: grid.getNeighbourData(farAway),
+            emptyAreaIsEmpty: grid.isAreaEmpty({ ...farAway, w: 3, h: 3 }),
+            availableOnEmptySpace: grid.isAreaAvailable('wooden-chest', farAway),
+            availableOnTopOfEntity: grid.isAreaAvailable('wooden-chest', first.position),
+            surroundingAllResolve: grid
+                .getSurroundingEntities(firstArea)
+                .every((e: any) => e !== undefined),
+            entitiesInAreaIncludesSelf: grid
+                .getEntitiesInArea(firstArea)
+                .some((e: any) => e.entityNumber === first.entityNumber),
+            // an entity is never a fast-replace candidate for its own name
+            fastReplaceOnSelf: grid.checkFastReplaceableGroup(
+                first.name,
+                first.direction,
+                first.position
+            ),
+            rotatedMatchNumber: grid.checkSameEntityAndDifferentDirection(
+                first.name,
+                (first.direction + 4) % 16,
+                first.position
+            )?.entityNumber,
+            firstNumber: first.entityNumber,
+            before,
+            whileRemoved,
+            after,
+        }
+    }, bpString)
+
+    expect(result.entityCount).toBeGreaterThan(100)
+    expect(result.unfindable).toBe(0)
+
+    // empty space reads as empty everywhere it is asked about
+    expect(result.emptyPositionIsUndefined).toBe(true)
+    expect(result.neighbours).toHaveLength(4)
+    expect(result.neighbours.every((n: { entity?: unknown }) => n.entity === undefined)).toBe(true)
+    expect(result.emptyAreaIsEmpty).toBe(true)
+    expect(result.availableOnEmptySpace).toBe(true)
+
+    // occupied space blocks placement and reports its occupants
+    expect(result.availableOnTopOfEntity).toBe(false)
+    expect(result.surroundingAllResolve).toBe(true)
+    expect(result.entitiesInAreaIncludesSelf).toBe(true)
+
+    expect(result.fastReplaceOnSelf).toBeUndefined()
+    expect(result.rotatedMatchNumber).toBe(result.firstNumber)
+
+    // the mutation round trip restores the cell
+    expect(result.before).toBe(result.firstNumber)
+    expect(result.whileRemoved).toBeUndefined()
+    expect(result.after).toBe(result.firstNumber)
+
+    expect(errors).toEqual([])
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,14 +13,17 @@
 
         // Incrementally migrating to full `strict` (TS7 defaults it true). The
         // umbrella stays off; sub-flags are enabled one batch at a time as the
-        // codebase is cleaned. Remaining before `strict: true`: strictNullChecks
-        // (~784) and strictPropertyInitialization (~1). See type-check-baseline.json.
+        // codebase is cleaned. `strictNullChecks` is now on with its errors
+        // ratcheted down via scripts/type-check-baseline.json; once that reaches 0,
+        // `strictPropertyInitialization` (~1 error) rides along and `strict: true`
+        // replaces this whole block. See issue #22.
         "strict": false,
         "noImplicitThis": true,
         "alwaysStrict": true,
         "useUnknownInCatchVariables": true,
         "strictBindCallApply": true,
         "strictFunctionTypes": true,
+        "strictNullChecks": true,
         "noImplicitAny": true,
 
         "paths": {


### PR DESCRIPTION
Starts issue #22. Turns `strictNullChecks` on behind the existing ratchet, then clears the first two areas: the oil outpost generators and `PositionGrid`.

## What lands

| Step | Editor errors |
| --- | --- |
| Flag on, baseline pinned | 760 |
| Generators (pipe, pole, beacon) | 664 |
| PositionGrid | 639 |

Lint also drops 109 -> 28 as a side effect: `no-useless-default-assignment` was reporting "this rule requires strictNullChecks" on 81 files instead of actually running.

## On not papering over

Issue #22 warns that `!` and `?.` would clear the count while losing the signal, so none of this uses a non-null assertion (the lint rule bans them anyway). Where an invariant genuinely holds it is now named and enforced rather than assumed:

- `U.expectFound` / `U.shiftFirst` in the generators, for `shift()` under a `while (list.length)` guard and for `find()` lookups the algorithm builds the data to guarantee.
- `PositionGrid.entityAt()`, for the fact that the grid is an index into `bp.entities` rather than an independent store - the two are kept in lockstep by a single `onCreateOrRemoveEntity` hook.

Two type-level fixes did more work than the assertions:

- `IPumpjack.plug?: IPlug` forced every later pipe stage to re-check something always set by then. Split into `IPumpjack` / `IPlacedPumpjack`, where joining a group *is* picking the plug. That alone was a third of pipe.ts.
- `getEntityAtPosition`, `findInArea` and `checkFastReplaceableGroup` all declared they returned an `Entity` while having paths that returned nothing. Correcting them moved 9 errors onto callers that relied on the lie - all in `spriteDataBuilder.ts`, which #22 already defers, so they land where that work will pick them up.

## Behaviour

Three edge cases change, all away from a crash and all noted in the commits: a self-line during group connection is now skipped instead of throwing a `TypeError` inside `connect2Groups`; an unreachable leftover pumpjack now throws naming the pumpjack instead of `Cannot read properties of undefined` a line later; `entityAt` throws on a drifted grid instead of returning `undefined`.

Everything else is byte-identical output, which is checked rather than asserted.

## Verification

Neither area had any tests, so both got one before being touched.

- `generators.test.ts` runs four pumpjack layouts through pipe -> beacon -> pole and compares against a fixture captured *before* the refactor. Mutation-checked: changing `MAX_GAP_BETWEEN_UNDERGROUNDS`, `GRID_MARGIN`, the middle-distance line sort, `POLE_TO_POLE_RADIUS` or `BEACON_EFFECT_RADIUS` each fail it. The fixture is a fixed point, not a snapshot to refresh - the header says so.
- `tests/position-grid.spec.ts` exercises the query and mutation surface against a 4245-entity blueprint. All 4245 resolve through `entityAt`, so the lockstep invariant holds in practice. Mutation-checked: breaking `removeTileData` fails it.
- All 10 blueprints in the Playwright suite still load clean, and `vp build` is clean.

## Next

`WireConnections.ts` (38) + `WireConnectionMap.ts` (10) + `WiresContainer.ts` (16) are one unit: they share a root cause in `IConnectionPoint`, whose fields are all optional even though a connection point is really either entity-anchored or a loose position on a wire being dragged. Splitting that into two types should take most of the 64 at once. Left for its own pass rather than rushed onto the end of this one.

Unrelated and untouched: the root `tsc` project reports ~30 errors in `tests/` from missing `@types/node`. It is not gated by CI and is not part of #22.