### PR TITLE
fix: survive a stale stored keybind, and clear actions.ts (#22)

### DIFF
--- a/packages/editor/src/actions.ts
+++ b/packages/editor/src/actions.ts
@@ -192,7 +192,12 @@ export class ActionRegistry {
         this.sortedActions.push(a)
         this.sort()
     }
-    public get(name: string): Action {
+    /**
+     * Undefined for a name that was never registered. Deliberately not a throw:
+     * the one caller is importKeybinds, reading persisted user data that
+     * outlives any given set of action names.
+     */
+    public get(name: string): Action | undefined {
         return this.actions.get(name)
     }
     public forEach(cb: (action: Action) => void): void {
@@ -290,8 +295,17 @@ class Action {
     private modifiers?: Modifiers
     private callbacks: Callbacks
     private modifierCallbacks?: Callbacks
-    private isActive = false
-    private isActiveModifier = false
+    /*
+        The release callback of a press currently being held, rather than a
+        boolean saying there is one. `isActive = succeeded && !!onRelease` and
+        the later `if (isActive) callbacks.onRelease()` were the same invariant
+        stated twice, in two methods, in a form the compiler could not check -
+        holding the callback makes it one statement that it can. Undefined
+        covers both "nothing held" and "held, but this action has no release",
+        which the boolean also conflated and which callers never told apart.
+    */
+    private activeRelease: (() => void) | undefined
+    private activeModifierRelease: (() => void) | undefined
     private onKeyComboChange: () => void
 
     public constructor(name: string, data: IAction, onKeyComboChange: () => void) {
@@ -354,7 +368,9 @@ class Action {
 
     public set keyCombo(value: string) {
         const parts = value.split('+')
-        const getModifier = (name: string): keyof Modifiers => {
+        // Undefined for a part that is not a modifier name, which the loop below
+        // already treats as "this whole combo is unparseable" and bails on.
+        const getModifier = (name: string): keyof Modifiers | undefined => {
             switch (name) {
                 case 'Control':
                     return 'control'
@@ -374,7 +390,9 @@ class Action {
         }
 
         const last = parts[parts.length - 1]
-        const getTrigger = (name: string): ITrigger => {
+        // Undefined for the empty name, which is what an unbound combo
+        // serialises to - `if (!trigger) return` below is what handles it.
+        const getTrigger = (name: string): ITrigger | undefined => {
             switch (name) {
                 case 'ClickL':
                     return { button: MouseButton.Left }
@@ -412,13 +430,15 @@ class Action {
 
     private hasModifier(modifier: ModifierKey): boolean {
         if (!this.modifiers) return false
+        // Every field of Modifiers is optional, and an absent one means the
+        // action does not require that modifier - the same answer as false.
         switch (modifier) {
             case 'Control':
-                return this.modifiers.control
+                return this.modifiers.control ?? false
             case 'Shift':
-                return this.modifiers.shift
+                return this.modifiers.shift ?? false
             case 'Alt':
-                return this.modifiers.alt
+                return this.modifiers.alt ?? false
         }
     }
 
@@ -443,10 +463,10 @@ class Action {
         if (!this.triggerMatches(e)) return false
         if (!this.hasModifiers(modifiers)) return false
 
-        // assert(!this.isActive)
+        // assert(this.activeRelease === undefined)
 
         const succeeded = this.callbacks.onPress()
-        this.isActive = succeeded && !!this.callbacks.onRelease
+        this.activeRelease = succeeded ? this.callbacks.onRelease : undefined
         return succeeded
     }
     public release(e: TriggerEvent): void {
@@ -464,9 +484,9 @@ class Action {
         }
     }
     private forceReleaseB(): void {
-        if (this.isActive) {
-            this.callbacks.onRelease()
-            this.isActive = false
+        if (this.activeRelease) {
+            this.activeRelease()
+            this.activeRelease = undefined
         }
     }
 
@@ -475,19 +495,19 @@ class Action {
         if (!this.hasModifier(modifier)) return false
         if (!this.hasModifiers(modifiers)) return false
 
-        // assert(!this.isActiveModifier)
+        // assert(this.activeModifierRelease === undefined)
 
         const succeeded = this.modifierCallbacks.onPress()
-        this.isActiveModifier = succeeded && !!this.modifierCallbacks.onRelease
+        this.activeModifierRelease = succeeded ? this.modifierCallbacks.onRelease : undefined
         return succeeded
     }
     public releaseMod(modifier: ModifierKey): void {
         if (this.hasModifier(modifier)) this.forceReleaseM()
     }
     private forceReleaseM(): void {
-        if (this.isActiveModifier) {
-            this.modifierCallbacks.onRelease()
-            this.isActiveModifier = false
+        if (this.activeModifierRelease) {
+            this.activeModifierRelease()
+            this.activeModifierRelease = undefined
         }
     }
 
@@ -515,7 +535,21 @@ function importKeybinds(keybinds: Record<string, string>): void {
     if (!keybinds) return
 
     for (const [name, kc] of Object.entries(keybinds)) {
-        G.actions.get(name).keyCombo = kc
+        const action = G.actions.get(name)
+        /*
+            Skip rather than throw. These names come from localStorage and
+            outlive the action list that produced them, so an action renamed or
+            dropped in any release leaves one behind - and throwing here cost
+            far more than the one keybind: it abandoned the rest of the loop and
+            escaped into registerActions, which then never attached the
+            visibilitychange listener that writes keybinds back. The stale entry
+            was therefore unclearable by normal use and failed again every load.
+        */
+        if (action === undefined) {
+            console.warn(`Ignoring stored keybind for unknown action "${name}".`)
+            continue
+        }
+        action.keyCombo = kc
     }
 }
 

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -222,6 +222,12 @@ document.addEventListener('paste', (e: ClipboardEvent) => {
         difference is the whole of issue #53.
     */
     paintContainerVisible: () => editor.paintContainerVisible,
+    /*
+        The keybinds that differ from their defaults, which is what
+        importKeybinds was asked to apply and what exportKeybinds would persist.
+        Empty means every action is on its default combo.
+    */
+    keyCombos: () => EDITOR.exportKeybinds(),
     loadingScreen,
     getBook: () => book,
     selectBookIndex: async (index: number) => {

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 61
+    "maxErrors": 52
 }

--- a/tests/helpers/fbe-test-api.ts
+++ b/tests/helpers/fbe-test-api.ts
@@ -61,6 +61,13 @@ export interface FbeTestApi {
     entityScreenPosition: (entityNumber: number) => { x: number; y: number } | undefined
     /** The hovered entity's number, or undefined in any mode but EDIT. */
     hoveredEntityNumber: () => number | undefined
+    /** Whether the paint container is drawn; undefined when there is none. */
+    paintContainerVisible: () => boolean | undefined
+    /**
+     * Action name -> key combo, for the actions not on their default combo.
+     * Empty when every action is default. See tests/keybinds.spec.ts.
+     */
+    keyCombos: () => Record<string, string>
 }
 
 /**

--- a/tests/keybinds.spec.ts
+++ b/tests/keybinds.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test'
+
+/*
+    Keybind import, which runs at startup against whatever is in localStorage.
+
+    That input is *persisted user data of unbounded age* - it survives every
+    update - so it is the one place in the editor guaranteed to be handed names
+    that no longer exist. An action renamed or removed in any release leaves a
+    stale entry behind, and the entry stays there failing on every load, because
+    nothing rewrites localStorage until keybinds are exported again.
+
+    The corpus cannot reach any of this: it is neither a blueprint nor input, and
+    the specs all start from an empty localStorage. Seeded with addInitScript,
+    which runs before the page's own scripts.
+
+    Runs against the dev server like the rest of tests/ - see CLAUDE.md for the
+    two servers that have to be up.
+*/
+
+type Page = import('@playwright/test').Page
+
+/** Seeds localStorage the way a previous session would have left it. */
+async function withStoredKeybinds(page: Page, keybinds: Record<string, string>): Promise<string[]> {
+    const errors: string[] = []
+    page.on('pageerror', e => errors.push(String(e)))
+    page.on('console', m => {
+        if (m.type() === 'error') errors.push(m.text())
+    })
+
+    await page.addInitScript((kb: Record<string, string>) => {
+        localStorage.setItem('keybinds2', JSON.stringify(kb))
+    }, keybinds)
+    await page.goto('/')
+    await page.waitForFunction(() => (window as any).__fbe_test !== undefined, { timeout: 60_000 })
+    return errors
+}
+
+const keyCombos = (page: Page): Promise<Record<string, string>> =>
+    page.evaluate(() => (window as any).__fbe_test.keyCombos())
+
+test('stored keybinds are applied at startup', async ({ page }) => {
+    const errors = await withStoredKeybinds(page, { rotate: 'KeyT', pipette: 'Shift+KeyP' })
+
+    expect(await keyCombos(page)).toEqual({ rotate: 'KeyT', pipette: 'Shift+KeyP' })
+    expect(errors.join(' | ')).not.toContain('TypeError')
+})
+
+test('a keybind naming an action that no longer exists takes the rest down with it', async ({
+    page,
+}) => {
+    /*
+        Pins the bug rather than the intent.
+
+        ActionRegistry.get is declared `: Action` but is a bare Map.get, so an
+        unknown name gives undefined and `.keyCombo = kc` throws. The throw
+        happens *inside* the import loop, so it is not one lost keybind - every
+        entry after the stale one is lost too, and the ordering is
+        Object.entries order, which makes which ones survive an accident of how
+        the object was serialised.
+
+        It also escapes importKeybinds entirely: the call is unguarded in
+        registerActions, so the `visibilitychange` listener registered after it
+        never gets attached and keybinds stop being persisted for the session.
+        That is the part that makes it self-perpetuating - the stale entry
+        cannot be cleaned up by normal use.
+    */
+    const errors = await withStoredKeybinds(page, {
+        'no-such-action-anymore': 'KeyZ',
+        rotate: 'KeyT',
+    })
+
+    expect(errors.join(' | ')).toContain('TypeError')
+    // rotate came after the stale entry and never got applied.
+    expect(await keyCombos(page)).toEqual({})
+})

--- a/tests/keybinds.spec.ts
+++ b/tests/keybinds.spec.ts
@@ -45,31 +45,42 @@ test('stored keybinds are applied at startup', async ({ page }) => {
     expect(errors.join(' | ')).not.toContain('TypeError')
 })
 
-test('a keybind naming an action that no longer exists takes the rest down with it', async ({
-    page,
-}) => {
+test('a keybind naming an action that no longer exists is skipped, not fatal', async ({ page }) => {
     /*
-        Pins the bug rather than the intent.
+        The stale entry used to throw - ActionRegistry.get was declared
+        `: Action` but is a bare Map.get, so an unknown name gave undefined and
+        `.keyCombo = kc` threw. Inside the import loop, so it was never one lost
+        keybind: every entry after the stale one went with it, and which ones
+        survived was an accident of Object.entries order.
 
-        ActionRegistry.get is declared `: Action` but is a bare Map.get, so an
-        unknown name gives undefined and `.keyCombo = kc` throws. The throw
-        happens *inside* the import loop, so it is not one lost keybind - every
-        entry after the stale one is lost too, and the ordering is
-        Object.entries order, which makes which ones survive an accident of how
-        the object was serialised.
-
-        It also escapes importKeybinds entirely: the call is unguarded in
-        registerActions, so the `visibilitychange` listener registered after it
-        never gets attached and keybinds stop being persisted for the session.
-        That is the part that makes it self-perpetuating - the stale entry
-        cannot be cleaned up by normal use.
+        The stale entry is deliberately listed *first*, so a fix that only
+        stopped the throw without continuing the loop still fails this.
     */
     const errors = await withStoredKeybinds(page, {
         'no-such-action-anymore': 'KeyZ',
         rotate: 'KeyT',
     })
 
-    expect(errors.join(' | ')).toContain('TypeError')
-    // rotate came after the stale entry and never got applied.
-    expect(await keyCombos(page)).toEqual({})
+    expect(errors.join(' | ')).not.toContain('TypeError')
+    expect(await keyCombos(page)).toEqual({ rotate: 'KeyT' })
+})
+
+test('the stale entry is named in a warning rather than dropped silently', async ({ page }) => {
+    /*
+        Skipping quietly would leave a user whose keybind stopped working with
+        nothing to look at. The name is the whole value of the message - it is
+        what tells them which binding to set again.
+    */
+    const warnings: string[] = []
+    page.on('console', m => {
+        if (m.type() === 'warning') warnings.push(m.text())
+    })
+
+    await page.addInitScript(() => {
+        localStorage.setItem('keybinds2', JSON.stringify({ 'no-such-action-anymore': 'KeyZ' }))
+    })
+    await page.goto('/')
+    await page.waitForFunction(() => (window as any).__fbe_test !== undefined, { timeout: 60_000 })
+
+    expect(warnings.join(' | ')).toContain('no-such-action-anymore')
 })


### PR DESCRIPTION
Gate **61 → 52**, exactly the file's own count. Playwright 47 → 50.

## The live bug

`ActionRegistry.get` was declared `: Action` over a bare `Map.get`. Its one caller is `importKeybinds`, which runs at startup against `localStorage` — **persisted data that outlives the action names that produced it.** An action renamed or removed in any release leaves an entry behind, and `.keyCombo = kc` then throws.

Three things made it worse than one lost keybind:

1. The throw is **inside the import loop**, so every entry after the stale one is lost too — and which ones survive is an accident of `Object.entries` order.
2. It **escapes `importKeybinds`** into `registerActions`, which then never attaches the `visibilitychange` listener that writes keybinds back.
3. So the stale entry **cannot be cleared by normal use**, and fails again on every load.

```
TypeError: Cannot set properties of undefined (setting 'keyCombo')
    at Object.importKeybinds (actions.ts)
    at registerActions (index.ts:429)
```

`get` now answers `Action | undefined`, and `importKeybinds` skips the name with a warning that names it.

**Deliberately not a throw**, unlike `PositionGrid.entityAt` or `EntityContainer.containerOf`. Those name invariants over data the editor itself maintains, where a violation means drift worth stopping for. This is user data of unbounded age, and the alternative to one keybind falling back to its default was losing all the others.

## The rest of the file

Same shape as TextInput in #59 — declarations asserting a presence the logic never assumed, with the check already written:

- `getModifier` and `getTrigger` both return `undefined` for input they cannot parse, and both callers already bail on it (`if (!mod) return`, `if (!trigger) return`).
- `hasModifier` reads three optional booleans where absent has always meant `false`.

## The last two took a change of representation, not a wider type

```ts
this.isActive = succeeded && !!this.callbacks.onRelease
// ...elsewhere, in another method
if (this.isActive) this.callbacks.onRelease()
```

That is one invariant written twice, in two places, in a form nothing could check. Holding the callback instead of a boolean asserting one exists makes it a single statement the compiler verifies:

```ts
this.activeRelease = succeeded ? this.callbacks.onRelease : undefined
// ...
if (this.activeRelease) { this.activeRelease(); this.activeRelease = undefined }
```

It also collapses "nothing held" and "held, but this action has no release" into the one state callers never told apart. Same move as `_buildBoxCache` taking its generator in #59: **keep the narrowed value rather than a flag standing in for it.**

## Verification

Characterization test committed first (`ded0ce6c`), pinning the crash, so the pair bisects cleanly. The corpus could never reach this — it is neither a blueprint nor input, and every other spec starts from an empty `localStorage`. Seeded with `addInitScript`.

| mutation | fails |
| --- | --- |
| restore the crash | both stale-keybind tests, **not** the happy path |
| skip quietly, no warning | the warning test only |
| skip but abandon the loop | the "rest still applied" test only — which is why the stale entry is listed **first** in it |
| never store `onRelease` | the 8 mode tests that depend on a release firing; hover, pipette and the keybind tests unaffected |

That last one is the payoff from #58: the callback refactor touches the release path of every mode, and `editor-mode-input.spec.ts` was already sitting under it.

`vp test` 75 passed · `npx playwright test` 50 passed · gate 52 at baseline 52 · `vp lint` and `vp fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJg7PoKTMaJuaVsL32jGJx