### PR TITLE
fix(types): one lying accessor under Filters, Modules and the quickbar (#22)

### DIFF
--- a/packages/editor/src/Editor.ts
+++ b/packages/editor/src/Editor.ts
@@ -92,10 +92,11 @@ export class Editor {
         G.BPC.gridPattern = pattern
     }
 
-    public get quickbarItems(): string[] {
+    /** One entry per slot, undefined where the slot is empty. */
+    public get quickbarItems(): (string | undefined)[] {
         return G.UI.quickbarPanel.serialize()
     }
-    public set quickbarItems(items: string[]) {
+    public set quickbarItems(items: (string | undefined)[]) {
         G.UI.quickbarPanel.generateSlots(items)
     }
 

--- a/packages/editor/src/UI/QuickbarPanel.ts
+++ b/packages/editor/src/UI/QuickbarPanel.ts
@@ -7,7 +7,8 @@ import F from './controls/functions'
 import { colors } from './style'
 
 class QuickbarSlot extends Slot<string | undefined> {
-    public get itemName(): string {
+    /** Undefined for an empty slot, which is what unassignItem leaves behind. */
+    public get itemName(): string | undefined {
         return this.data
     }
 
@@ -78,14 +79,18 @@ export class QuickbarPanel extends Panel {
         return button
     }
 
-    public generateSlots(itemNames?: string[]): void {
+    /** Positional: index i is slot i, and a hole leaves that slot empty. */
+    public generateSlots(itemNames?: (string | undefined)[]): void {
         for (let r = 0; r < this.rows; r++) {
             for (let i = 0; i < 10; i++) {
                 const quickbarSlot = new QuickbarSlot()
                 quickbarSlot.position.set((36 + 2) * i + (i > 4 ? 38 : 0), 38 * r)
 
-                if (itemNames && itemNames[r * 10 + i]) {
-                    quickbarSlot.assignItem(itemNames[r * 10 + i])
+                // Read into a local: the index is a loop `let`, so TypeScript
+                // will not carry the truthiness test across to the use.
+                const itemName = itemNames?.[r * 10 + i]
+                if (itemName) {
+                    quickbarSlot.assignItem(itemName)
                 }
 
                 quickbarSlot.on('pointerdown', e => {
@@ -152,7 +157,12 @@ export class QuickbarPanel extends Panel {
         this.generateSlots(itemNames)
     }
 
-    public serialize(): string[] {
+    /*
+        One entry per slot, so an empty slot is a hole rather than a gap closed
+        up - generateSlots indexes this positionally, and compacting it would
+        slide every later item one place left on the next load.
+    */
+    public serialize(): (string | undefined)[] {
         return this.slots.map(s => s.itemName)
     }
 

--- a/packages/editor/src/UI/controls/Button.ts
+++ b/packages/editor/src/UI/controls/Button.ts
@@ -15,8 +15,8 @@ export class Button<Data = undefined, Content extends Container = Container> ext
     /** Rollover Graphic */
     private readonly m_Hover: Sprite
 
-    /** Content of Control */
-    private m_Content: Content
+    /** Content of Control, absent when the control is showing nothing */
+    private m_Content: Content | undefined
 
     /** Data of Control */
     private m_Data: Data
@@ -80,15 +80,19 @@ export class Button<Data = undefined, Content extends Container = Container> ext
         this.m_Active.visible = active
     }
 
-    /** Control Content */
-    public get content(): Content {
+    /**
+     * Control Content. Undefined means the control is showing nothing, which is
+     * the state every caller already assigned to clear a slot and tested for
+     * before reading - the accessors were the only thing claiming otherwise.
+     */
+    public get content(): Content | undefined {
         return this.m_Content
     }
-    public set content(content: Content) {
-        if (
-            this.m_Content !== undefined ||
-            (this.m_Content !== undefined && content === undefined)
-        ) {
+    public set content(content: Content | undefined) {
+        // Was `A || (A && B)`, which is just `A` - the second clause could never
+        // decide anything, and reading as though it handled a separate
+        // clearing case is the only thing it did.
+        if (this.m_Content !== undefined) {
             this.removeChild(this.m_Content)
             this.m_Content.destroy()
             this.m_Content = undefined

--- a/packages/editor/src/UI/editors/ChestEditor.ts
+++ b/packages/editor/src/UI/editors/ChestEditor.ts
@@ -123,13 +123,27 @@ export class ChestEditor extends Editor {
             filters.updateFilter(this.m_Filter, value)
         })
         this.onEntityChange('filters', () => {
-            if (this.m_Filter > -1) {
-                slider.value = filters.getFilterCount(this.m_Filter)
-            }
-            if (slider.value === undefined) {
+            /*
+                getFilterCount answers undefined for a filter carrying no stack
+                count. This used to assign that straight into `slider.value`,
+                which is typed number and does arithmetic on it in
+                updateButtonPosition - the visibility check below was then
+                reading the undefined back out of the slider. Held in a local
+                instead, so nothing has to launder an undefined through Slider.
+
+                One deliberate difference: the slider no longer *retains* the
+                undefined. Previously a later 'filters' event with no filter
+                selected would re-read it and hide again; now it does not. The
+                controls are already hidden at that point and only the
+                'selected' handler shows them, so the visible state is the same.
+            */
+            const count = this.m_Filter > -1 ? filters.getFilterCount(this.m_Filter) : slider.value
+            if (count === undefined) {
                 label.visible = false
                 slider.visible = false
                 textbox.visible = false
+            } else {
+                slider.value = count
             }
         })
     }

--- a/packages/editor/src/UI/editors/TrainStopEditor.ts
+++ b/packages/editor/src/UI/editors/TrainStopEditor.ts
@@ -43,8 +43,10 @@ export class TrainStopEditor extends Editor {
         })
 
         limitTextbox.on('changed', () => {
-            let limit: number = parseInt(limitTextbox.text)
-            if (isNaN(limit)) {
+            // Undefined is the value that clears the limit, which is what an
+            // unparseable box means and what the setter above already writes.
+            let limit: number | undefined = parseInt(limitTextbox.text)
+            if (limit !== undefined && isNaN(limit)) {
                 limit = undefined
             }
 

--- a/packages/editor/src/UI/editors/components/Filters.ts
+++ b/packages/editor/src/UI/editors/components/Filters.ts
@@ -4,7 +4,7 @@ import FD from '../../../core/factorioData'
 import G from '../../../common/globals'
 import F from '../../controls/functions'
 import { Slot } from '../../controls/Slot'
-import { Entity, EntityEvents, IFilter } from '../../../core/Entity'
+import { Entity, EntityEvents, IFilterSlot } from '../../../core/Entity'
 
 /** Module Slots for Entity */
 export class Filters extends Container<Slot<number>> {
@@ -79,7 +79,12 @@ export class Filters extends Container<Slot<number>> {
     private readonly m_Amount: boolean
 
     /** Field to hold data for module visualization */
-    private m_Filters: IFilter[]
+    /*
+        One entry per slot, so an empty slot is present with no name - which is
+        what makes this IFilterSlot[] rather than IFilter[]. Entity's setter is
+        built for exactly this and strips the nameless entries on the way in.
+    */
+    private m_Filters: IFilterSlot[]
 
     public constructor(entity: Entity, amount = false) {
         super()
@@ -132,7 +137,10 @@ export class Filters extends Container<Slot<number>> {
      * Return filter count of specific filter
      * @param index Index of filter
      */
-    public getFilterCount(index: number): number {
+    public getFilterCount(index: number): number | undefined {
+        // Undefined for a filter with no stack count, which a logistic section
+        // filter is free to be - ChestEditor reads that as "hide the count
+        // controls" and has always had the check for it.
         return this.m_Filters[index].count
     }
 
@@ -175,7 +183,15 @@ export class Filters extends Container<Slot<number>> {
                     if (this.m_Amount) {
                         if (slot.content !== undefined) {
                             const text = slot.children[1] as Text
-                            if (text.text !== slotFilter.count.toString()) {
+                            /*
+                                `?? 1` matches what was actually drawn, not a
+                                guess: the icon below is built by
+                                CreateIconWithAmount, whose `amount` defaults to
+                                1, so a filter with no count rendered as "1".
+                                Comparing against "undefined" would have made
+                                every such slot look stale and rebuild forever.
+                            */
+                            if (text.text !== (slotFilter.count ?? 1).toString()) {
                                 slot.content = undefined
                             }
                         }

--- a/packages/editor/src/UI/editors/components/Modules.ts
+++ b/packages/editor/src/UI/editors/components/Modules.ts
@@ -10,8 +10,13 @@ export class Modules extends Container<Slot<number>> {
     /** Blueprint Editor Entity reference */
     private readonly m_Entity: Entity
 
-    /** Field to hold data for module visualization */
-    private readonly m_Modules: string[]
+    /**
+     * Field to hold data for module visualization. An entry is undefined for an
+     * empty slot, which is what right-clicking a slot writes and what every read
+     * of this array already checks for - `Entity.modules` has said so since the
+     * Entity batch, and this was the only thing narrowing it back.
+     */
+    private readonly m_Modules: (string | undefined)[]
 
     public constructor(entity: Entity) {
         super()
@@ -28,8 +33,12 @@ export class Modules extends Container<Slot<number>> {
             slot.position.set(slotIndex * 38, 0)
             slot.data = slotIndex
             slot.on('pointerdown', this.onSlotPointerDown, this)
-            if (this.m_Modules[slotIndex] !== undefined) {
-                slot.content = F.CreateIcon(this.m_Modules[slotIndex])
+            // Read into a local first: `slotIndex` is a loop `let`, so
+            // TypeScript will not carry a narrowing of `m_Modules[slotIndex]`
+            // from the test to the use.
+            const module = this.m_Modules[slotIndex]
+            if (module !== undefined) {
+                slot.content = F.CreateIcon(module)
             }
             this.addChild(slot)
         }
@@ -50,8 +59,8 @@ export class Modules extends Container<Slot<number>> {
         this.once('destroyed', () => this.m_Entity.off(event, fn))
     }
 
-    /** Update Content Icon */
-    private updateContent(slot: Slot<number>, module: string): void {
+    /** Update Content Icon. An undefined module empties the slot. */
+    private updateContent(slot: Slot<number>, module: string | undefined): void {
         if (module === undefined) {
             if (slot.content !== undefined) {
                 slot.content = undefined

--- a/packages/editor/src/core/Entity.ts
+++ b/packages/editor/src/core/Entity.ts
@@ -49,6 +49,18 @@ export interface IFilter {
     count?: number
 }
 
+/**
+ * A filter as the editor's UI holds it, which is one entry per *slot* rather
+ * than one per set filter - so an empty slot is present with no name.
+ *
+ * Only the `filters` setter takes these, and it drops the empty ones on the way
+ * in (`list.filter(f => !!f.name)`), which is why the getter can still answer
+ * the narrower `IFilter[]`: nothing without a name is ever stored.
+ */
+export interface IFilterSlot extends Omit<IFilter, 'name'> {
+    name: string | undefined
+}
+
 // TODO: Handle the modules within the class differently so that modules would stay in the same place during editing the blueprint
 
 export interface EntityEvents {
@@ -447,9 +459,18 @@ export class Entity extends EventEmitter<EntityEvents> {
             }
         }
     }
-    public set filters(list: IFilter[] | undefined) {
+    /*
+        Takes the wider slot shape while the getter above answers IFilter[].
+        TypeScript only asks that the getter type be assignable to the setter
+        type, and the filter below is what makes the difference safe.
+    */
+    public set filters(list: IFilterSlot[] | undefined) {
+        // The predicate is the whole point of this filter, and saying so is what
+        // lets the narrower IFilter[] reach the per-entity setters below.
         const FILTERS =
-            list === undefined || list.length === 0 ? undefined : list.filter(f => !!f.name)
+            list === undefined || list.length === 0
+                ? undefined
+                : list.filter((f): f is IFilter => !!f.name)
         switch (this.name) {
             case 'splitter':
             case 'fast-splitter':

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 52
+    "maxErrors": 36
 }


### PR DESCRIPTION
Gate **52 → 36**. The two files I set out to fix were 11 errors between them; the root cleared **16**, because it was one file over from both.

## The root

`Button.content` declared `Content` on both accessors, while the setter:

- handled `content === undefined` explicitly,
- assigned `this.m_Content = undefined` itself,
- and had **every** caller either assign undefined to clear a slot or test for it before reading.

Widening it to `| undefined` — three lines — cleared 6 errors across four files and pushed nothing anywhere. That is what an actual root looks like.

Worth recording that adjacency was *not* why `Filters` and `Modules` were picked together, and not what they had in common. The notes warn about exactly that (`OverlayContainer` and `Blueprint` looked adjacent and shared nothing); here the shared cause was real but lived in neither file.

## The same shape, once per caller

Each an accessor claiming a presence its own class contradicts:

| site | claimed | contradicted by |
| --- | --- | --- |
| `Modules.m_Modules` | `string[]` | right-clicking a slot writes `undefined`; `Entity.modules` has answered `(string \| undefined)[]` since the Entity batch, and this was the only thing narrowing it back |
| `QuickbarSlot.itemName` | `string` | `unassignItem` sets `undefined` |
| `TrainStopEditor`'s `let limit` | `number` | assigned `undefined` two lines down, which is how the limit is cleared |

`serialize` follows `itemName`, and deliberately stays one entry per slot rather than compacting — `generateSlots` indexes it **positionally**, so closing the holes would slide every later item one place left on the next load.

## The one that wanted a setter/getter split

`Entity.filters`. The setter already ran `list.filter(f => !!f.name)`, so it was *built* to accept one entry per **slot** with the empty ones unnamed — that is `IFilterSlot`. The getter still answers the narrower `IFilter[]`, because nothing without a name is ever stored. Straight application of "widen the setter, keep the getter as narrow as the truth"; saying so as a type predicate is what lets the narrow type reach the per-entity setters.

## Two smaller ones

- `Button`'s setter opened `if (A || (A && B))`, which is just `A`. The second clause could never decide anything and only read as though it handled a separate clearing case.
- `Filters` compared a slot's rendered amount against `count.toString()` where `count` is optional. `?? 1` is not a guess — it is what was drawn, since the icon comes from `CreateIconWithAmount` whose `amount` defaults to 1.

## No fixture, and why

Behaviour-neutral on every reachable path — the #37 / #49 / #59 precedent. The widenings are types only, and the two loop locals are the usual "narrowing does not survive a `let` index".

Verified by opening the module, requester-chest and storage-chest editors in the browser: all three come up with zero console errors. One documented divergence, in `ChestEditor`: the slider no longer *retains* an undefined count, so a later `filters` event with nothing selected does not re-hide the count controls. They are already hidden at that point and only the `selected` handler shows them, so the visible state is unchanged.

## A crash I am *not* claiming to have fixed

That `count.toString()` would throw on a filter carrying no count, and it is tempting to write this up as a live fix. It is not — yet. Reaching it needs a second slot update on a chest, and every write path there goes through `set logisticChestFilters`, whose first statement is an unconditional `throw new Error('TODO: set logisticChestFilters')`. Filed as **#64**. If that gets fixed, this path becomes reachable at the same moment and is already handled.

`vp test` 75 passed · `npx playwright test` 50 passed · gate 36 at baseline 36 · `vp lint` and `vp fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJg7PoKTMaJuaVsL32jGJx