### PR TITLE
chore(ts): split IConnectionPoint, clear the wire cluster (639 -> 562)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,8 @@ Vite dev server runs on port 8080. In dev mode, `/data` is proxied to `http://12
 - `packages/editor/src/core/Blueprint.ts` - Blueprint data model, entity creation, wire connections.
 - `packages/editor/src/core/PositionGrid.ts` - Spatial index behind placement, overlap rules and neighbour lookups. It stores entity numbers, not entities: `setTileData`/`removeTileData` keep it in lockstep with `Blueprint.entities` via `onCreateOrRemoveEntity`, and `entityAt()` throws if the two ever drift.
 - `packages/editor/src/core/generators/` - Oil outpost generators (pipe, beacon, pole). Untested geometry until recently; `generators.test.ts` pins their output against a committed fixture, so a diff there means a refactor changed generated layouts.
+- `packages/editor/src/core/WireConnections.ts` - Wire data model. A connection point is either `IEntityConnectionPoint` (anchored to an entity) or `ILooseConnectionPoint` (a bare position, produced only by `PaintWireContainer` for the end following the cursor). `IConnection` has two anchored ends and is what gets stored, hashed and serialized; `IDrawableConnection` is the wider type `WiresContainer.add` accepts. `hash()` sorts `cps` in place on purpose - that normalisation is load-bearing.
+- `packages/editor/src/core/WireConnectionMap.ts` - Stores wires twice: hash -> connection, plus an entity number -> hashes index. `get`/`getEntityConnections` throw if the two drift, same signal `PositionGrid.entityAt` gives. Note a self-connection is indexed once, not twice.
 - `packages/editor/src/containers/EntitySprite.ts` - Creates PixiJS sprites from sprite data. `getParts()` is the main entry point.
 - `packages/editor/src/containers/BlueprintContainer.ts` - Main rendering container. `spawnPaintContainer()` handles entity placement from inventory.
 - `packages/editor/src/containers/EntityContainer.ts` - Per-entity container, calls `EntitySprite.getParts()` in `redraw()`.
@@ -141,6 +143,7 @@ Automated tests that load blueprint `.txt` files from `wormeyman-tests/` against
 - `playwright.config.ts` - Config (base URL localhost:8080, 120s timeout, single worker)
 - `tests/blueprint-loading.spec.ts` - Main test file - iterates blueprints, uses `window.__fbe_test` API to load directly
 - `tests/position-grid.spec.ts` - Exercises `PositionGrid` queries and the setTileData/removeTileData round trip against a real loaded blueprint (the class is core to placement and cannot be unit tested without FD data loaded)
+- `tests/wire-connections.spec.ts` - Checks the connection map agrees with its entity index, that `serializeBpWires` resolves every endpoint, and that remove/re-create reproduces the wire set. Also needs FD loaded. The static `serialize`/`deserialize` are unit tested in `packages/editor/src/core/WireConnections.test.ts` instead - those need no FD
 - `tests/helpers/blueprint-files.ts` - Discovers `.txt` files from `wormeyman-tests/{collection}/`
 - `tests/helpers/report-generator.ts` - Generates JSON + markdown reports to `diagnostic-reports/`
 
@@ -152,6 +155,8 @@ Automated tests that load blueprint `.txt` files from `wormeyman-tests/` against
 
 - Terminal 1: `cd packages/website && vp dev` (Vite on port 8080)
 - Terminal 2: `npx serve packages/exporter/data/output -l 8081 --cors` (sprite data)
+
+Start them in that order and check the port Vite reports. If something else already holds 8080, Vite silently falls back to 8081 and then proxies `/data` to itself, which looks like the sprite server failing rather than a port clash. Pin it with `vp dev --port 8080 --strictPort` to get a clear failure instead, and note `playwright.config.ts` hardcodes `baseURL` to 8080.
 
 **Reports** are written to `diagnostic-reports/blueprint-diagnostics.json` and `diagnostic-reports/blueprint-diagnostics.md` (gitignored).
 
@@ -180,5 +185,5 @@ Mobile devices get a read-only viewer with touch gestures (single-finger pan, pi
 - Complex visualizations (crane arms, plasma effects, thruster flames) show only static base sprites
 - Blueprint book icons using planet names show no icon
 - Some entity types may have missing or incorrectly mapped textures
-- TypeScript has pre-existing type errors in Space Age code (`as any` casts used where prototype types don't match runtime data from data.json). Most of what is left sits in `spriteDataBuilder.ts` and is the same problem viewed through `strictNullChecks` - see issue #22 for the plan and the current count
+- TypeScript has pre-existing type errors in Space Age code (`as any` casts used where prototype types don't match runtime data from data.json). Most of what is left sits in `spriteDataBuilder.ts` (326 of the 562) and is the same problem viewed through `strictNullChecks` - see issue #22 for the plan and the current count
 - Mobile is view-only - no editing, inventory, or keyboard shortcuts

--- a/packages/editor/src/containers/PaintBlueprintContainer.ts
+++ b/packages/editor/src/containers/PaintBlueprintContainer.ts
@@ -4,7 +4,7 @@ import { EntitySprite } from './EntitySprite'
 import { PaintContainer } from './PaintContainer'
 import { PaintBlueprintEntityContainer } from './PaintBlueprintEntityContainer'
 import { BlueprintContainer } from './BlueprintContainer'
-import { IConnectionPoint } from '../core/WireConnections'
+import { IConnection } from '../core/WireConnections'
 
 export class PaintBlueprintContainer extends PaintContainer {
     private readonly bp: Blueprint
@@ -175,16 +175,21 @@ export class PaintBlueprintContainer extends PaintContainer {
             for (const [oldID] of oldEntIDToNewEntID) {
                 this.bp.wireConnections
                     .getEntityConnections(oldID)
-                    .filter(connection =>
-                        connection.cps.every(cp => oldEntIDToNewEntID.has(cp.entityNumber))
-                    )
-                    .map(connection => ({
-                        ...connection,
-                        cps: connection.cps.map(cp => ({
-                            ...cp,
-                            entityNumber: oldEntIDToNewEntID.get(cp.entityNumber),
-                        })) as [IConnectionPoint, IConnectionPoint],
-                    }))
+                    .flatMap<IConnection>(connection => {
+                        const en0 = oldEntIDToNewEntID.get(connection.cps[0].entityNumber)
+                        const en1 = oldEntIDToNewEntID.get(connection.cps[1].entityNumber)
+                        // only copy a wire when both of its ends were pasted
+                        if (en0 === undefined || en1 === undefined) return []
+                        return [
+                            {
+                                ...connection,
+                                cps: [
+                                    { ...connection.cps[0], entityNumber: en0 },
+                                    { ...connection.cps[1], entityNumber: en1 },
+                                ],
+                            },
+                        ]
+                    })
                     .forEach(conn => this.bpc.bp.wireConnections.create(conn))
             }
         }

--- a/packages/editor/src/containers/PaintWireContainer.ts
+++ b/packages/editor/src/containers/PaintWireContainer.ts
@@ -1,7 +1,7 @@
 import { Container } from 'pixi.js'
 import G from '../common/globals'
 import U from '../core/generators/util'
-import { IConnection, IConnectionPoint } from '../core/WireConnections'
+import { IConnection, IDrawableConnection, IEntityConnectionPoint } from '../core/WireConnections'
 import { Entity } from '../core/Entity'
 import { EntityContainer } from './EntityContainer'
 import { PaintContainer } from './PaintContainer'
@@ -10,7 +10,8 @@ import { WireColor } from '../types'
 
 export class PaintWireContainer extends PaintContainer {
     private color: WireColor
-    private cp?: IConnectionPoint = undefined
+    /** The anchored end of the wire being dragged; the other end follows the cursor. */
+    private cp?: IEntityConnectionPoint = undefined
     /** This is only a reference */
     private cursorBox: Container
 
@@ -25,7 +26,7 @@ export class PaintWireContainer extends PaintContainer {
         this.redraw()
     }
 
-    private get entity(): Entity {
+    private get entity(): Entity | undefined {
         if (this.cp === undefined) return undefined
         return this.bpc.bp.entities.get(this.cp.entityNumber)
     }
@@ -54,27 +55,28 @@ export class PaintWireContainer extends PaintContainer {
         return this.name
     }
 
-    private updateCursorBox(): IConnectionPoint {
+    private updateCursorBox(): IEntityConnectionPoint | undefined {
         this.destroyCursorBox()
         const cursor_position = this.getGridPosition()
         const entity = this.bpc.bp.entityPositionGrid.getEntityAtPosition(cursor_position)
         if (entity === undefined) return undefined
         const ec = EntityContainer.mappings.get(entity.entityNumber)
+        if (ec === undefined) return undefined
 
         const cp = this.bpc.bp.entityPositionGrid.getConnectionPointAtPosition(
             cursor_position,
             this.color
         )
 
+        // The anchored end, if the wire already has one. It is always an entity, so
+        // reach is measured between the two entities' positions.
+        const anchor = this.entity
         let connectionsReach = true
-        if (this.cp && G.BPC.limitWireReach) {
+        if (anchor !== undefined && G.BPC.limitWireReach) {
             connectionsReach &&= U.pointInCircle(
                 entity.position,
-                this.cp.position ?? this.entity.position,
-                Math.min(
-                    entity.maxWireDistance ?? Infinity,
-                    this.entity?.maxWireDistance ?? Infinity
-                )
+                anchor.position,
+                Math.min(entity.maxWireDistance ?? Infinity, anchor.maxWireDistance ?? Infinity)
             )
         }
 
@@ -84,6 +86,7 @@ export class PaintWireContainer extends PaintContainer {
             cp === undefined ? 'not_allowed' : connectionsReach ? 'regular' : 'not_allowed'
         )
         if (connectionsReach) return cp
+        return undefined
     }
 
     private destroyCursorBox(): void {
@@ -109,19 +112,22 @@ export class PaintWireContainer extends PaintContainer {
         return false
     }
 
+    // Unreachable: BlueprintContainer only calls these when canFlipOrRotateByCopying()
+    // is true, and a wire cannot be copied
     public override rotatedEntities(_ccw?: boolean): Entity[] {
-        return undefined
+        throw new Error('A wire cannot be rotated by copying')
     }
 
     public override flippedEntities(_vertical: boolean): Entity[] {
-        return undefined
+        throw new Error('A wire cannot be flipped by copying')
     }
 
     protected override redraw(): void {
         this.updateCursorBox()
         this.bpc.wiresContainer.remove('paint-wire')
         if (this.cp) {
-            const connection: IConnection = {
+            // The far end is wherever the cursor is, so this is drawable but not storable
+            const connection: IDrawableConnection = {
                 color: this.color,
                 cps: [this.cp, { position: this.getGridPosition() }],
             }

--- a/packages/editor/src/containers/WiresContainer.ts
+++ b/packages/editor/src/containers/WiresContainer.ts
@@ -1,7 +1,13 @@
 import { Container, Graphics, RenderTexture, Sprite } from 'pixi.js'
 import { Blueprint } from '../core/Blueprint'
-import { IConnection, IConnectionPoint } from '../core/WireConnections'
+import {
+    IConnection,
+    IConnectionPoint,
+    IDrawableConnection,
+    IEntityConnectionPoint,
+} from '../core/WireConnections'
 import U from '../core/generators/util'
+import { Entity } from '../core/Entity'
 import { IPoint, WireColor } from '../types'
 import { EntityContainer } from './EntityContainer'
 import G from '../common/globals'
@@ -105,7 +111,7 @@ export class WiresContainer extends Container {
         this.updateConnectedEntities(connection)
     }
 
-    public add(hash: string, connection: IConnection): void {
+    public add(hash: string, connection: IDrawableConnection): void {
         const sprite = this.getWireSprite(connection)
         this.addChild(sprite)
         this.connectionToSprite.set(hash, sprite)
@@ -128,7 +134,7 @@ export class WiresContainer extends Container {
                     ? conn.cps[1].entityNumber
                     : conn.cps[0].entityNumber
             const ec = EntityContainer.mappings.get(entNr)
-            if (ec.entity.type === 'electric-pole') {
+            if (ec?.entity.type === 'electric-pole') {
                 ec.redraw()
                 this.redrawEntityConnections(entNr)
             }
@@ -139,8 +145,7 @@ export class WiresContainer extends Container {
 
     private updateConnectedEntities(connection: IConnection): void {
         for (const cp of connection.cps) {
-            const ec = EntityContainer.mappings.get(cp.entityNumber)
-            ec.redraw()
+            EntityContainer.mappings.get(cp.entityNumber)?.redraw()
             this.update(cp.entityNumber)
         }
     }
@@ -155,39 +160,39 @@ export class WiresContainer extends Container {
         }
     }
 
-    private getWireSprite(connection: IConnection): Sprite {
+    private entityOf(cp: IEntityConnectionPoint): Entity {
+        const entity = this.bp.entities.get(cp.entityNumber)
+        if (entity === undefined) {
+            throw new Error(
+                `Wire connects to entity ${cp.entityNumber}, which is not in the blueprint`
+            )
+        }
+        return entity
+    }
+
+    private getWireSprite(connection: IDrawableConnection): Sprite {
         const getWirePos = (cp: IConnectionPoint, color: string): IPoint => {
-            if (cp.entityNumber) {
-                const entity = this.bp.entities.get(cp.entityNumber)
-                const point = entity.getWireConnectionPoint(color, cp.entitySide)
-                if (!point) {
-                    throw new Error('Could not find the wire connection point!')
-                }
-                return {
-                    x: (entity.position.x + point[0]) * 32,
-                    y: (entity.position.y + point[1]) * 32,
-                }
-            } else if (cp.position) {
+            if ('position' in cp) {
                 return {
                     x: cp.position.x * 32,
                     y: cp.position.y * 32,
                 }
             }
-        }
-        const getPos = (cp: IConnectionPoint): IPoint => {
-            if (cp.entityNumber) {
-                const entity = this.bp.entities.get(cp.entityNumber)
-                return entity.position
-            } else if (cp.position) {
-                return cp.position
+            const entity = this.entityOf(cp)
+            const point = entity.getWireConnectionPoint(color, cp.entitySide)
+            if (!point) {
+                throw new Error('Could not find the wire connection point!')
+            }
+            return {
+                x: (entity.position.x + point[0]) * 32,
+                y: (entity.position.y + point[1]) * 32,
             }
         }
-        const getMaxWireDistance = (cp: IConnectionPoint): number => {
-            if (cp.entityNumber) {
-                const entity = this.bp.entities.get(cp.entityNumber)
-                return entity.maxWireDistance
-            }
-        }
+        const getPos = (cp: IConnectionPoint): IPoint =>
+            'position' in cp ? cp.position : this.entityOf(cp).position
+        /** A loose end has no reach of its own; only the anchored ends constrain it. */
+        const getMaxWireDistance = (cp: IConnectionPoint): number | undefined =>
+            'position' in cp ? undefined : this.entityOf(cp).maxWireDistance
         const connectionsReach = U.pointInCircle(
             getPos(connection.cps[0]),
             getPos(connection.cps[1]),

--- a/packages/editor/src/core/PositionGrid.ts
+++ b/packages/editor/src/core/PositionGrid.ts
@@ -3,7 +3,7 @@ import { IPoint } from '../types'
 import FD, { getEntitySize } from './factorioData'
 import { Blueprint } from './Blueprint'
 import { Entity } from './Entity'
-import { IConnectionPoint } from './WireConnections'
+import { IEntityConnectionPoint } from './WireConnections'
 
 /** Anchor is in the middle */
 interface IArea {
@@ -116,7 +116,7 @@ export class PositionGrid {
     public getConnectionPointAtPosition(
         position: IPoint,
         color: string
-    ): IConnectionPoint | undefined {
+    ): IEntityConnectionPoint | undefined {
         const entity = this.getEntityAtPosition(position)
         if (entity === undefined) return undefined
         const rel_position = util.sumprod(position, -1, entity.position)

--- a/packages/editor/src/core/WireConnectionMap.ts
+++ b/packages/editor/src/core/WireConnectionMap.ts
@@ -8,7 +8,15 @@ export class WireConnectionMap extends Map<string, IConnection> {
     }
 
     public getEntityConnections(entityNumber: number): IConnection[] {
-        return this.getEntityConnectionHashes(entityNumber).map(hash => this.get(hash))
+        return this.getEntityConnectionHashes(entityNumber).map(hash => {
+            const connection = this.get(hash)
+            if (connection === undefined) {
+                // entNrToConnHash is this class's own bookkeeping, so a hash that
+                // resolves to nothing means set/delete have drifted out of step
+                throw new Error(`Connection ${hash} is indexed but missing from the map`)
+            }
+            return connection
+        })
     }
 
     public set(hash: string, connection: IConnection): this {
@@ -26,8 +34,12 @@ export class WireConnectionMap extends Map<string, IConnection> {
 
     public delete(hash: string): boolean {
         const connection = this.get(hash)
+        // Map.delete is a no-op for a key that was never set; stay consistent with it
+        // rather than throwing on the way to removing nothing
+        if (connection === undefined) return false
+
         const rem = (entityNumber: number): void => {
-            const conn = this.entNrToConnHash.get(entityNumber).filter(h => h !== hash)
+            const conn = (this.entNrToConnHash.get(entityNumber) ?? []).filter(h => h !== hash)
             if (conn.length > 0) {
                 this.entNrToConnHash.set(entityNumber, conn)
             } else {

--- a/packages/editor/src/core/WireConnections.test.ts
+++ b/packages/editor/src/core/WireConnections.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vite-plus/test'
+import { IBPConnection } from '../types'
+import { IConnection, WireConnections } from './WireConnections'
+
+/*
+    Characterization tests for the pre-2.0 wire (de)serialization.
+
+    `deserialize` is live: Blueprint.ts calls it through `createEntityConnections`
+    for every entity in a pre-2.0 blueprint, so anything that changes here changes
+    how old blueprints load. `serialize` is its inverse and is currently only
+    reachable from a commented-out line in Entity.ts, but it is tested alongside
+    because the two formats have to agree if it is ever switched back on.
+
+    These assert what the code does today, not what it should do. A diff here means
+    a refactor changed behaviour.
+
+    The instance methods are not covered: they need a Blueprint, which needs FD
+    loaded from data.json. Wire creation, hashing and rendering are exercised end to
+    end by the Playwright suite instead.
+*/
+
+/** serialize needs to know entity types; these tests only ever ask about a few. */
+const typeMap =
+    (types: Record<number, string>) =>
+    (entityNumber: number): string =>
+        types[entityNumber] ?? 'container'
+
+describe('WireConnections.deserialize (pre-2.0)', () => {
+    it('reads a red wire off side 1', () => {
+        const conns: IBPConnection = { '1': { red: [{ entity_id: 5, circuit_id: 1 }] } }
+        expect(WireConnections.deserialize(1, conns, undefined)).toEqual([
+            {
+                color: 'red',
+                cps: [
+                    { entityNumber: 1, entitySide: 1 },
+                    { entityNumber: 5, entitySide: 1 },
+                ],
+            },
+        ])
+    })
+
+    it('defaults a missing circuit_id to side 1', () => {
+        const conns: IBPConnection = { '1': { green: [{ entity_id: 5 }] } }
+        const [conn] = WireConnections.deserialize(1, conns, undefined)
+        expect(conn.cps[1]).toEqual({ entityNumber: 5, entitySide: 1 })
+    })
+
+    it('keeps the combinator output side distinct from the input side', () => {
+        const conns: IBPConnection = { '2': { green: [{ entity_id: 7, circuit_id: 2 }] } }
+        expect(WireConnections.deserialize(3, conns, undefined)).toEqual([
+            {
+                color: 'green',
+                cps: [
+                    { entityNumber: 3, entitySide: 2 },
+                    { entityNumber: 7, entitySide: 2 },
+                ],
+            },
+        ])
+    })
+
+    it('reads both wire colours on both sides', () => {
+        const conns: IBPConnection = {
+            '1': {
+                red: [{ entity_id: 2, circuit_id: 1 }],
+                green: [{ entity_id: 3, circuit_id: 1 }],
+            },
+            '2': { red: [{ entity_id: 4, circuit_id: 2 }] },
+        }
+        const result = WireConnections.deserialize(1, conns, undefined)
+        expect(result).toHaveLength(3)
+        expect(result.map(c => [c.color, c.cps[0].entitySide, c.cps[1].entityNumber])).toEqual([
+            ['red', 1, 2],
+            ['green', 1, 3],
+            ['red', 2, 4],
+        ])
+    })
+
+    it('maps Cu0 and Cu1 onto copper sides 1 and 2', () => {
+        const cu0: IBPConnection = { Cu0: [{ entity_id: 4, wire_id: 0 }] }
+        expect(WireConnections.deserialize(9, cu0, undefined)).toEqual([
+            {
+                color: 'copper',
+                cps: [
+                    { entityNumber: 9, entitySide: 1 },
+                    { entityNumber: 4, entitySide: 1 },
+                ],
+            },
+        ])
+
+        const cu1: IBPConnection = { Cu1: [{ entity_id: 4, wire_id: 0 }] }
+        const [conn] = WireConnections.deserialize(9, cu1, undefined)
+        expect(conn.cps[0]).toEqual({ entityNumber: 9, entitySide: 2 })
+    })
+
+    it('only reads the first copper connection on a side', () => {
+        // Cu0/Cu1 are arrays in the format but a power switch has one wire per side
+        const conns: IBPConnection = {
+            Cu0: [
+                { entity_id: 4, wire_id: 0 },
+                { entity_id: 5, wire_id: 0 },
+            ],
+        }
+        const result = WireConnections.deserialize(9, conns, undefined)
+        expect(result).toHaveLength(1)
+        expect(result[0].cps[1].entityNumber).toBe(4)
+    })
+
+    it('turns pole neighbours into copper connections', () => {
+        expect(WireConnections.deserialize(1, undefined, [2, 3])).toEqual([
+            {
+                color: 'copper',
+                cps: [
+                    { entityNumber: 1, entitySide: 1 },
+                    { entityNumber: 2, entitySide: 1 },
+                ],
+            },
+            {
+                color: 'copper',
+                cps: [
+                    { entityNumber: 1, entitySide: 1 },
+                    { entityNumber: 3, entitySide: 1 },
+                ],
+            },
+        ])
+    })
+
+    it('returns nothing for an entity with no wires', () => {
+        expect(WireConnections.deserialize(1, undefined, undefined)).toEqual([])
+        expect(WireConnections.deserialize(1, {}, [])).toEqual([])
+    })
+})
+
+describe('WireConnections.serialize (pre-2.0)', () => {
+    const conn = (
+        color: IConnection['color'],
+        a: [number, number],
+        b: [number, number]
+    ): IConnection => ({
+        color,
+        cps: [
+            { entityNumber: a[0], entitySide: a[1] },
+            { entityNumber: b[0], entitySide: b[1] },
+        ],
+    })
+
+    it('writes a red wire back onto the side it came from', () => {
+        const result = WireConnections.serialize(1, [conn('red', [1, 1], [5, 1])], typeMap({}))
+        expect(result).toEqual({
+            connections: { '1': { red: [{ entity_id: 5, circuit_id: 1 }] } },
+            neighbours: undefined,
+        })
+    })
+
+    it('writes the connection from the far entity point of view', () => {
+        // same connection, serialized for entity 5 instead of entity 1
+        const result = WireConnections.serialize(5, [conn('red', [1, 1], [5, 2])], typeMap({}))
+        expect(result.connections).toEqual({ '2': { red: [{ entity_id: 1, circuit_id: 1 }] } })
+    })
+
+    it('writes pole-to-pole copper as neighbours', () => {
+        const types = typeMap({ 1: 'electric-pole', 2: 'electric-pole' })
+        const result = WireConnections.serialize(1, [conn('copper', [1, 1], [2, 1])], types)
+        expect(result).toEqual({ connections: undefined, neighbours: [2] })
+    })
+
+    it('writes power-switch copper as Cu0/Cu1', () => {
+        const types = typeMap({ 1: 'power-switch', 2: 'electric-pole' })
+        const left = WireConnections.serialize(1, [conn('copper', [1, 1], [2, 1])], types)
+        expect(left.connections).toEqual({ Cu0: [{ entity_id: 2, wire_id: 0 }] })
+
+        const right = WireConnections.serialize(1, [conn('copper', [1, 2], [2, 1])], types)
+        expect(right.connections).toEqual({ Cu1: [{ entity_id: 2, wire_id: 0 }] })
+    })
+
+    it('drops connections to entities outside the whitelist', () => {
+        const conns = [conn('red', [1, 1], [5, 1]), conn('red', [1, 1], [6, 1])]
+        const result = WireConnections.serialize(1, conns, typeMap({}), new Set([5]))
+        expect(result.connections).toEqual({ '1': { red: [{ entity_id: 5, circuit_id: 1 }] } })
+    })
+
+    it('returns undefined rather than empty objects when there is nothing to write', () => {
+        expect(WireConnections.serialize(1, [], typeMap({}))).toEqual({
+            connections: undefined,
+            neighbours: undefined,
+        })
+    })
+
+    it('does not reorder the connection it was handed', () => {
+        // serialize used to reverse cps in place, mutating the stored connection
+        const connection = conn('red', [1, 1], [5, 2])
+        WireConnections.serialize(5, [connection], typeMap({}))
+        expect(connection.cps[0].entityNumber).toBe(1)
+        expect(connection.cps[1].entityNumber).toBe(5)
+    })
+
+    it('round-trips everything deserialize produces', () => {
+        const original: IBPConnection = {
+            '1': {
+                red: [{ entity_id: 2, circuit_id: 1 }],
+                green: [{ entity_id: 3, circuit_id: 2 }],
+            },
+            '2': { red: [{ entity_id: 4, circuit_id: 1 }] },
+        }
+        const parsed = WireConnections.deserialize(1, original, undefined)
+        expect(WireConnections.serialize(1, parsed, typeMap({})).connections).toEqual(original)
+    })
+})

--- a/packages/editor/src/core/WireConnections.ts
+++ b/packages/editor/src/core/WireConnections.ts
@@ -7,15 +7,38 @@ import { WireConnectionMap } from './WireConnectionMap'
 
 const MAX_POLE_CONNECTION_COUNT = 5
 
-export interface IConnection {
-    color: WireColor
-    cps: [IConnectionPoint, IConnectionPoint]
+/** A wire endpoint anchored to one of an entity's connection points. */
+export interface IEntityConnectionPoint {
+    entityNumber: number
+    entitySide: number
 }
 
-export interface IConnectionPoint {
-    entityNumber?: number
-    entitySide?: number
-    position?: IPoint
+/**
+ * A wire endpoint that is a bare world position. Only the wire currently being
+ * dragged has one - it is where the cursor is, before the far end is anchored.
+ */
+export interface ILooseConnectionPoint {
+    position: IPoint
+}
+
+export type IConnectionPoint = IEntityConnectionPoint | ILooseConnectionPoint
+
+/**
+ * A wire between two entities. This is what gets stored, hashed and serialized,
+ * so both ends are always anchored.
+ */
+export interface IConnection {
+    color: WireColor
+    cps: [IEntityConnectionPoint, IEntityConnectionPoint]
+}
+
+/**
+ * A wire that can be drawn but not necessarily stored, because one end may still
+ * be a loose position. Every IConnection is also drawable.
+ */
+export interface IDrawableConnection {
+    color: WireColor
+    cps: [IConnectionPoint, IConnectionPoint]
 }
 
 export interface WireConnectionsEvents {
@@ -33,6 +56,8 @@ export class WireConnections extends EventEmitter<WireConnectionsEvents> {
     }
 
     private static hash(conn: IConnection): string {
+        // Sorts in place on purpose: this normalises the connection before it is
+        // stored, so cps[0] is always the lower entity number afterwards.
         const cps = conn.cps.sort(
             (cp1, cp2) => cp1.entityNumber - cp2.entityNumber || cp1.entitySide - cp2.entitySide
         )
@@ -43,61 +68,64 @@ export class WireConnections extends EventEmitter<WireConnectionsEvents> {
 
     public static deserialize(
         entityNumber: number,
-        connections: IBPConnection,
-        neighbours: number[]
+        connections: IBPConnection | undefined,
+        neighbours: number[] | undefined
     ): IConnection[] {
         const parsedConnections: IConnection[] = []
 
-        const addConnSide = (side: '1' | '2'): void => {
-            if (connections[side]) {
-                for (const c in connections[side]) {
-                    const color = c as WireColor
-                    const conn = connections[side]
-                    for (const data of conn[color]) {
-                        parsedConnections.push({
-                            color,
-                            cps: [
-                                {
-                                    entityNumber: entityNumber,
-                                    entitySide: Number(side),
-                                },
-                                {
-                                    entityNumber: data.entity_id,
-                                    entitySide: data.circuit_id || 1,
-                                },
-                            ],
-                        })
-                    }
+        const addConnSide = (connSide: IConnSide | undefined, side: '1' | '2'): void => {
+            if (connSide === undefined) return
+            for (const c in connSide) {
+                const color = c as WireColor
+                const wires = connSide[color]
+                if (wires === undefined) continue
+                for (const data of wires) {
+                    parsedConnections.push({
+                        color,
+                        cps: [
+                            {
+                                entityNumber: entityNumber,
+                                entitySide: Number(side),
+                            },
+                            {
+                                entityNumber: data.entity_id,
+                                entitySide: data.circuit_id || 1,
+                            },
+                        ],
+                    })
                 }
             }
         }
 
-        const addCopperConnSide = (side: 'Cu0' | 'Cu1', color: WireColor): void => {
-            if (connections[side]) {
-                // For some reason Cu0 and Cu1 are arrays but the switch can only have 1 copper connection
-                const data = (connections[side] as IWireColor[])[0]
-                parsedConnections.push({
-                    color,
-                    cps: [
-                        {
-                            entityNumber: entityNumber,
-                            entitySide: Number(side.slice(2, 3)) + 1,
-                        },
-                        {
-                            entityNumber: data.entity_id,
-                            entitySide: 1,
-                        },
-                    ],
-                })
-            }
+        const addCopperConnSide = (
+            wires: IWireColor[] | undefined,
+            side: 'Cu0' | 'Cu1',
+            color: WireColor
+        ): void => {
+            // For some reason Cu0 and Cu1 are arrays but the switch can only have 1 copper connection
+            const data = wires?.[0]
+            if (data === undefined) return
+            parsedConnections.push({
+                color,
+                cps: [
+                    {
+                        entityNumber: entityNumber,
+                        entitySide: Number(side.slice(2, 3)) + 1,
+                    },
+                    {
+                        entityNumber: data.entity_id,
+                        entitySide: 1,
+                    },
+                ],
+            })
         }
 
         if (connections) {
-            addConnSide('1')
-            addConnSide('2')
+            addConnSide(connections['1'], '1')
+            addConnSide(connections['2'], '2')
             // power_switch only connections
-            addCopperConnSide('Cu0', 'copper')
-            addCopperConnSide('Cu1', 'copper')
+            addCopperConnSide(connections.Cu0, 'Cu0', 'copper')
+            addCopperConnSide(connections.Cu1, 'Cu1', 'copper')
         }
 
         if (neighbours) {
@@ -115,13 +143,16 @@ export class WireConnections extends EventEmitter<WireConnectionsEvents> {
         connections: IConnection[],
         getType: (entityNumber: number) => string,
         entNrWhitelist?: Set<number>
-    ): { connections: IBPConnection; neighbours: number[] } {
+    ): { connections: IBPConnection | undefined; neighbours: number[] | undefined } {
         const serialized: IBPConnection = {}
         const neighbours: number[] = []
 
         for (const connection of connections) {
             const isEntity0 = connection.cps[0].entityNumber === entityNumber
-            const [thisE, otherE] = isEntity0 ? connection.cps : connection.cps.reverse()
+            // Not connection.cps.reverse() - that reordered the caller's connection in place
+            const [thisE, otherE] = isEntity0
+                ? connection.cps
+                : [connection.cps[1], connection.cps[0]]
             const entitySide = thisE.entitySide
             const color = connection.color
 
@@ -132,25 +163,29 @@ export class WireConnections extends EventEmitter<WireConnectionsEvents> {
                     neighbours.push(otherE.entityNumber)
                 } else if (getType(entityNumber) === 'power-switch') {
                     const SIDE = `Cu${entitySide - 1}` as 'Cu0' | 'Cu1'
-                    if (serialized[SIDE] === undefined) {
-                        serialized[SIDE] = []
+                    let wires = serialized[SIDE]
+                    if (wires === undefined) {
+                        wires = []
+                        serialized[SIDE] = wires
                     }
-                    const c = serialized[SIDE] as IWireColor[]
-                    c.push({
+                    wires.push({
                         entity_id: otherE.entityNumber,
                         wire_id: 0,
                     })
                 }
             } else if (color === 'red' || color === 'green') {
                 const sideKey = entitySide as 1 | 2
-                if (serialized[sideKey] === undefined) {
-                    serialized[sideKey] = {}
+                let side = serialized[sideKey]
+                if (side === undefined) {
+                    side = {}
+                    serialized[sideKey] = side
                 }
-                const SIDE = serialized[sideKey] as IConnSide
-                if (SIDE[color] === undefined) {
-                    SIDE[color] = []
+                let wires = side[color]
+                if (wires === undefined) {
+                    wires = []
+                    side[color] = wires
                 }
-                SIDE[color].push({
+                wires.push({
                     entity_id: otherE.entityNumber,
                     circuit_id: otherE.entitySide,
                 })
@@ -204,7 +239,7 @@ export class WireConnections extends EventEmitter<WireConnectionsEvents> {
             .commit()
     }
 
-    private onCreateOrRemoveConnection(newValue: IConnection, oldValue: IConnection): void {
+    private onCreateOrRemoveConnection(newValue?: IConnection, oldValue?: IConnection): void {
         if (newValue) {
             this.emit('create', WireConnections.hash(newValue), newValue)
         } else if (oldValue) {
@@ -212,8 +247,13 @@ export class WireConnections extends EventEmitter<WireConnectionsEvents> {
         }
     }
 
+    /** The hash must be one that getEntityConnectionHashes handed out. */
     public get(hash: string): IConnection {
-        return this.connections.get(hash)
+        const connection = this.connections.get(hash)
+        if (connection === undefined) {
+            throw new Error(`Connection ${hash} is indexed but missing from the connection map`)
+        }
+        return connection
     }
 
     public forEach(fn: (value: IConnection, key: string) => void): void {
@@ -351,30 +391,45 @@ export class WireConnections extends EventEmitter<WireConnectionsEvents> {
         for (const conn of this.connections.values()) {
             const en0 = conn.cps[0].entityNumber
             const en1 = conn.cps[1].entityNumber
-            const id0 = getId(this.bp.entities.get(en0).type, conn.color, conn.cps[0].entitySide)
-            const id1 = getId(this.bp.entities.get(en1).type, conn.color, conn.cps[1].entitySide)
+            const id0 = getId(this.entityType(en0), conn.color, conn.cps[0].entitySide)
+            const id1 = getId(this.entityType(en1), conn.color, conn.cps[1].entitySide)
             wires.push([en0, id0, en1, id1])
         }
         return wires
+    }
+
+    /**
+     * Throws rather than skipping the wire: a connection to an entity the blueprint
+     * does not have cannot be serialized, and dropping it would silently export a
+     * blueprint that is missing wires.
+     */
+    private entityType(entityNumber: number): string {
+        const entity = this.bp.entities.get(entityNumber)
+        if (entity === undefined) {
+            throw new Error(
+                `Wire connects to entity ${entityNumber}, which is not in the blueprint`
+            )
+        }
+        return entity.type
     }
 
     // pre 2.0
     public serializeConnectionData(
         entityNumber: number,
         entNrWhitelist?: Set<number>
-    ): { connections: IBPConnection; neighbours: number[] } {
+    ): { connections: IBPConnection | undefined; neighbours: number[] | undefined } {
         const connections = this.getEntityConnections(entityNumber)
         return WireConnections.serialize(
             entityNumber,
             connections,
-            entityNumber => this.bp.entities.get(entityNumber).type,
+            entityNumber => this.entityType(entityNumber),
             entNrWhitelist
         )
     }
 
     public connectPowerPole(entityNumber: number): void {
         const entity = this.bp.entities.get(entityNumber)
-        if (entity.type !== 'electric-pole') return
+        if (entity === undefined || entity.type !== 'electric-pole') return
 
         const areaSize = (entity.maxWireDistance + 1) * 2
 
@@ -479,11 +534,11 @@ export class WireConnections extends EventEmitter<WireConnectionsEvents> {
             .filter(lines => lines.length === 3)
             .map(lines => lines.map(hashPoleSet))
 
-        const finalPoleSets: IPole[][] = []
+        const finalPoleSets: [IPole, IPole][] = []
         const addedMap: Set<string> = new Set()
 
-        while (poleSets.length) {
-            const poleSet = poleSets.shift()
+        let poleSet: [IPole, IPole] | undefined
+        while ((poleSet = poleSets.shift()) !== undefined) {
             const hash = hashPoleSet(poleSet)
 
             const formsATriangle = hashedTriangles
@@ -520,7 +575,10 @@ export class WireConnections extends EventEmitter<WireConnectionsEvents> {
 
         if (points.length === 0) return 0
 
-        return getPowerPoleRotation(this.bp.entities.get(entityNumber).position, points)
+        const pole = this.bp.entities.get(entityNumber)
+        if (pole === undefined) return 0
+
+        return getPowerPoleRotation(pole.position, points)
 
         function getPowerPoleRotation(centre: IPoint, points: IPoint[]): number {
             const sectorSum = points

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 639
+    "maxErrors": 562
 }

--- a/tests/wire-connections.spec.ts
+++ b/tests/wire-connections.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from '@playwright/test'
+import { discoverBlueprintFiles, readBlueprintString } from './helpers/blueprint-files'
+
+/*
+    WireConnections stores wires twice: as a hash -> connection map, and as an
+    entity number -> hashes index that WireConnectionMap maintains alongside it.
+    Nothing checked that the two agree, and both now throw rather than quietly
+    handing back undefined when they disagree, so it is worth proving the
+    invariant holds against a real blueprint.
+
+    The blueprint-loading suite already covers decode and render. This covers the
+    serialize direction and the create/remove cycle, neither of which that suite
+    reaches. The static (de)serialize functions are unit tested in
+    packages/editor/src/core/WireConnections.test.ts instead - they need no FD data.
+
+    Not covered: the loose connection point, which only exists while a wire is
+    being dragged in paint mode. Reaching it needs the BlueprintContainer, which
+    the editor does not expose.
+
+    Runs against the dev server like the rest of tests/ - see CLAUDE.md for the
+    two servers that have to be up.
+*/
+
+// biggest test blueprint, so the wire set is large and varied (circuit and copper)
+const BLUEPRINT = 'EARN/pocket-base-space-age-v22.1.2'
+
+test('wire connections stay consistent with their index and survive a round trip', async ({
+    page,
+}) => {
+    const blueprint = discoverBlueprintFiles().find(f => f.name === BLUEPRINT)
+    if (!blueprint) throw new Error(`test blueprint ${BLUEPRINT} not found in wormeyman-tests/`)
+
+    const errors: string[] = []
+    page.on('pageerror', e => errors.push(String(e)))
+    page.on('console', m => {
+        if (m.type() === 'error') errors.push(m.text())
+    })
+
+    await page.goto('/')
+    await page.waitForFunction(() => (window as any).__fbe_test !== undefined, { timeout: 60_000 })
+
+    const bpString = readBlueprintString(blueprint.filePath)
+
+    const result = await page.evaluate(async (str: string) => {
+        const api = (window as any).__fbe_test
+        let bp = await api.getBlueprintOrBookFromSource(str)
+        if (bp.selectBlueprint) bp = bp.selectBlueprint(0)
+
+        const wc = bp.wireConnections
+        const entityNumbers = [...bp.entities.keys()]
+
+        // Every hash the index hands out has to resolve to a connection that
+        // actually names the entity it was indexed under. Both getEntityConnections
+        // and get() throw on a dangling hash, so reaching the end proves neither did.
+        let indexedHashes = 0
+        let mismatchedIndexEntries = 0
+        for (const entNr of entityNumbers) {
+            const hashes = wc.getEntityConnectionHashes(entNr)
+            indexedHashes += hashes.length
+            for (const hash of hashes) {
+                const conn = wc.get(hash)
+                if (conn.cps[0].entityNumber !== entNr && conn.cps[1].entityNumber !== entNr) {
+                    mismatchedIndexEntries += 1
+                }
+            }
+        }
+
+        // serializeBpWires resolves both endpoints of every stored connection
+        // against bp.entities, so it throws if the wire set references an entity
+        // the blueprint does not have
+        const wires = wc.serializeBpWires()
+        const key = (w: number[]): string => w.join(',')
+        const before = wires.map(key).sort()
+
+        // A connection whose two ends are the same entity (a combinator wired from
+        // its own output back to its input) is indexed once, not twice
+        const selfConnections = wires.filter((w: number[]) => w[0] === w[2]).length
+
+        // serializing is a read; doing it twice must not drift
+        const again = wc.serializeBpWires().map(key).sort()
+        const stableAcrossCalls = JSON.stringify(before) === JSON.stringify(again)
+
+        // Take a real connection out and put it back. This drives
+        // WireConnectionMap.set/delete and the index bookkeeping on both ends,
+        // and the wire set has to come back identical.
+        const wiredEntity = entityNumbers.find(
+            (en: number) => wc.getEntityConnectionHashes(en).length > 0
+        )
+        if (wiredEntity === undefined) throw new Error('blueprint has no wired entities')
+        const sampleHash = wc.getEntityConnectionHashes(wiredEntity)[0]
+        const sample = wc.get(sampleHash)
+        // the hash, not the endpoints: two combinators can carry same-coloured wires
+        // on both their input and output sides, so endpoints alone do not identify one
+        const sampleEnds = [sample.cps[0].entityNumber, sample.cps[1].entityNumber]
+
+        wc.remove(sample)
+        const afterRemoveCount = wc.serializeBpWires().length
+        // getEntityConnections throws on a dangling hash, so if the index still held
+        // the removed hash this would blow up rather than return it
+        const endsStillIndexingRemoved = sampleEnds.filter((en: number) =>
+            wc.getEntityConnectionHashes(en).includes(sampleHash)
+        ).length
+
+        wc.create(sample)
+        const afterRecreate = wc.serializeBpWires().map(key).sort()
+        const endsIndexingAfterRecreate = sampleEnds.filter((en: number) =>
+            wc.getEntityConnectionHashes(en).includes(sampleHash)
+        ).length
+
+        return {
+            entityCount: entityNumbers.length,
+            wireCount: wires.length,
+            selfConnections,
+            indexedHashes,
+            mismatchedIndexEntries,
+            stableAcrossCalls,
+            removedExactlyOne: afterRemoveCount === wires.length - 1,
+            endsStillIndexingRemoved,
+            // one end if the wire is a self-connection, two otherwise
+            endsIndexingAfterRecreate,
+            expectedEndsIndexing: sampleEnds[0] === sampleEnds[1] ? 1 : 2,
+            roundTripped: JSON.stringify(afterRecreate) === JSON.stringify(before),
+        }
+    }, bpString)
+
+    // the blueprint has to actually contain wires, or none of this proves anything
+    expect(result.wireCount).toBeGreaterThan(0)
+    expect(result.indexedHashes).toBeGreaterThan(0)
+
+    // each connection is indexed under both of its ends, so the index holds two
+    // entries per wire - except a self-connection, which is indexed once
+    expect(result.indexedHashes).toBe(result.wireCount * 2 - result.selfConnections)
+    expect(result.mismatchedIndexEntries).toBe(0)
+
+    expect(result.stableAcrossCalls).toBe(true)
+    expect(result.removedExactlyOne).toBe(true)
+    expect(result.endsStillIndexingRemoved).toBe(0)
+    expect(result.endsIndexingAfterRecreate).toBe(result.expectedEndsIndexing)
+    expect(result.roundTripped).toBe(true)
+
+    expect(errors, `console/page errors: ${errors.join(' | ')}`).toEqual([])
+})


### PR DESCRIPTION
Continues #22. Follows on from #25, which took the count 760 -> 639.

## What this does

Type errors **639 -> 562**. Lint holds at 28 warnings, 0 errors.

The whole 73-error cluster across `WireConnections`, `WireConnectionMap`, `WiresContainer` and `PaintWireContainer` came from one lying type:

```ts
export interface IConnectionPoint {
    entityNumber?: number
    entitySide?: number
    position?: IPoint
}
```

Every field optional, so every read of `entityNumber` was possibly-undefined and every wire was typed as if it might be anchored to nothing. A connection point is really one of two things:

```ts
IEntityConnectionPoint  { entityNumber, entitySide }  // anchored to an entity
ILooseConnectionPoint   { position }                  // a bare world position
```

Only one thing produces the loose variant: `PaintWireContainer`, for the end of the wire following the cursor. Nothing stores it. So `IConnection` (stored, hashed, serialized) now has two anchored ends, and the new `IDrawableConnection` is the wider type `WiresContainer.add` accepts.

The split is what removes the errors; the rest is following through. `PositionGrid.getConnectionPointAtPosition` returns the anchored variant, which is all it ever built. `PaintBlueprintContainer`'s filter-then-map over pasted wires collapses into one `flatMap`, dropping an `as [IConnectionPoint, IConnectionPoint]` cast.

No non-null assertions anywhere.

## Tests first, again

Neither area had coverage, so both got some before the refactor.

**`packages/editor/src/core/WireConnections.test.ts`** pins the pre-2.0 wire format. `deserialize` is live - `Blueprint` calls it for every entity in a pre-2.0 blueprint - and `serialize` is its inverse. Characterization only: what the code does today, not what it should. 15 of 16 passed on the first run.

The one that didn't is the point: **`serialize` reversed `connection.cps` in place**, mutating the caller's stored connection while claiming to be a read. Written red, fixed in the next commit. It's dead code today (only reachable from a commented-out line in `Entity.ts`), but it's the counterpart to the live `deserialize`.

**`tests/wire-connections.spec.ts`** covers what unit tests can't. `WireConnections` stores wires twice - a hash -> connection map, plus an entity number -> hashes index - and nothing checked they agree. Against a 4245-entity blueprint: 246 wires all resolve, serializing twice doesn't drift, and removing a connection and putting it back reproduces the wire set exactly.

Confirmed it fails on breakage before trusting it - dropping the second endpoint from either `set()` or `delete()` in `WireConnectionMap` fails it.

Two things the real blueprint taught me, both now asserted rather than assumed:
- a **self-connection** (a combinator wired output back to input) is indexed once, not twice, so the index holds `2n - selfConnections` entries
- two entities can carry **same-coloured wires on both their sides**, so a connection has to be identified by hash, not by endpoints and colour

## Behaviour changes

Each away from a crash except where noted:

- `serialize` no longer reorders the caller's `cps` in place
- `WireConnectionMap.delete` on an unknown hash returns `false` instead of throwing a `TypeError`, matching `Map`'s contract
- `connectPowerPole` and `getPowerPoleDirection` no-op on an unknown entity
- `WiresContainer` skips redraw for an entity with no container
- `PaintWireContainer.rotatedEntities`/`flippedEntities` throw instead of returning `undefined` as `Entity[]`. Unreachable: `BlueprintContainer` only calls them when `canFlipOrRotateByCopying()` is true, and it returns `false`

Two now **throw** where they previously read through undefined and crashed anyway, but with a message naming the invariant instead of a `TypeError`: `serializeBpWires` on a wire whose entity isn't in the blueprint, and `WireConnections.get` / `WireConnectionMap.getEntityConnections` on a hash that's indexed but absent from the map. Same drift signal `PositionGrid.entityAt` gives.

`hash()` still sorts `cps` in place. That normalisation is load-bearing - `cps[0]` being the lower entity number determines the order `serializeBpWires` emits, so changing it would change exported blueprint strings. Left alone, now commented.

## Verification

- `npx tsc --noEmit -p packages/editor/tsconfig.json` - 562, gate lowered to match
- `vp test` - 51 pass
- `npx playwright test` - 12 pass, every blueprint loads clean

## Not in this PR

- **`spriteDataBuilder.ts` is now 326 of the 562** - unchanged, and still the bulk of what's left
- **`Entity.ts` (44) and `OverlayContainer.ts` (31)** are the next largest. `Entity.ts` shed 2 here as a side effect and looks like it has its own shared root cause worth finding before fixing errors singly
- **The loose connection point isn't covered by a test.** It only exists while a wire is being dragged, and reaching it needs the `BlueprintContainer`, which the editor doesn't expose. I didn't want to add production surface just for the test - flagging rather than hiding it
- **`@types/node` is still missing**, so the root tsc project reports ~30 errors in `tests/`. Not gated by CI and not part of #22. It did bite here: I wanted to make `playwright.config.ts` read the base URL from an env var and couldn't without it, so the port stays hardcoded

## Also

Port 8080 was held by another app on my machine, and the failure mode is nasty: Vite silently falls back to 8081, then proxies `/data` to itself, so it presents as the sprite server being broken rather than a port clash. Documented in CLAUDE.md with `--strictPort` as the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DWWJGdTN9iYbdj6eL4YzJ