### PR TITLE
chore(types): add @types/node so the Playwright specs type-check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ Automated tests that load blueprint `.txt` files from `wormeyman-tests/` against
 
 **Structure:**
 
-- `playwright.config.ts` - Config (base URL localhost:8080, 120s timeout, single worker)
+- `playwright.config.ts` - Config (base URL localhost:8080 unless `FBE_BASE_URL` is set, 120s timeout, single worker)
 - `tests/blueprint-loading.spec.ts` - Main test file - iterates blueprints, uses `window.__fbe_test` API to load directly
 - `tests/position-grid.spec.ts` - Exercises `PositionGrid` queries and the setTileData/removeTileData round trip against a real loaded blueprint (the class is core to placement and cannot be unit tested without FD data loaded)
 - `tests/sprite-generation.spec.ts` - Two halves. One builds a synthetic blueprint holding every entity in `data.json` at the four cardinal directions (`tests/helpers/all-entities-blueprint.ts`); the other loads the real bases, which is where the neighbour-dependent branches (pipe junctions, belt corners, undergrounds) and modules get exercised. Both assert against a pinned list of entity types that fail today
@@ -160,7 +160,14 @@ Automated tests that load blueprint `.txt` files from `wormeyman-tests/` against
 - Terminal 1: `cd packages/website && vp dev` (Vite on port 8080)
 - Terminal 2: `npx serve packages/exporter/data/output -l 8081 --cors` (sprite data)
 
-Start them in that order and check the port Vite reports. If something else already holds 8080, Vite silently falls back to 8081 and then proxies `/data` to itself, which looks like the sprite server failing rather than a port clash. Pin it with `vp dev --port 8080 --strictPort` to get a clear failure instead, and note `playwright.config.ts` hardcodes `baseURL` to 8080.
+Start them in that order and check the port Vite reports. If something else already holds 8080, Vite silently falls back to 8081 and then proxies `/data` to itself, which looks like the sprite server failing rather than a port clash. Pin it with `vp dev --port 8080 --strictPort` to get a clear failure instead.
+
+If 8080 is taken, run Vite elsewhere and point the specs at it with `FBE_BASE_URL` rather than editing `playwright.config.ts`. The sprite data server must stay on 8081 either way - the Vite dev proxy hardcodes it.
+
+```fish
+cd packages/website; vp dev --port 8090 --strictPort
+FBE_BASE_URL=http://localhost:8090 npx playwright test
+```
 
 **Reports** are written to `diagnostic-reports/blueprint-diagnostics.json` and `diagnostic-reports/blueprint-diagnostics.md` (gitignored).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             ],
             "devDependencies": {
                 "@playwright/test": "^1.58.2",
+                "@types/node": "^26.1.1",
                 "typed-factorio": "^3.35.0",
                 "typescript": "^7.0.2",
                 "vite-plus": "0.2.6"
@@ -2234,6 +2235,16 @@
             "integrity": "sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "26.1.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+            "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~8.3.0"
+            }
         },
         "node_modules/@types/pathfinding": {
             "version": "0.1.0",
@@ -5209,6 +5220,13 @@
             "engines": {
                 "node": ">=20.18.1"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/unenv": {
             "version": "2.0.0-rc.24",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     },
     "devDependencies": {
         "@playwright/test": "^1.58.2",
+        "@types/node": "^26.1.1",
         "typed-factorio": "^3.35.0",
         "typescript": "^7.0.2",
         "vite-plus": "0.2.6"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig } from '@playwright/test'
 
+// Port 8080 is the default because that is what the Vite dev server picks, but it
+// is not always free. Set FBE_BASE_URL to point the specs somewhere else - e.g.
+// FBE_BASE_URL=http://localhost:8090 npx playwright test - rather than editing
+// this file and having to remember to revert it before committing.
+const baseURL = process.env.FBE_BASE_URL ?? 'http://localhost:8080'
+
 export default defineConfig({
     testDir: './tests',
     timeout: 120_000,
@@ -7,7 +13,7 @@ export default defineConfig({
         timeout: 60_000,
     },
     use: {
-        baseURL: 'http://localhost:8080',
+        baseURL,
         headless: true,
     },
     retries: 0,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,10 @@
             "@fbe/*": ["./packages/*/src/index.ts"]
         },
 
-        "types": ["vite-plus/client", "typed-factorio/prototype"]
+        // "node" is for the Playwright specs, their helpers and playwright.config.ts,
+        // which read process.env / cwd and use zlib + Buffer. The editor project
+        // narrows this list back to typed-factorio only, so browser code cannot
+        // reach node globals - see packages/editor/tsconfig.json.
+        "types": ["vite-plus/client", "typed-factorio/prototype", "node"]
     }
 }


### PR DESCRIPTION
## What

Adds `@types/node` as a devDependency and `"node"` to the root `tsconfig.json` `types` allowlist. Both are needed - installing the package without listing it means the types are never loaded.

## Why

`tests/` and its helpers read `process.env` / `process.cwd()` and use `zlib` and `Buffer`. None of that had types, which accounted for **13 of the 303 errors** the root `tsc` reports. They were invisible in practice because `npm run type-check:gate` only guards `packages/editor`.

## The gate is unaffected

`packages/editor/tsconfig.json` overrides `types` back to `["typed-factorio/prototype"]`, so editor code still cannot reach node globals and the CI gate stays at **270**. This does not touch #22's count in either direction.

## Also: `FBE_BASE_URL`

With `process.env` typed, `playwright.config.ts` now reads `FBE_BASE_URL` and falls back to `http://localhost:8080`.

Port 8080 is not always free; when it isn't, Vite silently falls back to 8081 and then proxies `/data` to itself, which presents as the sprite-data server being broken rather than a port clash. The previous workaround was to edit the hardcoded `baseURL` and remember to revert it before committing. Now:

```fish
cd packages/website; vp dev --port 8090 --strictPort
FBE_BASE_URL=http://localhost:8090 npx playwright test
```

`CLAUDE.md` is updated to describe this instead of the manual edit.

## Verification

| Check | Before | After |
| --- | --- | --- |
| Root `tsc --noEmit` | 303 | **290** |
| Editor gate (`type-check:gate`) | 270 | 270 |
| `vp lint` | 28 warnings / 0 errors | 28 warnings / 0 errors |
| `vp test` | 51 passing | 51 passing |
| `playwright test --list` | 15 tests / 5 files | 15 tests / 5 files |

Config resolution checked both ways: unset gives `http://localhost:8080`, `FBE_BASE_URL=http://localhost:8090` gives `http://localhost:8090`.

Refs #22 (unblocks tooling; does not change the baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqyEwvXMDwkDWHnNRetwrJ