### PR TITLE
refactor(data): clear factorioData's strictNullChecks errors (237 -> 227)

### DIFF
--- a/packages/editor/src/core/factorioData.ts
+++ b/packages/editor/src/core/factorioData.ts
@@ -71,6 +71,7 @@ import {
     WallPrototype,
 } from 'factorio:prototype'
 import { IPoint } from '../types'
+import { need } from './need'
 import { WireConnectionPoint } from 'factorio:prototype'
 import { BoundingBox } from 'factorio:prototype'
 import { MapPosition } from 'factorio:prototype'
@@ -90,7 +91,7 @@ function getModulesFor(entityName: string): ModulePrototype[] {
             // filter modules based on entity allowed_effects (ex: beacons don't accept productivity effect)
             .filter(module =>
                 Object.keys(module.effect)
-                    .filter(effect => module.effect[effect] > 0) // needed or else speed modules can't be placed in beacons, not sure what the game does here
+                    .filter(effect => (module.effect[effect] ?? 0) > 0) // needed or else speed modules can't be placed in beacons, not sure what the game does here
                     .every(effect => allowed_effects.includes(effect))
             )
             .filter(
@@ -187,12 +188,20 @@ export function getModule(name: string): ModulePrototype {
     else throw new Error('Internal Error!')
 }
 
+/*
+    Returns undefined, not null, for "this entity has no circuit connector".
+    The two used to be mixed: the default arm returned null while every other arm
+    returned an optional prototype field, so the same absence arrived spelled two
+    ways and the type could describe neither. Every caller tests truthiness, so
+    settling on undefined - which is what the fields themselves are - costs
+    nothing and removes the coercion the split would otherwise need at each arm.
+*/
 export function getCircuitConnector(
     e: EntityWithOwnerPrototype,
     dir: number,
     isLoaderInputting: () => boolean,
     getBeltConnectionIndex: () => number
-): null | CircuitConnectorDefinition {
+): CircuitConnectorDefinition | undefined {
     switch (e.type) {
         case 'accumulator':
         case 'agricultural-tower':
@@ -250,23 +259,23 @@ export function getCircuitConnector(
                 | PumpPrototype
                 | StorageTankPrototype
                 | TrainStopPrototype
-            return e_resolved.circuit_connector[dir / 4]
+            return e_resolved.circuit_connector?.[dir / 4]
         }
         case 'rail-chain-signal':
         case 'rail-signal': {
             const e_resolved = e as RailSignalBasePrototype
-            return e_resolved.ground_picture_set.circuit_connector[dir]
+            return e_resolved.ground_picture_set.circuit_connector?.[dir]
         }
         case 'loader':
         case 'loader-1x1': {
             const e_resolved = e as LoaderPrototype
             // First the four cardinal directions for `direction_out`, followed by the four directions for `direction_in`.
-            return e_resolved.circuit_connector[(isLoaderInputting() ? 4 : 0) + dir / 4]
+            return e_resolved.circuit_connector?.[(isLoaderInputting() ? 4 : 0) + dir / 4]
         }
         case 'transport-belt': {
             const e_resolved = e as TransportBeltPrototype
             // Set of 7 CircuitConnectorDefinition in order: X, H, V, SE, SW, NE and NW.
-            return e_resolved.circuit_connector[getBeltConnectionIndex()]
+            return e_resolved.circuit_connector?.[getBeltConnectionIndex()]
         }
         case 'ammo-turret':
         case 'electric-turret':
@@ -286,10 +295,10 @@ export function getCircuitConnector(
             } else if (e_resolved.turret_base_has_direction) {
                 d = dir / 4
             }
-            return e_resolved.circuit_connector[d]
+            return e_resolved.circuit_connector?.[d]
         }
         default:
-            return null
+            return undefined
     }
 }
 
@@ -517,7 +526,7 @@ export function mapBoundingBox(bb: BoundingBox): [[number, number], [number, num
 }
 
 export function getEntitySize(e: EntityWithOwnerPrototype, dir: number = 0): IPoint {
-    const bb = mapBoundingBox(e.collision_box)
+    const bb = mapBoundingBox(need(e, 'collision_box'))
     const w = e.tile_width || Math.ceil(Math.abs(bb[0][0]) + Math.abs(bb[1][0]))
     const h = e.tile_height || Math.ceil(Math.abs(bb[0][1]) + Math.abs(bb[1][1]))
     if (w === h) {
@@ -662,7 +671,8 @@ export function getHeatBuffer(e: EntityWithOwnerPrototype): null | HeatBuffer {
             return null
     }
 }
-export function getEnergySource(e: EntityWithOwnerPrototype): null | EnergySource {
+/** undefined for "no energy source", for the same reason getCircuitConnector is. */
+export function getEnergySource(e: EntityWithOwnerPrototype): EnergySource | undefined {
     switch (e.type) {
         case 'agricultural-tower':
         case 'boiler':
@@ -730,7 +740,7 @@ export function getEnergySource(e: EntityWithOwnerPrototype): null | EnergySourc
             return e_resolved.energy_source
         }
         default:
-            return null
+            return undefined
     }
 }
 

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 237
+    "maxErrors": 227
 }


### PR DESCRIPTION
Refs #22. Baseline **237 -> 227**. Completes Cluster A apart from `spriteDataBuilder.ts`'s remaining 82.

## The lying type here is a split concept, not an over-optional interface

Eight of the ten errors are one root cause. `getCircuitConnector` and `getEnergySource` both express "this entity has none" as `null` in the `default` arm, while every other arm returns an **optional prototype field** and so hands back `undefined`. The same absence arrived spelled two ways, and the declared return type could describe only one of them.

Settled on `undefined`, which is what the fields themselves already are. Checked every caller before changing it:

| caller | how it tests the result |
| --- | --- |
| `Entity.ts:1076` | `cc?.points` |
| `spriteDataBuilder.ts:199` | `cc?.sprites` |
| `spriteDataBuilder.ts:386`, `:1105` | truthiness |
| `UnderlayContainer.ts:110` | `energy_source && energy_source.type === 'electric'` |
| `factorioData.ts:343` (`getFluidBoxes`) | `es && es.type === 'fluid'` |

None compares against `null`, so the change is invisible to all of them. Keeping `| null` would have meant a `?? null` coercion on each of the ten `return` arms instead of one signature change.

## One real improvement falls out of it

With the return type honest, the indexed reads become `circuit_connector?.[i]`. They previously **threw** when the field was absent - and in the sprite builder that throw is caught by `getSpriteData`, so the entity would lose *all* of its sprites rather than just its connector. Now the connector is skipped and the entity still draws.

The pinned failure list in `sprite-generation.spec.ts` is unchanged, so nothing in `data.json` actually takes that path today. It is a latent-crash fix, not an observable one.

## The other two

- `module.effect[effect] ?? 0` - exact, `undefined > 0` was already false
- `collision_box` through `need()` - verified rather than assumed: **all 155 entities in data.json have one**, so its absence is a broken export rather than a case to handle

## Why there is no new test

This is the one place I deliberately did not follow the test-first pattern, so flagging it rather than leaving it to be noticed.

`factorioData.ts` has no dedicated spec, but it is data-shaping code the entire suite runs through - `sprite-generation`, `overlay-container` and `entity-accessors` all pin its output downstream, and each of the three would have caught a change here. A new spec would have pinned strictly less than they already do.

The two behaviour-sensitive edits were checked directly instead: the caller audit above, and the `data.json` probe for `collision_box`.

## Deliberate non-change

`getHeatBuffer` keeps `| null` even though it now reads inconsistently with its two neighbours. It has no errors, and changing it for symmetry is churn that could push errors onto its callers. Happy to fold it in if you would rather the file were uniform.

## Verification

| check | result |
| --- | --- |
| Playwright | 17 passed |
| `vp test` | 51 passed |
| `type-check:gate` | 227 at baseline 227 |
| `vp lint` | 28 warnings / 0 errors, unchanged |

Error set diffed ignoring line numbers: **10 removed** from `factorioData`, **3 changed flavour** in `spriteDataBuilder` (`possibly null` -> `possibly undefined`, same three errors, still counted), **none genuinely added**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqyEwvXMDwkDWHnNRetwrJ