### PR TITLE
chore(types): make the rotate/flip-by-copying contract explicit

### DIFF
--- a/packages/editor/src/containers/PaintContainer.ts
+++ b/packages/editor/src/containers/PaintContainer.ts
@@ -162,12 +162,26 @@ export abstract class PaintContainer extends Container<EntitySprite> {
     // override
     public abstract rotate(ccw?: boolean): void
 
+    /**
+     * Whether rotating or flipping this container means replacing it with a
+     * container of transformed copies, rather than transforming it in place.
+     * This is the guard on the two below - `BlueprintContainer.rotate` and
+     * `.flip` ask it first and call them only when it answers true.
+     */
     // override
     public abstract canFlipOrRotateByCopying(): boolean
 
+    /**
+     * The copies to respawn with, valid only where `canFlipOrRotateByCopying()`
+     * is true. The three containers that answer false throw instead of returning
+     * anything, because there is no list that means "not applicable" - the
+     * caller destroys this container before spawning whatever comes back, so an
+     * empty array or undefined would take paint mode down with it.
+     */
     // override
     public abstract rotatedEntities(ccw?: boolean): Entity[]
 
+    /** As `rotatedEntities`, and guarded by the same predicate. */
     // override
     public abstract flippedEntities(vertical: boolean): Entity[]
 

--- a/packages/editor/src/containers/PaintEntityContainer.ts
+++ b/packages/editor/src/containers/PaintEntityContainer.ts
@@ -141,11 +141,11 @@ export class PaintEntityContainer extends PaintContainer {
     }
 
     public override rotatedEntities(_ccw?: boolean): Entity[] {
-        return undefined
+        throw new Error('A single entity is not rotated by copying')
     }
 
     public override flippedEntities(_vertical: boolean): Entity[] {
-        return undefined
+        throw new Error('A single entity is not flipped by copying')
     }
 
     protected override redraw(): void {

--- a/packages/editor/src/containers/PaintTileContainer.ts
+++ b/packages/editor/src/containers/PaintTileContainer.ts
@@ -76,11 +76,11 @@ export class PaintTileContainer extends PaintContainer {
     }
 
     public override rotatedEntities(_ccw?: boolean): Entity[] {
-        return undefined
+        throw new Error('A tile is not rotated by copying')
     }
 
     public override flippedEntities(_vertical: boolean): Entity[] {
-        return undefined
+        throw new Error('A tile is not flipped by copying')
     }
 
     protected override redraw(): void {

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 81
+    "maxErrors": 77
 }


### PR DESCRIPTION
Part of #22. Gate **81 → 77**.

## The root

`rotatedEntities` / `flippedEntities` mean something only where `canFlipOrRotateByCopying()` is true — `BlueprintContainer.rotate` and `.flip` ask that first and call them only when it answers true.

Three of the four containers answer `false`. One of them already said so correctly:

| container | `canFlipOrRotateByCopying()` | what the two methods did | errors |
| --- | --- | --- | --- |
| `PaintWireContainer` | `false` | throws a named error | 0 |
| `PaintEntityContainer` | `false` | `return undefined`, declared `Entity[]` | 2 |
| `PaintTileContainer` | `false` | `return undefined`, declared `Entity[]` | 2 |
| `PaintBlueprintContainer` | `true` | returns real copies | 1 (see below) |

So the same statement was written twice as a lie and once as a throw. This makes the other two match the wire container.

## Why a throw and not `Entity[] | undefined`

There is no list that means "not applicable" here. The caller destroys the container *before* spawning whatever comes back:

```ts
const copies = this.paintContainer.rotatedEntities(ccw)
this.paintContainer.destroy()
this.spawnPaintContainer(copies, 0)
```

An empty array or an `undefined` would take paint mode down with it — `spawnPaintContainer(undefined)` reaches `new PaintBlueprintContainer(this, undefined)` and survives only because a try/catch turns it into a `console.error` and drops to `EditorMode.NONE`. Widening the base signature would also push a null check into a caller where the guard already makes it unnecessary.

## Behaviour and testing

Behaviour-neutral — the guard is the only caller of either method, so neither throw is reachable today (verified: `BlueprintContainer.rotate`/`.flip` are the only call sites).

No fixture: there is no runtime behaviour to pin, and no test can drive paint mode at all yet (#44). The contract is documented on the abstract declarations in `PaintContainer` instead, since it was previously only inferable by reading all four implementations.

## Deliberately not included

`PaintBlueprintContainer.rotatedEntities` returns `undefined` when `!this.visible` — the same `TS2322`, but a real bug rather than a lie. With the pointer off the canvas the container is hidden, so pressing rotate destroys the paint container and drops paint mode with a console error; `flippedEntities` has no such check and works fine, which is what makes it look like an oversight. Fixing it is a behaviour change in code no test can reach, so it gets its own change rather than riding along here.

## Verification

- `npm run type-check:gate` — 77, baseline lowered to match
- `vp test` — 69 passed
- `npx playwright test` — 28 passed
- `vp lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UMUmQi25ZDoHP7KbSK4Kn