### PR TITLE
chore: add `npm run localpreview` to launch both dev servers together

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,10 +14,15 @@ Web-based Factorio blueprint viewer/editor using PixiJS. Fork adding Space Age D
 ## Key Commands
 
 ```fish
-# Dev server (from packages/website/)
-vp dev
+# Both dev servers at once, from the repo root - Vite on 8080 and the sprite
+# data on 8081. Checks both ports by name before spawning anything, and one
+# Ctrl-C stops the pair. This is the way to start them.
+npm run localpreview
 
-# Static file server for sprite data (separate terminal, from repo root)
+# ...or run them by hand in two terminals, if you want them separate.
+# Terminal 1, from packages/website/:
+vp dev --port 8080 --strictPort
+# Terminal 2, from the repo root:
 npx serve packages/exporter/data/output -l 8081 --cors
 
 # Build
@@ -177,19 +182,16 @@ Automated tests that load blueprint `.txt` files from `wormeyman-tests/` against
 
 **How it works:** Tests navigate to the editor, wait for init, then call `window.__fbe_test.getBlueprintOrBookFromSource()` and `loadBp()` via `page.evaluate()` to inject blueprints directly (avoiding URL length limits). Console warnings/errors and JS exceptions are captured per blueprint.
 
-**Prerequisites:** Both dev servers must be running before tests:
-
-- Terminal 1: `cd packages/website && vp dev` (Vite on port 8080)
-- Terminal 2: `npx serve packages/exporter/data/output -l 8081 --cors` (sprite data)
+**Prerequisites:** Both dev servers must be running before tests. `npm run localpreview` from the repo root starts both (Vite on 8080, sprite data on 8081) and stops both on Ctrl-C.
 
 Also run `npx playwright install` after any `@playwright/test` version bump. The bundled browser revision moves with it, and every spec then fails on a missing `chrome-headless-shell` executable - which reads like a suite-wide regression rather than a missing download.
 
-Start them in that order and check the port Vite reports. If something else already holds 8080, Vite silently falls back to 8081 and then proxies `/data` to itself, which looks like the sprite server failing rather than a port clash. Pin it with `vp dev --port 8080 --strictPort` to get a clear failure instead.
+The reason to prefer the script over two hand-started terminals is that both servers fail _quietly_ on a port clash, in the same direction. Vite without `--strictPort` falls back to 8081 and then proxies `/data` to itself, which looks like the sprite server failing rather than a port clash; `npx serve` moves to a random high port and says so in one line that scrolls away. `localpreview` checks both ports by name and refuses to start. Note its check probes both loopback families - Vite binds `localhost`, which is `::1` alone on macOS, so an IPv4-only probe reports 8080 free while Vite holds it.
 
-If 8080 is taken, run Vite elsewhere and point the specs at it with `FBE_BASE_URL` rather than editing `playwright.config.ts`. The sprite data server must stay on 8081 either way - the Vite dev proxy hardcodes it.
+If 8080 is taken, run Vite elsewhere and point the specs at it with `FBE_BASE_URL` rather than editing `playwright.config.ts`. The sprite data server must stay on 8081 either way - the Vite dev proxy hardcodes it, which is why `--port` only moves Vite.
 
 ```fish
-cd packages/website; vp dev --port 8090 --strictPort
+npm run localpreview -- --port 8090
 FBE_BASE_URL=http://localhost:8090 npx playwright test
 ```
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "packages/worker"
     ],
     "scripts": {
+        "localpreview": "node scripts/localpreview.mjs",
         "start:website": "npm --workspace=@fbe/website run start",
         "preview:website": "npm --workspace=@fbe/website run preview",
         "start:exporter": "cd ./packages/exporter && cargo run --release",

--- a/scripts/localpreview.mjs
+++ b/scripts/localpreview.mjs
@@ -1,0 +1,212 @@
+// Launches the two dev servers the editor needs, together, and ties their
+// lifetimes to this process so one Ctrl-C stops both.
+//
+//   Vite   :8080  the website (packages/website)
+//   serve  :8081  the sprite data (packages/exporter/data/output)
+//
+// The two are separate because in dev Vite proxies /data to 127.0.0.1:8081
+// rather than serving the sprite output itself. That proxy target is hardcoded,
+// so the sprite server's port is not negotiable - only Vite's is, via --port.
+//
+// Both ports are checked before anything is spawned. That is the point of the
+// script as much as the convenience is: if something else already holds 8080,
+// Vite without --strictPort silently falls back to 8081 and then proxies /data
+// to itself, which presents as the sprite server failing rather than as a port
+// clash. Here it is a named error before either server starts.
+import { spawn } from 'node:child_process'
+import { connect } from 'node:net'
+import { dirname, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const SPRITE_PORT = 8081
+
+export function parseArgs(argv) {
+    const i = argv.indexOf('--port')
+    if (i === -1) return { port: 8080 }
+
+    const raw = argv[i + 1]
+    const port = Number(raw)
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        throw new Error(`--port wants an integer from 1 to 65535, got ${raw ?? '(nothing)'}`)
+    }
+    return { port }
+}
+
+// Probes by connecting rather than by binding, and checks both loopback
+// families. Vite binds localhost, which on macOS is ::1 only - a bind probe
+// against 127.0.0.1 succeeds while Vite is running and would report the port
+// free, which is the one answer this check must never give.
+function isHostFree(port, host) {
+    return new Promise(resolve => {
+        const socket = connect({ port, host })
+        const done = free => {
+            socket.destroy()
+            resolve(free)
+        }
+        socket.setTimeout(500)
+        socket.once('connect', () => done(false))
+        socket.once('timeout', () => done(false)) // Answering slowly still means occupied.
+        socket.once('error', e => done(e.code === 'ECONNREFUSED' || e.code === 'EADDRNOTAVAIL'))
+    })
+}
+
+/** True when nothing is listening on the port, on either loopback family. */
+export async function isPortFree(port) {
+    const results = await Promise.all(['127.0.0.1', '::1'].map(host => isHostFree(port, host)))
+    return results.every(Boolean)
+}
+
+const children = []
+let shuttingDown = false
+
+// Each child is spawned into its own process group so the whole group can be
+// signalled. `npx serve` in particular is a wrapper - killing the npx pid on
+// its own leaves the real server holding 8081, which makes the next run fail
+// the port check for a server this script started.
+function start(name, command, args, cwd) {
+    const child = spawn(command, args, { cwd, detached: true, stdio: ['ignore', 'pipe', 'pipe'] })
+
+    const prefix = line => `[${name}] ${line}`
+    const pipe = (stream, out) => {
+        let buffered = ''
+        stream.setEncoding('utf8')
+        stream.on('data', chunk => {
+            buffered += chunk
+            const lines = buffered.split('\n')
+            buffered = lines.pop() ?? ''
+            for (const line of lines) out.write(`${prefix(line)}\n`)
+        })
+        stream.on('end', () => {
+            if (buffered) out.write(`${prefix(buffered)}\n`)
+        })
+    }
+    pipe(child.stdout, process.stdout)
+    pipe(child.stderr, process.stderr)
+
+    child.on('error', e => {
+        console.error(prefix(`failed to start: ${e.message}`))
+        shutdown(1)
+    })
+    // Neither server is meant to exit on its own, so one leaving means the pair
+    // is broken - take the other down rather than leave a half-working setup
+    // that looks fine until /data 502s.
+    child.on('exit', (code, signal) => {
+        if (shuttingDown) return
+        console.error(prefix(`exited (${signal ?? `code ${code}`}) - stopping the other server`))
+        shutdown(code ?? 1)
+    })
+
+    children.push({ name, child })
+    return child
+}
+
+function shutdown(code) {
+    if (shuttingDown) return
+    shuttingDown = true
+
+    for (const { child } of children) {
+        if (child.exitCode !== null || child.signalCode !== null) continue
+        try {
+            process.kill(-child.pid, 'SIGTERM')
+        } catch {
+            // Already gone, or never got a group - nothing to signal.
+        }
+    }
+
+    // Give them a moment to close their ports, then insist. Without this a
+    // server that ignores SIGTERM keeps 8080 or 8081 and the next run fails
+    // the port check.
+    const timer = setTimeout(() => {
+        for (const { child } of children) {
+            if (child.exitCode !== null || child.signalCode !== null) continue
+            try {
+                process.kill(-child.pid, 'SIGKILL')
+            } catch {
+                // Same.
+            }
+        }
+        process.exit(code)
+    }, 3000)
+    timer.unref()
+
+    const allDown = () =>
+        children.every(({ child }) => child.exitCode !== null || child.signalCode !== null)
+    const poll = setInterval(() => {
+        if (!allDown()) return
+        clearInterval(poll)
+        process.exit(code)
+    }, 50)
+    poll.unref()
+}
+
+async function main() {
+    const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+    const { port } = parseArgs(process.argv.slice(2))
+
+    const taken = []
+    if (!(await isPortFree(port))) taken.push(`${port} (Vite)`)
+    if (!(await isPortFree(SPRITE_PORT))) taken.push(`${SPRITE_PORT} (sprite data)`)
+    if (taken.length > 0) {
+        console.error(`Port already in use: ${taken.join(', ')}.`)
+        console.error('Stop whatever is holding it, or find it with:  lsof -nP -iTCP -sTCP:LISTEN')
+        if (taken.some(t => t.startsWith(`${port} `))) {
+            console.error(
+                `To run Vite elsewhere instead:  npm run localpreview -- --port 8090\n` +
+                    `then point the Playwright specs at it with FBE_BASE_URL=http://localhost:8090.`
+            )
+        }
+        if (taken.some(t => t.startsWith(`${SPRITE_PORT} `))) {
+            console.error(
+                `Port ${SPRITE_PORT} has no alternative - the Vite dev proxy targets it directly.`
+            )
+        }
+        process.exit(1)
+    }
+
+    for (const signal of ['SIGINT', 'SIGTERM']) {
+        process.on(signal, () => {
+            console.log(`\nStopping both servers...`)
+            shutdown(0)
+        })
+    }
+
+    // Vite first, matching the order in CLAUDE.md, and with --strictPort so a
+    // clash that appears between the check above and the bind is still an error
+    // rather than a silent fallback.
+    start(
+        'vite',
+        'vp',
+        ['dev', '--port', String(port), '--strictPort'],
+        join(repoRoot, 'packages/website')
+    )
+    // --yes so a machine without `serve` cached installs it instead of sitting
+    // on an install prompt that never gets answered.
+    start(
+        'sprites',
+        'npx',
+        [
+            '--yes',
+            'serve',
+            join(repoRoot, 'packages/exporter/data/output'),
+            '-l',
+            String(SPRITE_PORT),
+            '--cors',
+        ],
+        repoRoot
+    )
+
+    console.log(`Editor:      http://localhost:${port}`)
+    console.log(`Sprite data: http://localhost:${SPRITE_PORT}`)
+    if (port !== 8080) {
+        console.log(`\nPlaywright:  FBE_BASE_URL=http://localhost:${port} npx playwright test`)
+    }
+    console.log(`\nCtrl-C stops both.\n`)
+}
+
+const isMain = import.meta.url === pathToFileURL(process.argv[1]).href
+if (isMain) {
+    main().catch(e => {
+        console.error(e.message)
+        process.exit(1)
+    })
+}

--- a/scripts/localpreview.test.mjs
+++ b/scripts/localpreview.test.mjs
@@ -1,0 +1,64 @@
+import { test } from 'vite-plus/test'
+import assert from 'node:assert/strict'
+import { createServer } from 'node:net'
+import { parseArgs, isPortFree } from './localpreview.mjs'
+
+/** Listens on one loopback family and resolves the port it got. */
+function listenOn(host) {
+    return new Promise((resolve, reject) => {
+        const server = createServer()
+        server.once('error', reject)
+        server.listen(0, host, () => resolve({ server, port: server.address().port }))
+    })
+}
+
+const close = server => new Promise(resolve => server.close(resolve))
+
+test('parseArgs defaults Vite to 8080', () => {
+    assert.deepEqual(parseArgs([]), { port: 8080 })
+})
+
+test('parseArgs reads --port', () => {
+    assert.deepEqual(parseArgs(['--port', '8090']), { port: 8090 })
+})
+
+test('parseArgs rejects a non-port rather than silently defaulting', () => {
+    // Silently falling back to 8080 here would start Vite on a port the caller
+    // did not ask for and then report success, which is the same class of
+    // confusion the port check exists to prevent.
+    assert.throws(() => parseArgs(['--port', 'lol']), /wants an integer/)
+    assert.throws(() => parseArgs(['--port']), /wants an integer/)
+    assert.throws(() => parseArgs(['--port', '70000']), /wants an integer/)
+})
+
+test('isPortFree is true for a port nothing is listening on', async () => {
+    // Bind and release to get a port the OS just confirmed is assignable.
+    const { server, port } = await listenOn('127.0.0.1')
+    await close(server)
+    assert.equal(await isPortFree(port), true)
+})
+
+test('isPortFree is false for an IPv4 listener', async () => {
+    const { server, port } = await listenOn('127.0.0.1')
+    try {
+        assert.equal(await isPortFree(port), false)
+    } finally {
+        await close(server)
+    }
+})
+
+test('isPortFree is false for an IPv6-only listener', async () => {
+    /*
+        The case that motivated probing both families. Vite binds localhost,
+        which on macOS resolves to ::1 alone, so a check that only looked at
+        127.0.0.1 reported the port free while Vite was holding it - and the
+        script would then launch a second Vite that loses the bind, or worse
+        fall through to the silent-fallback behaviour the check exists to stop.
+    */
+    const { server, port } = await listenOn('::1')
+    try {
+        assert.equal(await isPortFree(port), false)
+    } finally {
+        await close(server)
+    }
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -149,6 +149,13 @@ export default defineConfig({
                 globals: {
                     console: 'readonly',
                     process: 'readonly',
+                    // Node's timer family. Declared as a group rather than
+                    // one at a time so the next script reaching for the other
+                    // half of a pair does not fail lint for it.
+                    setTimeout: 'readonly',
+                    clearTimeout: 'readonly',
+                    setInterval: 'readonly',
+                    clearInterval: 'readonly',
                 },
             },
         ],


### PR DESCRIPTION
Starting the editor in dev needs two servers - Vite on 8080 and the sprite data on 8081, which Vite proxies `/data` to - and that meant two terminals plus remembering which port is which.

```fish
npm run localpreview                  # both, one Ctrl-C stops the pair
npm run localpreview -- --port 8090   # moves Vite only
```

Output is line-prefixed `[vite]` / `[sprites]` so the two are tellable apart.

## The port check is as much the point as the convenience

Both servers fail *quietly* on a clash, and in the same direction:

- Vite without `--strictPort` falls back to 8081 and then proxies `/data` to itself, which presents as the sprite server failing rather than as a port clash.
- `npx serve` moves to a random high port and says so in one line that scrolls away. This machine had two orphaned copies from a previous session sitting on ports 56581 and 59884 for exactly that reason.

So both ports are checked by name before anything spawns, and Vite gets `--strictPort` for the gap between the check and the bind.

## Two things that were wrong on the first pass

**The probe has to check both loopback families.** It originally tested availability by binding `127.0.0.1`. Vite binds `localhost`, which resolves to `::1` alone on macOS - so the check reported 8080 free while Vite was holding it, which is the one answer it must never give. It now probes by connecting, on both families. Pinned in `scripts/localpreview.test.mjs`; reverting to the single-family probe fails that test and none of the other five.

**`npx serve` needs a process-group kill.** It is a wrapper, and signalling its pid alone leaves the real server holding 8081 - which then fails the port check on the next run, for a server this script started. Children are spawned detached and the group is signalled, with a SIGKILL escalation after 3s.

Either server exiting on its own takes the other down, rather than leaving a half-working setup that looks fine until `/data` stops resolving.

## Verification

- Both servers up, and `/data/data.json` resolving **through** the Vite proxy (200) - the integration the two-server setup exists for.
- SIGINT releases both ports with no stray `vite` or `serve` left behind.
- Clash path reports the right port by name, including the IPv6-only Vite.
- `--port` passthrough via `npm run ... --` reaches the script.
- 22 tests pass under the existing `gate` vitest project; `vp lint` and `vp fmt` clean.

Tests land in `scripts/localpreview.test.mjs`, which `scripts/**/*.test.mjs` in the `gate` project already collects - no config change needed.

CLAUDE.md now points at the script and keeps the by-hand form as an alternative, with `--strictPort` on the Vite line this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJg7PoKTMaJuaVsL32jGJx