### PR TITLE
fix: strip unknown tiles on load instead of crashing

### DIFF
--- a/packages/editor/src/core/bpString.ts
+++ b/packages/editor/src/core/bpString.ts
@@ -90,20 +90,45 @@ function getAndClearLoadWarnings(): string[] {
     return warnings
 }
 
-function stripUnknownEntities(data: StringData): string[] {
-    const strippedNames = new Set<string>()
+/**
+ * The prototype names a blueprint used that this build does not have, by kind.
+ * Both kinds have to be dropped before the blueprint reaches the model: an
+ * unknown entity throws in the sprite builder, and an unknown tile throws in
+ * TileContainer, which reads `FD.tiles[name].variants` (issue #46).
+ */
+interface StrippedNames {
+    entities: string[]
+    tiles: string[]
+}
+
+function stripUnknownPrototypes(data: StringData): StrippedNames {
+    const strippedEntities = new Set<string>()
+    const strippedTiles = new Set<string>()
     const stripBlueprint = (bp: IBlueprint): void => {
         if (bp.entities) {
             const before = bp.entities.length
             bp.entities = bp.entities.filter(e => {
                 if (!FD.entities[e.name]) {
-                    strippedNames.add(e.name)
+                    strippedEntities.add(e.name)
                     return false
                 }
                 return true
             })
             if (bp.entities.length < before) {
                 console.warn(`Stripped ${before - bp.entities.length} unknown entities`)
+            }
+        }
+        if (bp.tiles) {
+            const before = bp.tiles.length
+            bp.tiles = bp.tiles.filter(t => {
+                if (!FD.tiles[t.name]) {
+                    strippedTiles.add(t.name)
+                    return false
+                }
+                return true
+            })
+            if (bp.tiles.length < before) {
+                console.warn(`Stripped ${before - bp.tiles.length} unknown tiles`)
             }
         }
     }
@@ -120,7 +145,7 @@ function stripUnknownEntities(data: StringData): string[] {
     } else if (data.blueprint_book) {
         stripBook(data.blueprint_book.blueprints)
     }
-    return [...strippedNames]
+    return { entities: [...strippedEntities], tiles: [...strippedTiles] }
 }
 
 function decode(str: string): Promise<Blueprint | Book> {
@@ -143,12 +168,18 @@ function decode(str: string): Promise<Blueprint | Book> {
             console.warn('Blueprint validation warnings (loading anyway):', JSON.stringify(errors))
             loadWarnings.push('Blueprint had validation warnings (loaded anyway)')
         }
-        // Always strip unknown entities - they crash during rendering if they
-        // reach Blueprint.ts (e.g., mod entities like ee-infinity-loader)
-        const strippedNames = stripUnknownEntities(data as StringData)
-        if (strippedNames.length > 0) {
+        // Always strip unknown names - they crash during rendering if they reach
+        // Blueprint.ts (e.g., mod entities like ee-infinity-loader, or a tile from
+        // a Factorio version newer than the exporter ran against)
+        const stripped = stripUnknownPrototypes(data as StringData)
+        if (stripped.entities.length > 0) {
             loadWarnings.push(
-                `Skipped ${strippedNames.length} unknown entit${strippedNames.length === 1 ? 'y' : 'ies'}: ${strippedNames.join(', ')}`
+                `Skipped ${stripped.entities.length} unknown entit${stripped.entities.length === 1 ? 'y' : 'ies'}: ${stripped.entities.join(', ')}`
+            )
+        }
+        if (stripped.tiles.length > 0) {
+            loadWarnings.push(
+                `Skipped ${stripped.tiles.length} unknown tile${stripped.tiles.length === 1 ? '' : 's'}: ${stripped.tiles.join(', ')}`
             )
         }
 

--- a/tests/helpers/encode-blueprint.ts
+++ b/tests/helpers/encode-blueprint.ts
@@ -1,0 +1,22 @@
+import { deflateSync } from 'zlib'
+
+/*
+    Builds the blueprint strings bpString.decode() reads, for the specs whose case
+    cannot come out of wormeyman-tests/ - anything about a version other than the
+    2.0.45+ the corpus declares, or about a prototype name that is deliberately
+    not in FD.
+
+    The other two synthetic builders (all-entities-blueprint, all-recipes-blueprint)
+    hand back a source string of their own and do not need this; they are building a
+    corpus, this is for hand-written one-off cases.
+*/
+
+/** The encoding decode() expects: a version byte, then deflated JSON. */
+export function encodeBlueprint(blueprint: Record<string, unknown>): string {
+    return `0${deflateSync(Buffer.from(JSON.stringify({ blueprint }))).toString('base64')}`
+}
+
+/** How Factorio packs a version into the blueprint's `version` field. */
+export function packVersion(main: number, major: number, minor: number, dev = 0): number {
+    return main * 2 ** 48 + major * 2 ** 32 + minor * 2 ** 16 + dev
+}

--- a/tests/name-migrations.spec.ts
+++ b/tests/name-migrations.spec.ts
@@ -1,5 +1,5 @@
-import { deflateSync } from 'zlib'
 import { test, expect } from '@playwright/test'
+import { encodeBlueprint as encode, packVersion as version } from './helpers/encode-blueprint'
 
 /*
     The legacy prototype renames in nameMigrations.ts apply per blueprint, by the
@@ -18,17 +18,9 @@ import { test, expect } from '@playwright/test'
     two servers that have to be up.
 */
 
-/** How Factorio packs a version into the blueprint's `version` field. */
-const version = (main: number, major: number, minor: number): number =>
-    main * 2 ** 48 + major * 2 ** 32 + minor * 2 ** 16
-
 const V_0_16 = version(0, 16, 51)
 const V_1_1 = version(1, 1, 107)
 const V_2_0 = version(2, 0, 55)
-
-/** The encoding bpString.decode() reads: version byte, then deflated JSON. */
-const encode = (blueprint: Record<string, unknown>): string =>
-    `0${deflateSync(Buffer.from(JSON.stringify({ blueprint }))).toString('base64')}`
 
 interface Loaded {
     entities: string[]

--- a/tests/unknown-prototypes.spec.ts
+++ b/tests/unknown-prototypes.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprint, packVersion } from './helpers/encode-blueprint'
+
+/*
+    A blueprint can name a prototype this build of the editor does not have - a
+    mod's entity, a tile from a Factorio version newer than the exporter ran
+    against, a hand-edited string. bpString drops what it cannot resolve and warns
+    rather than failing the load, and this pins that for each kind of name a
+    blueprint carries, because the two were not handled the same way: entities
+    were filtered and tiles were not, so an unknown tile took the whole load down
+    on `FD.tiles[name].variants` (issue #46).
+
+    Synthetic blueprints, because the corpus cannot hold this case: an unknown name
+    is by definition one that is not in data.json, and every blueprint in
+    wormeyman-tests/ loads clean today.
+
+    Runs against the dev server like the rest of tests/ - see CLAUDE.md for the
+    two servers that have to be up.
+*/
+
+/** Current, so no name migration applies - see nameMigrations.ts. */
+const VERSION = packVersion(2, 0, 55)
+
+interface Loaded {
+    entities: string[]
+    tiles: string[]
+    warnings: string[]
+    errors: string[]
+}
+
+async function load(
+    page: import('@playwright/test').Page,
+    blueprint: Record<string, unknown>
+): Promise<Loaded> {
+    const warnings: string[] = []
+    const errors: string[] = []
+    page.on('pageerror', e => errors.push(String(e)))
+    page.on('console', m => {
+        if (m.type() === 'warning') warnings.push(m.text())
+        if (m.type() === 'error') errors.push(m.text())
+    })
+
+    await page.goto('/')
+    await page.waitForFunction(() => (window as any).__fbe_test !== undefined, { timeout: 60_000 })
+
+    const loaded = await page.evaluate(async (str: string) => {
+        const api = (window as any).__fbe_test
+        const bp = await api.getBlueprintOrBookFromSource(str)
+        // loadBp is what emits the warnings, and rendering is where an
+        // unresolvable name actually throws.
+        await api.loadBp(bp)
+        return {
+            entities: [...bp.entities.values()].map((e: any) => e.name).sort(),
+            tiles: [...bp.tiles.values()].map((t: any) => t.name).sort(),
+        }
+    }, encodeBlueprint(blueprint))
+
+    return { ...loaded, warnings, errors }
+}
+
+test('an unknown entity is dropped and named in a warning', async ({ page }) => {
+    const loaded = await load(page, {
+        item: 'blueprint',
+        version: VERSION,
+        entities: [
+            { entity_number: 1, name: 'inserter', position: { x: 0.5, y: 0.5 } },
+            { entity_number: 2, name: 'ee-infinity-loader', position: { x: 20.5, y: 0.5 } },
+        ],
+    })
+
+    expect(loaded.entities).toEqual(['inserter'])
+    expect(loaded.warnings.join(' | ')).toContain('ee-infinity-loader')
+    expect(loaded.errors, `page errors: ${loaded.errors.join(' | ')}`).toEqual([])
+})
+
+test('an unknown tile is dropped and named in a warning', async ({ page }) => {
+    const loaded = await load(page, {
+        item: 'blueprint',
+        version: VERSION,
+        tiles: [
+            { name: 'refined-concrete', position: { x: 0, y: 0 } },
+            // grass-1 is the realistic case: a real Factorio tile until 0.17.10,
+            // so a genuinely old string can carry it, and not in FD today.
+            { name: 'grass-1', position: { x: 1, y: 0 } },
+        ],
+    })
+
+    expect(loaded.tiles).toEqual(['refined-concrete'])
+    expect(loaded.warnings.join(' | ')).toContain('grass-1')
+    expect(loaded.errors, `page errors: ${loaded.errors.join(' | ')}`).toEqual([])
+})
+
+test('a blueprint of nothing but unknown names still loads', async ({ page }) => {
+    /*
+        The empty-after-stripping case reaches Blueprint with no entities and no
+        tiles, which is the same shape as a blank editor and must not be an error.
+    */
+    const loaded = await load(page, {
+        item: 'blueprint',
+        version: VERSION,
+        entities: [{ entity_number: 1, name: 'ee-infinity-loader', position: { x: 0.5, y: 0.5 } }],
+        tiles: [{ name: 'grass-1', position: { x: 0, y: 0 } }],
+    })
+
+    expect(loaded.entities).toEqual([])
+    expect(loaded.tiles).toEqual([])
+    expect(loaded.errors, `page errors: ${loaded.errors.join(' | ')}`).toEqual([])
+})


### PR DESCRIPTION
Closes #46.

## The bug

`stripUnknownEntities` filtered `bp.entities` against `FD.entities` and left `bp.tiles` alone. An unrecognised tile therefore reached the model intact and then `TileContainer` read `FD.tiles[name].variants` on `undefined`:

```
TypeError: Cannot read properties of undefined (reading 'variants')
  TileContainer.generateSprite (TileContainer.ts:21)
  new TileContainer (TileContainer.ts:7)
  BlueprintContainer.initBP (BlueprintContainer.ts:715)
  Editor.loadBlueprint (Editor.ts:128)
```

The asymmetry was the bug. The same blueprint with an unknown **entity** loaded with a warning; with an unknown **tile** the whole load failed. The function's own comment said it existed because unknown names "crash during rendering if they reach `Blueprint.ts`" — which is precisely what tiles were doing.

Reachable from a mod's tile, a hand-edited string, or a tile from a Factorio version newer than the exporter ran against.

## The fix

Renamed to `stripUnknownPrototypes`, filtering both kinds and reporting them separately so a user can tell which was dropped:

```
Skipped 1 unknown entity: ee-infinity-loader
Skipped 1 unknown tile: grass-1
```

## What this deliberately does not do

`FD.tiles` is typed `Record<string, TilePrototype>`, so `FD.tiles[name]` is not `| undefined` and TypeScript never flagged the read — the lying type that let this through. Stripping at the boundary makes that type *honest* rather than papering over it, which is why the fix is here and not a guard at the read site.

The four strictNullChecks errors still in `TileContainer.ts` have a different root (`TileVariants.main` and `count` are genuinely optional) and stay on #22. The gate is unchanged at 81.

## Tests

New `tests/unknown-prototypes.spec.ts` pins both sides of the asymmetry — the entity case passed before this change, the two tile cases crashed. It needs synthetic blueprints, since an unknown name is by definition one that no clean-loading blueprint in `wormeyman-tests/` carries; the encoder moved to `tests/helpers/encode-blueprint.ts` in its own commit, shared with `name-migrations.spec.ts`.

Also covered: a blueprint left completely empty after stripping, which reaches `Blueprint` with no entities and no tiles and must not be an error.

## Verification

- `npx playwright test` — 31 passed. The round-trip tile count (426868) is unchanged, so nothing in the corpus is affected.
- `vp test` — 69 passed
- `npm run type-check:gate` — 81, at baseline
- `vp lint` — no errors

Both commits are green standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UMUmQi25ZDoHP7KbSK4Kn