### PR TITLE
chore(deps): bump @playwright/test to 1.62 and typed-factorio to 3.36

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
                 "packages/worker"
             ],
             "devDependencies": {
-                "@playwright/test": "^1.58.2",
+                "@playwright/test": "^1.62.0",
                 "@types/node": "^26.1.1",
-                "typed-factorio": "^3.35.0",
+                "typed-factorio": "^3.36.0",
                 "typescript": "^7.0.2",
                 "vite-plus": "0.2.6"
             }
@@ -2065,19 +2065,19 @@
             "license": "MIT"
         },
         "node_modules/@playwright/test": {
-            "version": "1.61.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-            "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+            "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.61.1"
+                "playwright": "1.62.0"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/@polka/url": {
@@ -4697,35 +4697,35 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.61.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-            "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+            "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.61.1"
+                "playwright-core": "1.62.0"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "optionalDependencies": {
                 "fsevents": "2.3.2"
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.61.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-            "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+            "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
         "test:e2e:report": "npx playwright test --reporter=list"
     },
     "devDependencies": {
-        "@playwright/test": "^1.58.2",
+        "@playwright/test": "^1.62.0",
         "@types/node": "^26.1.1",
-        "typed-factorio": "^3.35.0",
+        "typed-factorio": "^3.36.0",
         "typescript": "^7.0.2",
         "vite-plus": "0.2.6"
     },


### PR DESCRIPTION
Both drop in cleanly.

## typed-factorio 3.35 -> 3.36

The one that could have moved something, since the prototype types are what the strictNullChecks work in #22 is measured against. It doesn't: the gate stays at **81**, with the same errors in the same files, and every characterization fixture is unchanged — so no prototype field this codebase reads changed optionality.

Still on v3; v4 remains held back over the Factorio 2.1 data mismatch.

## @playwright/test 1.58 -> 1.62

No CI impact — no workflow runs the e2e suite, it's run locally against the dev servers.

⚠️ **Needs `npx playwright install` once after pulling.** The bundled browser revision moved and the old `chrome-headless-shell` is gone; without it all 25 specs fail on a missing executable rather than on anything real. Worth knowing before anyone reads a red suite as a regression.

## Checks

| | |
| --- | --- |
| `npm run type-check:gate` | 81, at baseline |
| `vp lint` | clean |
| `vp test` | 55 passing |
| `npx playwright test` | 25 passing, no fixture diffs |