### PR TITLE
refactor(containers): make the cursor box and container lookup honest (108 -> 86)

### DIFF
--- a/packages/editor/src/UI/UIContainer.ts
+++ b/packages/editor/src/UI/UIContainer.ts
@@ -37,7 +37,8 @@ export class UIContainer extends Container {
         }
     }
 
-    public updateEntityInfoPanel(entity: Entity): void {
+    /** `undefined` hides the panel, which is what a hover-out sends. */
+    public updateEntityInfoPanel(entity: Entity | undefined): void {
         this.entityInfoPanel.updateVisualization(entity)
     }
 

--- a/packages/editor/src/containers/BlueprintContainer.ts
+++ b/packages/editor/src/containers/BlueprintContainer.ts
@@ -231,12 +231,15 @@ export class BlueprintContainer extends Container {
                     this.on('globalpointermove', panModule._onPan)
                     return true
                 }
+                return false
             },
             panEnd: (): void => {
                 if (this.mode === EditorMode.PAN) {
                     this.off('globalpointermove', panModule._onPan)
                     this.setMode(EditorMode.NONE)
-                    this.cursor = null
+                    // pixi's setCursor does `mode || (mode = 'default')`, so this is
+                    // the same reset-to-default the `null` here used to mean.
+                    this.cursor = undefined
                 }
             },
         }
@@ -283,7 +286,8 @@ export class BlueprintContainer extends Container {
             })
         }
 
