### PR TITLE
fix(sprites): render big-mining-drill, and stop drills failing silently (#29)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,8 @@ Common patterns for `draw_*` functions:
 - **Signal types**: Space Age adds `space-location`, `asteroid-chunk`, `quality` signal types beyond the base `item`, `virtual`, `fluid`, `recipe`, `entity`.
 - **Array-form base_visualisation**: Some Space Age turrets (tesla-turret) have `graphics_set.base_visualisation` as an array instead of a direct object. `draw_electric_turret` handles both formats.
 - **Blueprint validation**: Made lenient to handle Space Age content. Unknown entity names are stripped; other validation failures (unknown signals, new enum values) are logged as warnings but don't block loading.
+- **`draw_*` functions that switch on `e.name` need a `default`**: falling off the end returns `undefined`, and `getSpriteData` then calls it, so the entity fails with `graphicsFn is not a function` - which names neither the entity nor the real problem, and is swallowed by the try/catch into a placeholder box. Throw instead, naming the entity. `draw_mining_drill` had this and `big-mining-drill` rendered as an unknown entity for it (issue #29). Switching on `e.name` at all is a Space Age hazard: the DLC adds new members to existing entity types.
+- **`always_draw` working visualisations come in two shapes**: directional (`north_animation` and friends, absent for facings the visualisation does not apply to) and a single non-directional `animation` drawn the same whichever way the entity points. Read `vis[animDir] ?? vis.animation` - reading only the directional key silently drops the second kind, which cost `big-mining-drill` its drill head and scorch mark. The `??` order matters: a directional entry that omits the current facing must stay dropped, not fall back.
 
 ## Cloudflare Deployment
 

--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -1990,6 +1990,7 @@ function draw_mining_drill(e: MiningDrillPrototype): (data: IDrawData) => readon
             ]
 
         case 'electric-mining-drill':
+        case 'big-mining-drill':
             return (data: IDrawData) => {
                 const dir = util.getDirName(data.dir)
                 const layers0 = dirEntry(need(e, 'graphics_set', 'animation'), dir).layers
@@ -2000,14 +2001,37 @@ function draw_mining_drill(e: MiningDrillPrototype): (data: IDrawData) => readon
                     | 'south_animation'
                     | 'west_animation'
 
+                /*
+                    An always_draw visualisation is either directional - one entry per
+                    facing, and absent for facings it does not apply to - or a single
+                    non-directional `animation` drawn the same way whichever way the
+                    drill points. electric-mining-drill only has the first kind, so it
+                    was enough to read the directional key and drop everything else.
+                    big-mining-drill has two of the second kind (a scorch mark and the
+                    drill head), which that would silently discard.
+
+                    The order matters: a directional entry that omits this facing has
+                    to stay dropped rather than fall back to a plain `animation` it
+                    does not have, which is what the filter below still does.
+                */
                 const layers1 = need(e, 'graphics_set', 'working_visualisations')
                     .filter(vis => vis.always_draw)
-                    .map(vis => vis[animDir])
+                    .map(vis => vis[animDir] ?? vis.animation)
                     .filter(vis => !!vis)
                     .flatMap(vis => (vis.layers ? vis.layers : [vis]))
 
                 return [...layers0, ...layers1]
             }
+
+        default:
+            /*
+                getSpriteData catches this and logs it, so an unhandled drill degrades
+                to a placeholder box rather than taking the editor down. Falling off
+                the end of the switch instead used to return undefined, which surfaced
+                as "graphicsFn is not a function" and named neither the entity nor the
+                real problem. See issue #29.
+            */
+            throw new Error(`no draw case for mining drill '${e.name}'`)
     }
 }
 function draw_offshore_pump(e: OffshorePumpPrototype): (data: IDrawData) => readonly SpriteData[] {

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 270
+    "maxErrors": 269
 }

--- a/tests/sprite-generation.spec.ts
+++ b/tests/sprite-generation.spec.ts
@@ -44,7 +44,6 @@ const DIRECTIONS = [0, 4, 8, 12]
  * matters, a Space Age entity a player can actually build.
  */
 const EXPECTED_FAILURES: string[] = [
-    'big-mining-drill',
     'factorio-logo-11tiles',
     'factorio-logo-16tiles',
     'factorio-logo-22tiles',


### PR DESCRIPTION
Closes #29. Refs #22.

## The bug

`draw_mining_drill` switched on `e.name` with no `default`, so `big-mining-drill` fell off the end and the function returned `undefined`. `getSpriteData` then called it, producing `graphicsFn is not a function` - which its try/catch swallowed into `SPRITE_GENERATION_FAILED`. The user saw a placeholder box; the log named neither the entity nor the actual problem.

It is the only one of the four `mining-drill` entities in `data.json` that was unhandled.

## The fix is not quite the one-liner the issue proposed

`big-mining-drill` now shares the `electric-mining-drill` case, but that alone renders it wrong.

An `always_draw` working visualisation comes in two shapes:

- **directional** - `north_animation` / `east_animation` / …, and absent for facings it does not apply to
- **non-directional** - a single `animation` drawn the same way whichever way the drill points

The existing code read only `vis[animDir]`, which is fine for `electric-mining-drill` because every one of its `always_draw` entries is the first kind. `big-mining-drill` has two of the second kind, and dropping them loses:

| entry | file |
| --- | --- |
| `[0]` (unnamed) | `big-mining-drill-drill-scorchmark.png` |
| `[1]` `drill-animation` | `big-mining-drill-drill.png` + `big-mining-drill-drill-shadow.png` |

The second is **the drill head itself**. So the read becomes `vis[animDir] ?? vis.animation`.

The `??` order is load-bearing: a directional entry that omits the current facing must stay dropped rather than fall back to a plain `animation` it does not have. The `.filter(vis => !!vis)` below still handles that, and entry `[14]` - a light-only visualisation with no animation of either kind - stays dropped too.

Checked across all four drills rather than assumed:

```
electric-mining-drill    UNCHANGED by the fallback
burner-mining-drill      UNCHANGED by the fallback
pumpjack                 UNCHANGED by the fallback
big-mining-drill         8 sprite(s) added  (2 entries x 4 facings)
```

## The `default` throws

Reached only if Factorio adds a drill type. `getSpriteData` still catches it, so the failure mode is the same placeholder box - but the log says `no draw case for mining drill 'x'` instead of `graphicsFn is not a function`.

Switching on `e.name` is inherently exposed to the DLC adding members to an existing type, so this guard matters more than the one error it clears.

## Visual check

The issue flagged that the candidate fix generated sprites but had not been looked at. Rendering both variants side by side is what turned up the missing drill head - the minimal fix leaves a gap showing bare grid where the drill should be.

| minimal fix (issue's candidate) | with `?? vis.animation` |
| --- | --- |
| drill head and scorch mark missing | complete |

## #22

The missing return is `spriteDataBuilder.ts(1975,54) TS2366: Function lacks ending return statement`. Baseline **270 -> 269**, and the before/after error sets differ by exactly that one line removed, none added.

## Verification

- Removed `big-mining-drill` from `EXPECTED_FAILURES` **first** and confirmed the spec failed on it and nothing else, so the test genuinely guards this
- `npx playwright test` - 15 passed
- `vp test` - 51 passed
- `npm run type-check:gate` - 269 at baseline 269
- `vp lint` - 28 warnings / 0 errors, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqyEwvXMDwkDWHnNRetwrJ