### PR TITLE
test: drive real pointer and keyboard input for the drag-entered modes

### DIFF
--- a/packages/editor/src/Editor.ts
+++ b/packages/editor/src/Editor.ts
@@ -14,7 +14,7 @@ import { loadData } from './core/factorioData'
 import G, { Logger } from './common/globals'
 import { Entity } from './core/Entity'
 import { Blueprint, oilOutpostSettings, IOilOutpostSettings } from './core/Blueprint'
-import { BlueprintContainer, GridPattern } from './containers/BlueprintContainer'
+import { BlueprintContainer, EditorMode, GridPattern } from './containers/BlueprintContainer'
 import { PaintTileContainer } from './containers/PaintTileContainer'
 import { UIContainer } from './UI/UIContainer'
 import { Dialog } from './UI/controls/Dialog'
@@ -114,6 +114,16 @@ export class Editor {
                 oilOutpostSettings[key] = settings[key]
             }
         }
+    }
+
+    /**
+     * The interaction mode the canvas is in, by name - NONE, EDIT, PAINT, PAN,
+     * COPY or DELETE. Exposed for tests/editor-mode-input.spec.ts, which is the
+     * first spec to drive real pointer and keyboard input (issue #44); the name
+     * rather than the enum member so a test does not have to import it.
+     */
+    public get mode(): string {
+        return EditorMode[G.BPC.mode]
     }
 
     public get debug(): boolean {

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -198,6 +198,11 @@ document.addEventListener('paste', (e: ClipboardEvent) => {
 ;(window as any).__fbe_test = {
     getBlueprintOrBookFromSource,
     loadBp,
+    /*
+        The interaction mode the canvas is in, by name. The first thing any spec
+        driving real pointer or keyboard input needs to assert on (issue #44).
+    */
+    editorMode: () => editor.mode,
     loadingScreen,
     getBook: () => book,
     selectBookIndex: async (index: number) => {

--- a/tests/editor-mode-input.spec.ts
+++ b/tests/editor-mode-input.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test'
+
+/*
+    The first spec that dispatches real pointer and keyboard input (issue #44).
+    Every other spec drives the model layer through window.__fbe_test hooks, which
+    was a deliberate trade - injecting blueprints directly is fast and avoids URL
+    length limits - but it means nothing covers the point where a user touches
+    anything, and 29 of the strictNullChecks errors left in #22 live in exactly
+    that code.
+
+    This covers the three mode transitions that need no entity under the cursor:
+
+        NONE -> PAN     left drag on empty space
+        NONE -> COPY    ctrl + left drag
+        NONE -> DELETE  ctrl + right drag
+
+    The bindings are in Editor.ts's ActionRegistry. EDIT and PAINT are not here:
+    EDIT needs the pointer over a specific entity, which needs a world -> screen
+    mapping the editor does not currently expose (`toWorld` goes the other way),
+    and PAINT needs the inventory. Both want a follow-up rather than a fragile
+    aim-at-the-middle-and-hope.
+
+    Deliberately runs against the empty blueprint the editor opens with, so every
+    point on the canvas is empty space and a press cannot be caught by an entity
+    under the cursor.
+
+    Runs against the dev server like the rest of tests/ - see CLAUDE.md for the
+    two servers that have to be up.
+*/
+
+const CANVAS = '#editor'
+
+type Page = import('@playwright/test').Page
+
+const modeOf = (page: Page): Promise<string> =>
+    page.evaluate(() => (window as any).__fbe_test.editorMode())
+
+async function openEditor(page: Page): Promise<{ x: number; y: number }> {
+    await page.goto('/')
+    await page.waitForFunction(() => (window as any).__fbe_test !== undefined, { timeout: 60_000 })
+
+    const box = await page.locator(CANVAS).boundingBox()
+    if (!box) throw new Error('the editor canvas has no bounding box')
+    return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+}
+
+test('a left drag on empty space enters and leaves PAN', async ({ page }) => {
+    const centre = await openEditor(page)
+
+    await page.mouse.move(centre.x, centre.y)
+    expect(await modeOf(page)).toBe('NONE')
+
+    await page.mouse.down()
+    expect(await modeOf(page)).toBe('PAN')
+
+    // The drag itself, so panEnd is reached from a moved viewport rather than a
+    // press and release in place.
+    await page.mouse.move(centre.x + 64, centre.y + 32)
+    expect(await modeOf(page)).toBe('PAN')
+
+    await page.mouse.up()
+    expect(await modeOf(page)).toBe('NONE')
+})
+
+test('ctrl and a left drag enter and leave COPY', async ({ page }) => {
+    const centre = await openEditor(page)
+    await page.mouse.move(centre.x, centre.y)
+
+    await page.keyboard.down('Control')
+    await page.mouse.down()
+    expect(await modeOf(page)).toBe('COPY')
+
+    await page.mouse.move(centre.x + 96, centre.y + 96)
+    expect(await modeOf(page)).toBe('COPY')
+
+    await page.mouse.up()
+    await page.keyboard.up('Control')
+    expect(await modeOf(page)).toBe('NONE')
+})
+
+test('ctrl and a right drag enter and leave DELETE', async ({ page }) => {
+    const centre = await openEditor(page)
+    await page.mouse.move(centre.x, centre.y)
+
+    await page.keyboard.down('Control')
+    await page.mouse.down({ button: 'right' })
+    expect(await modeOf(page)).toBe('DELETE')
+
+    await page.mouse.move(centre.x + 96, centre.y + 96)
+    expect(await modeOf(page)).toBe('DELETE')
+
+    await page.mouse.up({ button: 'right' })
+    await page.keyboard.up('Control')
+    expect(await modeOf(page)).toBe('NONE')
+})
+
+test('the modes do not leak into one another', async ({ page }) => {
+    /*
+        Each entry/exit pair is registered independently, so the thing worth
+        checking is that running them back to back leaves no mode set - an
+        exit that failed to fire would show up here rather than in the tests
+        above, each of which starts from a fresh page.
+    */
+    const centre = await openEditor(page)
+    await page.mouse.move(centre.x, centre.y)
+    const errors: string[] = []
+    page.on('pageerror', e => errors.push(String(e)))
+
+    for (let i = 0; i < 3; i++) {
+        await page.keyboard.down('Control')
+        await page.mouse.down()
+        await page.mouse.move(centre.x + 32, centre.y + 32)
+        await page.mouse.up()
+        await page.keyboard.up('Control')
+        expect(await modeOf(page)).toBe('NONE')
+
+        await page.mouse.down()
+        await page.mouse.move(centre.x, centre.y)
+        await page.mouse.up()
+        expect(await modeOf(page)).toBe('NONE')
+    }
+
+    expect(errors, `page errors: ${errors.join(' | ')}`).toEqual([])
+})

--- a/tests/helpers/fbe-test-api.ts
+++ b/tests/helpers/fbe-test-api.ts
@@ -42,6 +42,11 @@ export interface FbeTestApi {
      * readers that throws on the awkward shapes.
      */
     recipeShapeTally: (blueprint?: unknown) => RecipeShapeTally
+    /**
+     * The interaction mode the canvas is in: NONE, EDIT, PAINT, PAN, COPY or
+     * DELETE. See tests/editor-mode-input.spec.ts.
+     */
+    editorMode: () => string
 }
 
 /**


### PR DESCRIPTION
First step on #44.

## The gap

No spec dispatched a pointer or keyboard event. Every one drove the model layer through `window.__fbe_test` hooks — a deliberate and good trade, but it meant the suite covered parsing, the blueprint model, sprite generation, overlays and wires, and stopped exactly at the point where a user touches anything. **29 of the strictNullChecks errors left in #22 are in that code.**

## What this covers

The three transitions that need no entity under the cursor, per the bindings in `Editor.ts`'s `ActionRegistry`:

| from → to | input |
| --- | --- |
| `NONE` → `PAN` | left drag on empty space |
| `NONE` → `COPY` | ctrl + left drag |
| `NONE` → `DELETE` | ctrl + right drag |

So `panStart`/`panEnd`, `enterCopyMode`/`exitCopyMode` and `enterDeleteMode`/`exitDeleteMode` now run under test — along with the `ActionRegistry`'s modifier matching, which is what decides between *pan* and *copy* on the same mouse button.

It runs against the **empty blueprint the editor opens with**, so every point on the canvas is empty space and no press can be caught by an entity under the cursor.

A fourth test runs the pairs back to back. An exit that failed to fire shows up there, where the individual tests — each starting from a fresh page — would not see it.

## Mutation-checked

Not assumed to work. Both mutations were caught, and with the right selectivity:

| mutation | result |
| --- | --- |
| `exitCopyMode` stops resetting the mode | COPY **and** back-to-back fail; PAN and DELETE pass |
| `panStart` stops setting the mode | only PAN fails |

The second is correctly *not* caught by the back-to-back test, which asserts no mode leaks rather than that a mode was entered.

## The one hook

`Editor` gains a `mode` getter returning the **name** rather than the enum member, so a spec does not have to import `EditorMode`. Same delegate-to-`G.BPC` style as the existing `moveSpeed` and `gridPattern` getters.

## Deliberately not here

`EDIT` and `PAINT`. `EDIT` needs the pointer over a *specific* entity, which needs a world → screen mapping the editor does not currently expose (`toWorld` goes the other way), and `PAINT` needs the inventory. Both deserve a follow-up rather than aiming at the middle of the canvas and hoping.

## Verification

- `npx playwright test` — 32 passed
- `vp test` — 69 passed
- `npm run type-check:gate` — 81, unchanged
- `vp lint` — no errors
- `npm run build` (website) — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UMUmQi25ZDoHP7KbSK4Kn