-        let constraint: boolean
+        // Tri-state: undefined until the first drag decides whether to lock an axis.
+        let constraint: boolean | undefined
         const build = (_x: number, _y: number, dx: number, dy: number): void => {
             if (constraint === undefined) {
                 const cX = Math.abs(Math.sign(dx))
@@ -597,7 +601,7 @@ export class BlueprintContainer extends Container {
             const H = Math.abs(endY - startPos.y) + 1
 
             for (const e of this.copyModeEntities) {
-                EntityContainer.mappings.get(e.entityNumber).cursorBox = undefined
+                EntityContainer.containerOf(e.entityNumber).cursorBox = undefined
             }
 
             this.copyModeEntities = this.bp.entityPositionGrid.getEntitiesInArea({
@@ -608,7 +612,7 @@ export class BlueprintContainer extends Container {
             })
 
             for (const e of this.copyModeEntities) {
-                EntityContainer.mappings.get(e.entityNumber).cursorBox = 'copy'
+                EntityContainer.containerOf(e.entityNumber).cursorBox = 'copy'
             }
         }
         this.copyModeUpdateFn(startPos.x, startPos.y)
@@ -630,7 +634,7 @@ export class BlueprintContainer extends Container {
             this.spawnPaintContainer(this.copyModeEntities)
         }
         for (const e of this.copyModeEntities) {
-            EntityContainer.mappings.get(e.entityNumber).cursorBox = undefined
+            EntityContainer.containerOf(e.entityNumber).cursorBox = undefined
         }
         this.copyModeEntities = []
     }
@@ -652,7 +656,7 @@ export class BlueprintContainer extends Container {
             const H = Math.abs(endY - startPos.y) + 1
 
             for (const e of this.deleteModeEntities) {
-                EntityContainer.mappings.get(e.entityNumber).cursorBox = undefined
+                EntityContainer.containerOf(e.entityNumber).cursorBox = undefined
             }
 
             this.deleteModeEntities = this.bp.entityPositionGrid.getEntitiesInArea({
@@ -663,7 +667,7 @@ export class BlueprintContainer extends Container {
             })
 
             for (const e of this.deleteModeEntities) {
-                EntityContainer.mappings.get(e.entityNumber).cursorBox = 'not_allowed'
+                EntityContainer.containerOf(e.entityNumber).cursorBox = 'not_allowed'
             }
         }
         this.deleteModeUpdateFn(startPos.x, startPos.y)
@@ -683,7 +687,7 @@ export class BlueprintContainer extends Container {
 
         if (cancel) {
             for (const e of this.deleteModeEntities) {
-                EntityContainer.mappings.get(e.entityNumber).cursorBox = undefined
+                EntityContainer.containerOf(e.entityNumber).cursorBox = undefined
             }
         } else {
             this.bp.removeEntities(this.deleteModeEntities)
@@ -961,8 +965,15 @@ export class BlueprintContainer extends Container {
         return rect
     }
 
-    public getPicture(): Promise<Blob> {
-        if (this.bp.isEmpty()) return
+    /**
+     * Rejects rather than resolving to nothing, on all three ways this can fail to
+     * produce an image. The bare `return` this used to do on an empty blueprint
+     * handed back `undefined` instead of a promise, so the caller's `.then` threw
+     * before its `.catch` was attached - and the only caller already refuses to ask
+     * for a picture of an empty blueprint, so that path was unreachable anyway.
+     */
+    public async getPicture(): Promise<Blob> {
+        if (this.bp.isEmpty()) throw new Error('Cannot take a picture of an empty blueprint')
 
         const frame = this.getBlueprintBounds()
         const texture = G.app.renderer.generateTexture({
@@ -975,11 +986,22 @@ export class BlueprintContainer extends Container {
         })
 
         const canvas = G.app.renderer.extract.canvas(texture)
+        // Held as a local because narrowing a property does not survive into the
+        // closure below.
+        const toBlob = canvas.toBlob?.bind(canvas)
+        if (toBlob === undefined) {
+            texture.destroy(true)
+            throw new Error('Canvas cannot produce a blob')
+        }
 
-        return new Promise(resolve => {
-            canvas.toBlob(blob => {
+        return new Promise((resolve, reject) => {
+            toBlob(blob => {
                 texture.destroy(true)
-                resolve(blob)
+                if (blob === null) {
+                    reject(new Error('Canvas failed to produce a blob'))
+                } else {
+                    resolve(blob)
+                }
             })
         })
     }

--- a/packages/editor/src/containers/EntityContainer.ts
+++ b/packages/editor/src/containers/EntityContainer.ts
@@ -10,6 +10,30 @@ import { CursorBoxSpecification } from 'factorio:prototype'
 export class EntityContainer {
     public static readonly mappings: Map<number, EntityContainer> = new Map()
 
+    /**
+     * The container drawing `entityNumber`, for callers holding an entity that is
+     * live in the current blueprint.
+     *
+     * `mappings` is an index into `bp.entities`, not an independent store:
+     * `initBP` constructs a container for every entity and the constructor is the
+     * only thing that writes, while the only delete is on that same entity's
+     * `destroy`. So an entity reached through `bp.entityPositionGrid` or through a
+     * stored wire connection always has a container, and a miss means the two have
+     * drifted apart rather than that the caller asked for something reasonable -
+     * the same signal `PositionGrid.entityAt` gives.
+     *
+     * `mappings` stays public for the lookups where absence is a real answer:
+     * `OverlayContainer` asks about `entityForCopyData`, which is remembered
+     * across the entity being deleted.
+     */
+    public static containerOf(entityNumber: number): EntityContainer {
+        const ec = EntityContainer.mappings.get(entityNumber)
+        if (ec === undefined) {
+            throw new Error(`Entity ${entityNumber} has no container`)
+        }
+        return ec
+    }
+
     private static _updateGroups: Map<string, Set<string>>
     private static get updateGroups(): Map<string, Set<string>> {
         if (!EntityContainer._updateGroups) {
@@ -22,7 +46,7 @@ export class EntityContainer {
     private entityInfo: Container | undefined
     private entitySprites: EntitySprite[] = []
     /** This is only a reference */
-    private cursorBoxContainer: Container
+    private cursorBoxContainer: Container | undefined
     /** This is only a reference */
     private undergroundLine: Container | undefined
 
@@ -203,12 +227,13 @@ export class EntityContainer {
             })
             .reduce<Map<string, Set<string>>>((map, cV) => {
                 for (const k of cV.is) {
-                    if (map.has(k)) {
-                        for (const v of cV.updates) {
-                            map.get(k).add(v)
-                        }
-                    } else {
+                    const updates = map.get(k)
+                    if (updates === undefined) {
                         map.set(k, new Set(cV.updates))
+                    } else {
+                        for (const v of cV.updates) {
+                            updates.add(v)
+                        }
                     }
                 }
                 return map
@@ -226,9 +251,11 @@ export class EntityContainer {
         }
     }
 
-    public set cursorBox(type: keyof CursorBoxSpecification) {
+    /** `undefined` removes the box, which is how every hover-out and mode exit clears it. */
+    public set cursorBox(type: keyof CursorBoxSpecification | undefined) {
         if (this.cursorBoxContainer) {
             this.cursorBoxContainer.destroy()
+            this.cursorBoxContainer = undefined
         }
         if (type !== undefined) {
             this.cursorBoxContainer = G.BPC.overlayContainer.createCursorBox(
@@ -320,7 +347,7 @@ export class EntityContainer {
             G.bp.entityPositionGrid
                 .getEntitiesInArea(area)
                 .filter(e => e.type === 'gate')
-                .forEach(entity => EntityContainer.mappings.get(entity.entityNumber).redraw())
+                .forEach(entity => EntityContainer.containerOf(entity.entityNumber).redraw())
         } else {
             const entities = G.bp.entityPositionGrid.getSurroundingEntities(area)
 
@@ -343,7 +370,7 @@ export class EntityContainer {
             entities
                 .filter(entity => updatesEntities.has(entity.name))
                 .forEach(entity => {
-                    EntityContainer.mappings.get(entity.entityNumber).redraw()
+                    EntityContainer.containerOf(entity.entityNumber).redraw()
                     if (entity.type === 'transport-belt') {
                         G.BPC.wiresContainer.update(entity.entityNumber)
                     }

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 108
+    "maxErrors": 86
 }


### PR DESCRIPTION
Part of #22. Gate 108 -> 86. `EntityContainer.ts` is now clear; `BlueprintContainer.ts` goes 18 -> 2.

## The two lying types

**`set cursorBox(type: keyof CursorBoxSpecification)`** never admitted `undefined`, even though the body is `if (type !== undefined)` and every hover-out, copy mode exit and delete mode exit clears the box that way. It also destroyed `cursorBoxContainer` without clearing the reference, so the next set destroyed an already-destroyed container - harmless, since pixi's `destroy` opens with `if (this.destroyed) return`, but the type was pointing at it.

**`EntityContainer.mappings.get(n).x`** read a `Map.get` as if it could not miss. It cannot, for these callers: `initBP` builds a container for every entity, the constructor is the only write and the entity's own `destroy` the only delete, so an entity reached through the position grid always has one. Same invariant `PositionGrid.entityAt` carries, so it gets the same treatment - a named `containerOf` that throws, instead of a `TypeError` one property later. `mappings` stays public for the lookups where a miss is a real answer (`OverlayContainer` asks about `entityForCopyData`, which outlives its entity).

Between them, 14 of BlueprintContainer's 18 and 4 of EntityContainer's 6.

## The rest, none of which rippled

- `panStart` fell off the end where its sibling `buildStart` returns `false`
- `panEnd` set `cursor = null`; pixi's `setCursor` opens `mode || (mode = 'default')`, so `undefined` is the same reset it meant
- `constraint` is a tri-state the code already tested with `=== undefined`
- `getPicture` returned `undefined` rather than a promise for an empty blueprint, which would throw in the caller's `.then` before its `.catch` was attached. Now rejects, along with the two blob failure paths it ignored
- `UIContainer.updateEntityInfoPanel` narrowed its parameter to `Entity` while the `EntityInfoPanel.updateVisualization` it forwards to already took `entity?: Entity` and hides the panel when it is absent

## On the missing fixture

The last four batches each came with a characterization test because widening a type revealed unhandled `undefined` - real new behaviour worth pinning. This one is behaviour-neutral: the cursor box change is a no-op call skipped, `containerOf` throws where a `TypeError` was already coming, and the rest are type-only or unreachable paths.

So it was verified in the browser instead, which is worth doing because hover and copy/delete mode have no automated coverage at all: hover in and out (box drawn then cleared, info panel populated then hidden), pan, and a ctrl-drag copy selection drawing `'copy'` boxes on every selected entity and clearing all of them on release. Delete mode is the same line with `'not_allowed'`.

## Checks

- `npm run type-check:gate` - 86, baseline lowered to match
- `vp test` - 51 passing
- `vp lint` / `vp fmt` - clean
- `npx playwright test` - 23 passing, every fixture unchanged

## Noted along the way

- The 2 errors left in BlueprintContainer are `hoverContainer`/`paintContainer`. Widening those is +33 errors across 10 files and wants its own pass.
- `EntityInfoPanel.ts:201,220` read `recipe.ingredients` unguarded and throw `ingredients is not iterable` on recipes that have none - `OverlayContainer.ts:95` documents the same field as optional and guards it. Pre-existing and untouched here; that file still carries 6 errors.
- `EntityContainer.mappings` is static and never cleared when a blueprint is swapped, so containers from a previous blueprint leak at entity numbers the new one does not reuse. Not reachable from these call sites, so left alone.