### PR TITLE
fix: release the previous blueprint's containers on a blueprint swap

### DIFF
--- a/packages/editor/src/containers/EntityContainer.ts
+++ b/packages/editor/src/containers/EntityContainer.ts
@@ -149,6 +149,30 @@ export class EntityContainer {
             this.m_Entity.off('splitterOutputPriority', this.redrawEntityInfo, this)
 
             this.m_Entity.off('destroy', onEntityDestroy)
+
+            /*
+                Replacing a blueprint never destroys the outgoing one's entities,
+                so nothing else takes these out of the index (issue #42). The
+                identity check is what makes this safe under the load ordering:
+                Editor.loadBlueprint runs the new blueprint's initBP() *before*
+                destroying the old container, so the new containers have already
+                claimed the entity numbers they share - and a blanket delete here
+                would remove the entries just written.
+            */
+            if (EntityContainer.mappings.get(this.m_Entity.entityNumber) === this) {
+                EntityContainer.mappings.delete(this.m_Entity.entityNumber)
+            }
+
+            // Unlinking alone would leave these for the GC; the old container was
+            // destroyed with pixi's default destroyChildren: false, so its sprites
+            // are merely detached from the stage.
+            for (const s of this.entitySprites) {
+                s.destroy()
+            }
+            this.visualizationArea.destroy()
+            if (this.entityInfo !== undefined) {
+                this.entityInfo.destroy()
+            }
         })
     }
 

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -11,6 +11,7 @@ import {
 import { Editor } from './Editor'
 import FD from './core/factorioData'
 import { OverlayContainer } from './containers/OverlayContainer'
+import { EntityContainer } from './containers/EntityContainer'
 import { EntitySprite } from './containers/EntitySprite'
 import { EntityInfoPanel } from './UI/EntityInfoPanel'
 import { getSpriteData, SPRITE_GENERATION_FAILED } from './core/spriteDataBuilder'
@@ -21,7 +22,9 @@ export * from './core/bpString'
 // SPRITE_GENERATION_FAILED are exported for tests/sprite-data.spec.ts, which
 // digests the sprite data every entity generates. EntityInfoPanel is exported for
 // tests/recipe-shapes.spec.ts, which needs the panel a hover updates without
-// hovering. Nothing in the app imports any of them from here.
+// hovering. EntityContainer is exported for tests/entity-container-mappings.spec.ts,
+// which measures its static container index across a blueprint swap. Nothing in
+// the app imports any of them from here.
 export {
     Editor,
     Book,
@@ -29,6 +32,7 @@ export {
     GridPattern,
     FD,
     OverlayContainer,
+    EntityContainer,
     EntitySprite,
     EntityInfoPanel,
     getSpriteData,

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -14,6 +14,7 @@ import EDITOR, {
     getBlueprintOrBookFromSource,
     getAndClearLoadWarnings,
     OverlayContainer,
+    EntityContainer,
     FD,
     EntitySprite,
     EntityInfoPanel,
@@ -205,6 +206,13 @@ document.addEventListener('paste', (e: ClipboardEvent) => {
         bp = book.selectBlueprint(index)
         await editor.loadBlueprint(bp)
     },
+    /*
+        The size of EntityContainer.mappings, the static entity-number -> container
+        index. Loading a blueprint should leave it holding exactly that
+        blueprint's containers; anything above is retention from a previously
+        loaded one (issue #42).
+    */
+    entityContainerCount: () => EntityContainer.mappings.size,
     /*
         Per entity name, the number of children each entity's info overlay came
         out with, or -1 where it produced no overlay at all. Deliberately calls

--- a/tests/entity-container-mappings.spec.ts
+++ b/tests/entity-container-mappings.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test'
+import { discoverBlueprintFiles, readBlueprintString } from './helpers/blueprint-files'
+
+/*
+    EntityContainer.mappings is a static Map<entityNumber, EntityContainer>.
+    Entries are written in the constructor and, before issue #42, removed in
+    exactly one place: the entity's own `destroy` handler. Loading a different
+    blueprint never destroys the previous blueprint's entities - Editor.loadBlueprint
+    builds the new BlueprintContainer and calls initBP() before destroying the old
+    one - so every container above the new blueprint's highest entity number stayed
+    in the map, holding its Entity, its EntitySprites, its VisualizationArea and its
+    info overlay for the life of the tab.
+
+    Measured rather than asserted loosely, because the retention is bounded by the
+    largest blueprint seen rather than unbounded, so a "does it grow" test would
+    pass while leaking. Big-then-small is the shape that shows it: after loading
+    the small one the map should hold the small one's containers and nothing else.
+
+    Runs against the dev server like the rest of tests/ - see CLAUDE.md for the
+    two servers that have to be up.
+*/
+
+/*
+    A large and a small blueprint. Both files are books, and loadBp renders only
+    a book's first blueprint, so these are the counts of entry 0 - which is why
+    the big one is 243 rather than the 1636 issue #42 quotes for the whole book.
+*/
+const BIG = 'EARN/quick-start-v22-0-11'
+const SMALL = 'AVADII/Alpha Cygni Blueprints 1.3'
+
+interface Loaded {
+    entities: number
+    mappings: number
+}
+
+test('the container index holds only the loaded blueprint after a swap', async ({ page }) => {
+    const files = discoverBlueprintFiles()
+    const find = (name: string): string => {
+        const file = files.find(f => f.name === name)
+        if (!file) throw new Error(`test blueprint ${name} not found in wormeyman-tests/`)
+        return readBlueprintString(file.filePath)
+    }
+
+    const errors: string[] = []
+    page.on('pageerror', e => errors.push(String(e)))
+    page.on('console', m => {
+        if (m.type() === 'error') errors.push(m.text())
+    })
+
+    await page.goto('/')
+    await page.waitForFunction(() => (window as any).__fbe_test !== undefined, { timeout: 60_000 })
+
+    const [big, small]: Loaded[] = await page.evaluate(
+        async (sources: string[]) => {
+            const api = (window as any).__fbe_test
+            const out = []
+            for (const src of sources) {
+                let bp = await api.getBlueprintOrBookFromSource(src)
+                // loadBp renders only a book's first blueprint, so select it here and
+                // hand over the blueprint itself - the counts have to agree on which.
+                if (bp.selectBlueprint) bp = bp.selectBlueprint(0)
+                await api.loadBp(bp)
+                out.push({ entities: bp.entities.size, mappings: api.entityContainerCount() })
+            }
+            return out
+        },
+        [find(BIG), find(SMALL)]
+    )
+
+    // The corpus fixed points these rest on: if either blueprint changed size the
+    // test could pass while measuring nothing.
+    expect(big.entities).toBe(243)
+    expect(small.entities).toBe(2)
+
+    // Loading the first blueprint into an empty editor was never in question.
+    expect(big.mappings).toBe(big.entities)
+
+    // The leak: this was 243 - every container of the big blueprint retained,
+    // 241 of them belonging to a blueprint no longer on screen.
+    expect(small.mappings).toBe(small.entities)
+
+    expect(errors, `page errors: ${errors.join(' | ')}`).toEqual([])
+})

--- a/tests/helpers/fbe-test-api.ts
+++ b/tests/helpers/fbe-test-api.ts
@@ -23,6 +23,12 @@ export type RecipeShapeTally = Record<string, string[]>
 export interface FbeTestApi {
     getBlueprintOrBookFromSource: (source: string) => Promise<BlueprintOrBook>
     loadBp: (bp: unknown) => Promise<void>
+    /**
+     * The size of `EntityContainer.mappings`, the static entity-number ->
+     * container index. Loading a blueprint should leave it holding exactly that
+     * blueprint's containers - see tests/entity-container-mappings.spec.ts.
+     */
+    entityContainerCount: () => number
     overlayInfoTally: () => OverlayTally
     /**
      * Defaults to the loaded blueprint; pass one to tally a book entry instead.


### PR DESCRIPTION
Closes #42.

## The leak

`EntityContainer.mappings` is a `static Map<entityNumber, EntityContainer>`. Entries were written in the constructor and removed in exactly one place — the entity's own `destroy` handler — and **replacing a blueprint never destroys the outgoing one's entities**.

`Editor.loadBlueprint` builds the new `BlueprintContainer`, calls `initBP()`, and only then destroys the old one. So every container above the new blueprint's highest entity number stayed in the map, holding its `Entity`, its `EntitySprite`s, its `VisualizationArea` and its info overlay for the life of the tab.

Measured with the new hook, loading a large blueprint then a small one:

| | entities | `mappings` after |
| --- | --- | --- |
| big | 243 | 243 |
| small | 2 | **243** — 241 retained |

A correction to the issue while I was here: it quotes 1636, which is the whole book. Both files are books and `loadBp` renders only entry 0, so 243 is the count that actually reaches the screen.

## The fix

Each container now removes its own entry on its `BlueprintContainer`'s `destroyed` — but **only where the map still points at itself**:

```ts
if (EntityContainer.mappings.get(this.m_Entity.entityNumber) === this) {
    EntityContainer.mappings.delete(this.m_Entity.entityNumber)
}
```

That identity check is the whole trick, and it is why a blanket `clear()` is wrong: `initBP()` for the incoming blueprint runs *before* the outgoing container is destroyed, so the new containers have already claimed the entity numbers the two blueprints share. A blanket clear would delete the entries just written.

The retained sprites, visualization area and info overlay are destroyed at the same time rather than only unlinked — the old container is destroyed with pixi's default `destroyChildren: false`, so they were merely detached from the stage.

## Why the test is shaped this way

`tests/entity-container-mappings.spec.ts` measures **big-then-small**, not growth. Retention is bounded by the largest blueprint seen in the session rather than unbounded, so a "does it keep growing" test would pass while leaking.

Needed a new `entityContainerCount` hook on `window.__fbe_test`, and `EntityContainer` joins the test-only exports in the editor's index — the same pattern already used for `OverlayContainer`, `EntitySprite` and `EntityInfoPanel`.

## On the added destroys

`sprite-data.spec.ts`'s real half swaps blueprints **578 times in a single page**, so this path is well exercised by the existing suite rather than only by the new test.

## Verification

- `npx playwright test` — 29 passed
- `vp test` — 69 passed
- `npm run type-check:gate` — 81, unchanged
- `vp lint` — no errors
- `npm run build` (website) — succeeds; checked because this changes the editor's public exports

## Not addressed

The issue's secondary risk — `OverlayContainer` looking up `entityForCopyData`, the one call site whose key does not come from the live blueprint — is closed as a practical matter by the map no longer holding foreign entries, but I did not add a test for it since it was never reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UMUmQi25ZDoHP7KbSK4Kn