### PR TITLE
fix(types): clear TextInput's 15 strictNullChecks errors (#22)

### DIFF
--- a/packages/editor/src/UI/controls/TextInput.ts
+++ b/packages/editor/src/UI/controls/TextInput.ts
@@ -54,7 +54,9 @@ type PreviousData = {
 class OriginalTextInput extends Container {
     private _input_style: InputStyles
     private _placeholder: string
-    private _box_generator: BoxGenerator
+    // Absent when no `box` option was given, which _renderInternal already
+    // returns early on - the declaration was the only thing claiming otherwise.
+    private _box_generator: BoxGenerator | undefined
     private _box_cache: Record<State, Container>
     private _previous: Partial<PreviousData>
     private _dom_added: boolean
@@ -67,11 +69,13 @@ class OriginalTextInput extends Container {
     private _max_length: number
     private _multiline: boolean
     private _renderer: Renderer
-    private _canvas_bounds: IRect
-    private _box: Container
+    // Both are unset until the first render, and both are read through an
+    // `if (!...)` guard that predates this - see _renderInternal.
+    private _canvas_bounds: IRect | undefined
+    private _box: Container | undefined
     public state: State
 
-    public constructor(options?: Options) {
+    public constructor(options: Options) {
         super()
         this._input_style = {
             position: 'absolute',
@@ -86,7 +90,7 @@ class OriginalTextInput extends Container {
         if (options.box)
             this._box_generator =
                 typeof options.box === 'function' ? options.box : DefaultBoxGenerator(options.box)
-        else this._box_generator = null
+        else this._box_generator = undefined
 
         this._multiline = !!options.multiline
 
@@ -182,7 +186,11 @@ class OriginalTextInput extends Container {
 
     public setInputStyle<K extends keyof InputStyles>(key: K, value: InputStyles[K]): void {
         this._input_style[key] = value
-        this._dom_input.style[key] = value
+        // InputStyles is a Partial, so undefined is a value it can carry, and it
+        // means "no such style". The empty string is how CSSOM says that -
+        // assigning undefined would stringify to "undefined" and be dropped as
+        // an invalid value, leaving whatever was there before.
+        this._dom_input.style[key] = value ?? ''
 
         if (this._renderer) this._update()
     }
@@ -204,7 +212,7 @@ class OriginalTextInput extends Container {
         }
 
         for (const [key, value] of Object.entries(this._input_style)) {
-            this._dom_input.style[key as keyof InputStyles] = value
+            this._dom_input.style[key as keyof InputStyles] = value ?? ''
         }
     }
 
@@ -219,7 +227,14 @@ class OriginalTextInput extends Container {
     }
 
     private _onInputKeyDown(): void {
-        this._selection = [this._dom_input.selectionStart, this._dom_input.selectionEnd]
+        /*
+            The DOM types these `number | null`, null being what an input whose
+            type does not support selection answers. _createDOMInput only ever
+            makes a textarea or a text input, both of which do, so the null arm
+            is unreachable here - 0 rather than a throw because the only
+            consumer is a setSelectionRange call restoring a restricted value.
+        */
+        this._selection = [this._dom_input.selectionStart ?? 0, this._dom_input.selectionEnd ?? 0]
 
         // this.emit('keydown', e.keyCode)
     }
@@ -275,7 +290,7 @@ class OriginalTextInput extends Container {
     private _updateBox(): void {
         if (!this._box_generator) return
 
-        if (this._needsNewBoxCache()) this._buildBoxCache()
+        if (this._needsNewBoxCache()) this._buildBoxCache(this._box_generator)
 
         if (this.state === this._previous.state && this._box === this._box_cache[this.state]) return
 
@@ -336,18 +351,19 @@ class OriginalTextInput extends Container {
 
     // CACHING OF INPUT BOX GRAPHICS
 
-    private _buildBoxCache(): void {
+    /*
+        Takes the generator rather than reading the field, so the one caller's
+        `if (!this._box_generator) return` is what makes this callable at all.
+        The alternative was a second check here that could never fire.
+    */
+    private _buildBoxCache(box_generator: BoxGenerator): void {
         this._destroyBoxCache()
 
         const states = ['DEFAULT', 'FOCUSED', 'DISABLED']
         const input_bounds = this._getDOMInputBounds()
 
         for (const state of states) {
-            this._box_cache[state] = this._box_generator(
-                input_bounds.width,
-                input_bounds.height,
-                state
-            )
+            this._box_cache[state] = box_generator(input_bounds.width, input_bounds.height, state)
         }
 
         this._previous.input_bounds = input_bounds
@@ -356,7 +372,7 @@ class OriginalTextInput extends Container {
     private _destroyBoxCache(): void {
         if (this._box) {
             this.removeChild(this._box)
-            this._box = null
+            this._box = undefined
         }
 
         for (const obj of Object.values(this._box_cache)) {
@@ -416,7 +432,13 @@ class OriginalTextInput extends Container {
         return `matrix(${[m.a, m.b, m.c, m.d, m.tx, m.ty].join(',')})`
     }
 
-    private _comparePixiMatrices(m1: Matrix, m2: Matrix): boolean {
+    /*
+        Only the second parameter is widened. m1 is always `this.worldTransform`,
+        which pixi guarantees; m2 comes out of `_previous`, which is a Partial and
+        is empty until the first render. Saying `| undefined` on both would push
+        a check onto a caller that cannot pass one.
+    */
+    private _comparePixiMatrices(m1: Matrix, m2: Matrix | undefined): boolean {
         if (!m1 || !m2) return false
         return (
             m1.a === m2.a &&
@@ -428,7 +450,9 @@ class OriginalTextInput extends Container {
         )
     }
 
-    private _compareClientRects(r1: IRect, r2: IRect): boolean {
+    // Both widened here, unlike _comparePixiMatrices: r1 is `_canvas_bounds`,
+    // which is unset until the first _renderInternal.
+    private _compareClientRects(r1: IRect | undefined, r2: IRect | undefined): boolean {
         if (!r1 || !r2) return false
         return (
             r1.left === r2.left &&

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 76
+    "maxErrors": 61
 }

--- a/tests/text-input.spec.ts
+++ b/tests/text-input.spec.ts
@@ -1,0 +1,220 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprint as encode, packVersion as version } from './helpers/encode-blueprint'
+
+/*
+    The first coverage `UI/controls/TextInput.ts` has had.
+
+    It is a port of Mwni's pixi-text-input, and it is the odd one out among the
+    UI controls: it is not drawn with pixi at all, it appends a real DOM <input>
+    over the canvas and keeps it positioned. So unlike everything else in UI/,
+    what it produces can be asserted on directly, without a tally or a digest -
+    the element is either in the document with the right value and styles or it
+    is not.
+
+    Reached the way a user reaches it: hover an entity to enter EDIT, then left
+    click, which is the `openEntityGUI` action. That route only became drivable
+    with the EDIT coverage from issue #44.
+
+    Runs against the dev server like the rest of tests/ - see CLAUDE.md for the
+    two servers that have to be up.
+*/
+
+type Page = import('@playwright/test').Page
+
+const STATION = 'Iron Pickup'
+
+const TRAIN_STOP = encode({
+    item: 'blueprint',
+    version: version(2, 0, 55),
+    entities: [
+        {
+            entity_number: 1,
+            name: 'train-stop',
+            position: { x: 1, y: 1 },
+            direction: 0,
+            station: STATION,
+            manual_trains_limit: 4,
+        },
+    ],
+})
+
+/** Loads the train stop and answers where it is on screen. */
+async function loadTrainStop(page: Page): Promise<{ x: number; y: number }> {
+    await page.goto('/')
+    await page.waitForFunction(() => (window as any).__fbe_test !== undefined, { timeout: 60_000 })
+    await page.evaluate(async (src: string) => {
+        const t = (window as any).__fbe_test
+        await t.loadBp(await t.getBlueprintOrBookFromSource(src))
+    }, TRAIN_STOP)
+
+    const at = await page.evaluate(() => (window as any).__fbe_test.entityScreenPosition(1))
+    if (!at) throw new Error('the train stop is not in the loaded blueprint')
+    return at
+}
+
+/*
+    Hovers the entity and left clicks, which is the `openEntityGUI` action.
+
+    Steps away from the entity first, because hovering is driven by GridData's
+    `update32`, which only fires when the pointer crosses a tile boundary -
+    moving to a point the pointer already occupies emits nothing and leaves the
+    mode at NONE. That matters on the second open in the lifecycle test.
+*/
+async function openEditorAt(page: Page, at: { x: number; y: number }): Promise<void> {
+    await page.mouse.move(at.x, at.y + 240)
+    await page.mouse.move(at.x, at.y)
+    expect(await page.evaluate(() => (window as any).__fbe_test.editorMode())).toBe('EDIT')
+
+    await page.mouse.down()
+    await page.mouse.up()
+}
+
+async function openEntityEditor(page: Page): Promise<{ x: number; y: number }> {
+    const at = await loadTrainStop(page)
+    await openEditorAt(page, at)
+    return at
+}
+
+/*
+    The elements TextInput put on the page, told apart from the settings pane's
+    own inputs (55 of them at rest) by having an inline style - TextInput writes
+    _input_style onto the element, nothing else on the page does.
+*/
+const textInputValues = (page: Page): Promise<string[]> =>
+    page.evaluate(() =>
+        ([...document.querySelectorAll('input, textarea')] as HTMLInputElement[])
+            .filter(el => el.style.cssText !== '')
+            .map(el => el.value)
+    )
+
+test('the entity editor puts its inputs on the page and takes them away again', async ({
+    page,
+}) => {
+    /*
+        TextInput manages the element's presence in the document by hand, so the
+        assertion is the exact set rather than "at least one": a close that left
+        the element behind shows up here as a surplus and nowhere else, and
+        closing and reopening would then pile a fresh pair of inputs over the
+        canvas every time. Confirmed by mutation - stopping _onRemoved from
+        detaching fails this and neither of the other two.
+
+        _getDOMInputBounds has a third append/remove pair for measuring, and this
+        does *not* cover it: it only appends when the element is not already in
+        the document, which by the time it runs here it is. Breaking that removal
+        passes all three tests.
+    */
+    const at = await openEntityEditor(page)
+
+    // The station name box and the trains-limit box, and nothing else.
+    expect(await textInputValues(page)).toEqual([STATION, '4'])
+
+    await page.keyboard.press('Escape')
+    expect(await textInputValues(page)).toEqual([])
+
+    await openEditorAt(page, at)
+    expect(await textInputValues(page)).toEqual([STATION, '4'])
+})
+
+test('the input carries the styles TextInput was constructed with', async ({ page }) => {
+    /*
+        _createDOMInput writes every entry of _input_style onto the element, and
+        that loop is the only consumer of the option. A style silently dropped
+        there leaves the input unstyled and floating over the canvas rather than
+        sitting in the box drawn for it, which no mode or sprite assertion can
+        see.
+    */
+    await openEntityEditor(page)
+
+    const styled = await page.evaluate(() => {
+        const el = [...document.querySelectorAll('input')].find(i => i.value === 'Iron Pickup') as
+            | HTMLInputElement
+            | undefined
+        if (!el) return undefined
+        /*
+            Longhands rather than the shorthands the constructor writes. Setting
+            `border` to 'none' and reading `border` back gives '' - the CSSOM
+            will not re-serialise a shorthand whose longhands came out mixed -
+            so the shorthand tells you nothing about whether the write landed.
+        */
+        return {
+            position: el.style.position,
+            width: el.style.width,
+            color: el.style.color,
+            borderStyle: el.style.borderStyle,
+            outlineStyle: el.style.outlineStyle,
+            transformOrigin: el.style.transformOrigin,
+            // From the constructor's literal rather than from options, so this
+            // also pins that the defaults survive the spread of `options.input`.
+            lineHeight: el.style.lineHeight,
+            fontFamily: el.style.fontFamily,
+            fontSize: el.style.fontSize,
+        }
+    })
+
+    expect(styled).toEqual({
+        position: 'absolute',
+        width: '250px',
+        color: 'black',
+        borderStyle: 'none',
+        outlineStyle: 'none',
+        transformOrigin: '0px 0px',
+        lineHeight: '1',
+        fontFamily: 'Roboto, sans-serif',
+        /*
+            Empty, and that is a bug being recorded rather than the expected
+            answer. style.ts has `fontSize: 14`, a number, and TextInput
+            interpolates it straight into a CSS value - so the element is asked
+            for `font-size: 14`, which has no unit, is invalid, and is dropped.
+            Every text box in the editor renders at the browser default instead
+            of 14px. Left alone here because fixing it changes what the UI looks
+            like, which does not belong in a type-error batch; this line moves
+            when someone fixes it.
+        */
+        fontSize: '',
+    })
+})
+
+/** Focuses the DOM input currently holding `value`. */
+async function focusInputWithValue(page: Page, value: string): Promise<void> {
+    await page.evaluate((v: string) => {
+        const el = [...document.querySelectorAll('input')].find(i => i.value === v)
+        if (!el) throw new Error(`no input holding ${v}`)
+        el.focus()
+    }, value)
+}
+
+const valueOf = (page: Page, selectorValue: string): Promise<string | undefined> =>
+    page.evaluate(
+        (v: string) =>
+            ([...document.querySelectorAll('input')] as HTMLInputElement[]).find(
+                i => i.style.cssText !== '' && (i.value === v || i.value.startsWith(v))
+            )?.value,
+        selectorValue
+    )
+
+test('a numeric-only box rejects what does not match its restriction', async ({ page }) => {
+    /*
+        The trains-limit box is built with numericOnly, which sets `restrict`.
+        This is the only test that runs the input event path rather than just
+        construction: _onInputKeyDown records the selection, _onInputInput fires,
+        and _applyRestriction either accepts the new text or puts the old one
+        back and restores the caret from that recorded selection.
+
+        Worth having beyond the round trip, because the reverting branch is the
+        one that reads `_selection` - and a caret restored to the wrong place is
+        the kind of thing that only shows up when a second character is typed.
+    */
+    await openEntityEditor(page)
+    await focusInputWithValue(page, '4')
+
+    await page.keyboard.press('End')
+    await page.keyboard.type('7')
+    expect(await valueOf(page, '47')).toBe('47')
+
+    // Rejected, and the caret must survive it - hence typing again after.
+    await page.keyboard.type('x')
+    expect(await valueOf(page, '47')).toBe('47')
+
+    await page.keyboard.type('9')
+    expect(await valueOf(page, '479')).toBe('479')
+})


### PR DESCRIPTION
Gate **76 → 61** — exactly the file's own count, no net ripple. Playwright 44 → 47.

## Not one lying type, but one lying *habit*

`TextInput.ts` is a port of Mwni's pixi-text-input, and its field and parameter declarations assert a presence the logic never assumed. Every site fixed here **already had the runtime check**:

```ts
if (!this._box_generator) return
if (!this._canvas_bounds) return
if (!m1 || !m2) return false
if (this._box) { ... }
```

So nothing gained a guard — the declarations were brought in line with guards that were always there. That also settles the `need()` question: the code is *testing* for absence, and CLAUDE.md's note about never rewriting a read that tests for absence applies directly.

| change | why |
| --- | --- |
| `options?: Options` → required | 7 of the 15. The only caller is `TextInput`'s own `super()`, which always passes `renderer`, `input` and `box` — and `options.renderer` was read unconditionally regardless |
| `_box_generator`, `_box`, `_canvas_bounds` → `\| undefined` | all three read through the falsy guards above; `= null` became `= undefined`, which behaves identically at those sites |
| `_comparePixiMatrices` widens **only** its second parameter | `m1` is always `this.worldTransform`. Widening it too would push a check onto a caller that cannot pass undefined |
| `_compareClientRects` widens **both** | `r1` is `_canvas_bounds`, unset until the first render |
| `_buildBoxCache(box_generator)` | takes it instead of reading the field, so the one caller's guard is what makes it callable. The alternative was a second check that could never fire |
| `?? ''` on the two style writes | `InputStyles` is a `Partial`, so undefined is a value it carries, and `''` is how CSSOM says "no such style". Assigning undefined stringifies to `"undefined"`, is dropped as invalid, and leaves the previous value |
| `?? 0` on `selectionStart`/`End` | the DOM types these nullable for input types that don't support selection; `_createDOMInput` only ever makes a textarea or text input |

## Tests, and why there are any

The change is **behaviour-neutral end to end**, which by the #37 and #49 precedent means no fixture is owed. These exist for a different reason: `TextInput` had **no coverage at all**, and the EDIT coverage from #44 just made it reachable — hover an entity, left click, `openEntityGUI`. It's also the one UI control that can be asserted on directly, since it appends a real DOM `<input>` over the canvas rather than drawing with pixi.

Each test mutation-checked, each failing only itself:

| mutation | fails |
| --- | --- |
| `_createDOMInput` drops the style loop | styles test only |
| `_selection` records `[0, 0]` instead of the caret | restriction test only — which is what proves it covers the `?? 0` above |
| `_onRemoved` stops detaching | lifecycle test only |

## Two things found and deliberately left alone

Both written down in the spec rather than fixed, since neither belongs in a type-error batch.

1. **Every text box in the editor renders at the browser default size, not 14px.** `style.ts` has `fontSize: 14` — a number — which `TextInput` interpolates straight into a CSS value. `font-size: 14` has no unit, is invalid, and is silently dropped. Fixing it changes what the UI looks like, so it wants its own change; the test pins `fontSize: ''` and will move when someone does it.
2. **`_getDOMInputBounds`'s measure-and-detach path is uncovered.** It only appends when the element is not already in the document, which by the time it runs here it is — so breaking that removal passes all three tests. Recorded so the next person doesn't assume the count assertion covers it.

`vp test` 75 passed · `npx playwright test` 47 passed · gate 61 at baseline 61 · `vp lint` and `vp fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJg7PoKTMaJuaVsL32jGJx