### PR TITLE
fix(types): clear the three paint containers, and cover pasting wires (#22)

### DIFF
--- a/packages/editor/src/containers/PaintBlueprintEntityContainer.ts
+++ b/packages/editor/src/containers/PaintBlueprintEntityContainer.ts
@@ -119,11 +119,22 @@ export class PaintBlueprintEntityContainer {
         this.checkBuildable()
     }
 
-    public placeEntityContainer(): Entity {
+    /**
+     * The entity this placed, or undefined where it placed none - which is the
+     * normal outcome of three of the four paths below, not a failure. A fast
+     * replace and a rotate-in-place both reuse an entity that already exists,
+     * and an unavailable area places nothing at all.
+     *
+     * The one caller, PaintBlueprintContainer.placeEntityContainer, is building
+     * an old-entity-number -> new-entity-number map to copy wires through, and
+     * already skips the undefined: only a genuinely new entity has a new number
+     * to map to.
+     */
+    public placeEntityContainer(): Entity | undefined {
         const position = this.entityPosition
         const direction = this.entity.direction
 
-        if (this.bpc.bp.fastReplaceEntity(this.entity.name, direction, position)) return
+        if (this.bpc.bp.fastReplaceEntity(this.entity.name, direction, position)) return undefined
 
         const snEnt = this.bpc.bp.entityPositionGrid.checkSameEntityAndDifferentDirection(
             this.entity.name,
@@ -132,10 +143,10 @@ export class PaintBlueprintEntityContainer {
         )
         if (snEnt) {
             snEnt.direction = direction
-            return
+            return undefined
         }
 
-        let ent: Entity
+        let ent: Entity | undefined
         if (this.bpc.bp.entityPositionGrid.isAreaAvailable(this.entity.name, position, direction)) {
             ent = this.bpc.bp.createEntity({
                 ...this.entity.serialize(),

--- a/packages/editor/src/containers/PaintContainer.ts
+++ b/packages/editor/src/containers/PaintContainer.ts
@@ -116,7 +116,10 @@ export abstract class PaintContainer extends Container<EntitySprite> {
         this.moveAtCursor()
     }
 
-    protected setPosition(position?: IPoint): void {
+    // Not optional: all four call sites pass a position, and every branch below
+    // reads it. Unlike setNewPosition's `size`, where PaintWireContainer really
+    // does omit it and the undefined arm is the one it takes.
+    protected setPosition(position: IPoint): void {
         if (this._posConstraint === undefined) {
             this.position = position
         } else {

--- a/packages/editor/src/containers/PaintEntityContainer.ts
+++ b/packages/editor/src/containers/PaintEntityContainer.ts
@@ -87,7 +87,20 @@ export class PaintEntityContainer extends PaintContainer {
     private updateUndergroundBeltRotation(): void {
         const fd = FD.entities[this.name]
         if (isUndergroundBelt(fd)) {
-            const otherEntity = this.bpc.bp.entityPositionGrid.getOpposingEntity(
+            /*
+                getOpposingEntity answers an entity *number*, and the variable
+                holding it was named as though it were the entity - which is how
+                the resolve below ended up inside the branch, dereferencing a
+                Map.get result that nothing had checked.
+
+                Resolved before the branch instead, which is what both other
+                callers of getOpposingEntity already do (Entity.rotate and
+                OverlayContainer). Degrading rather than throwing matches them
+                too: an unresolvable number lands in the same arm as no opposing
+                entity at all, which is the arm that just leaves the direction
+                type alone.
+            */
+            const opposingEntityNumber = this.bpc.bp.entityPositionGrid.getOpposingEntity(
                 this.name,
                 (this.direction + 8) % 16,
                 {
@@ -97,13 +110,15 @@ export class PaintEntityContainer extends PaintContainer {
                 this.direction,
                 fd.max_distance
             )
+            const otherEntity =
+                opposingEntityNumber === undefined
+                    ? undefined
+                    : this.bpc.bp.entities.get(opposingEntityNumber)
+
             if (otherEntity) {
-                const oe = this.bpc.bp.entities.get(otherEntity)
-                this.directionType = oe.directionType === 'input' ? 'output' : 'input'
-            } else {
-                if (this.directionType === 'output') {
-                    this.directionType = 'input'
-                }
+                this.directionType = otherEntity.directionType === 'input' ? 'output' : 'input'
+            } else if (this.directionType === 'output') {
+                this.directionType = 'input'
             }
             this.redraw()
         }

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -228,6 +228,13 @@ document.addEventListener('paste', (e: ClipboardEvent) => {
         Empty means every action is on its default combo.
     */
     keyCombos: () => EDITOR.exportKeybinds(),
+    /*
+        The loaded blueprint's wires, in the form they would be serialized to a
+        blueprint string. Reads live editor state, unlike wire-connections.spec,
+        which walks a blueprint it decoded itself - pasting is the case that
+        needs the difference.
+    */
+    wireCount: () => bp.wireConnections.serializeBpWires().length,
     loadingScreen,
     getBook: () => book,
     selectBookIndex: async (index: number) => {

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 36
+    "maxErrors": 29
 }

--- a/tests/helpers/fbe-test-api.ts
+++ b/tests/helpers/fbe-test-api.ts
@@ -68,6 +68,8 @@ export interface FbeTestApi {
      * Empty when every action is default. See tests/keybinds.spec.ts.
      */
     keyCombos: () => Record<string, string>
+    /** How many wires the loaded blueprint would serialize. */
+    wireCount: () => number
 }
 
 /**

--- a/tests/paste-wires.spec.ts
+++ b/tests/paste-wires.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprint as encode, packVersion as version } from './helpers/encode-blueprint'
+
+/*
+    Pasting a wired selection, which is the only consumer of
+    PaintBlueprintEntityContainer.placeEntityContainer's return value.
+
+    That method answers the entity it created, or undefined where it created
+    none - a fast replace and a rotate-in-place both reuse an entity that already
+    exists. PaintBlueprintContainer collects the ones that are not undefined into
+    an old-number -> new-number map and copies each wire whose *both* ends are in
+    it. So the return value does not decide whether entities get placed; it
+    decides whether their wires come with them, which is why placing entities and
+    counting them cannot see a mistake in it.
+
+    Nothing covered this: wire-connections.spec.ts walks a blueprint it decoded
+    itself, and the paste path only exists in the live editor.
+
+    Runs against the dev server like the rest of tests/ - see CLAUDE.md for the
+    two servers that have to be up.
+*/
+
+type Page = import('@playwright/test').Page
+
+/*
+    Two constant combinators joined by one green wire. The 2.0 `wires` form is
+    [entity, connector, entity, connector], and 2 is the green circuit connector
+    on a combinator's input side.
+*/
+const TWO_WIRED = encode({
+    item: 'blueprint',
+    version: version(2, 0, 55),
+    entities: [
+        { entity_number: 1, name: 'constant-combinator', position: { x: 0.5, y: 0.5 } },
+        { entity_number: 2, name: 'constant-combinator', position: { x: 2.5, y: 0.5 } },
+    ],
+    wires: [[1, 2, 2, 2]],
+})
+
+const wireCount = (page: Page): Promise<number> =>
+    page.evaluate(() => (window as any).__fbe_test.wireCount())
+
+const entityCount = (page: Page): Promise<number> =>
+    page.evaluate(() => (window as any).__fbe_test.entityContainerCount())
+
+async function screenOf(page: Page, entityNumber: number): Promise<{ x: number; y: number }> {
+    const at = await page.evaluate(
+        (n: number) => (window as any).__fbe_test.entityScreenPosition(n),
+        entityNumber
+    )
+    if (!at) throw new Error(`no entity ${entityNumber} in the loaded blueprint`)
+    return at
+}
+
+async function load(page: Page): Promise<void> {
+    await page.goto('/')
+    await page.waitForFunction(() => (window as any).__fbe_test !== undefined, { timeout: 60_000 })
+    await page.evaluate(async (src: string) => {
+        const t = (window as any).__fbe_test
+        await t.loadBp(await t.getBlueprintOrBookFromSource(src))
+    }, TWO_WIRED)
+}
+
+test('the blueprint loads with its wire', async ({ page }) => {
+    // The baseline the paste is measured against - a wire that failed to decode
+    // would make the interesting test below pass for the wrong reason.
+    await load(page)
+    expect(await entityCount(page)).toBe(2)
+    expect(await wireCount(page)).toBe(1)
+})
+
+test('pasting a wired selection brings the wire with it', async ({ page }) => {
+    await load(page)
+
+    const first = await screenOf(page, 1)
+    const second = await screenOf(page, 2)
+
+    // Ctrl drag across both, which leaves PAINT holding a copy.
+    await page.mouse.move(first.x, first.y)
+    await page.keyboard.down('Control')
+    await page.mouse.down()
+    await page.mouse.move(second.x, second.y)
+    await page.mouse.up()
+    await page.keyboard.up('Control')
+    expect(await page.evaluate(() => (window as any).__fbe_test.editorMode())).toBe('PAINT')
+
+    // Well clear of the originals, so the paste has somewhere to land.
+    await page.mouse.move(first.x, first.y + 220)
+    await page.mouse.down()
+    await page.mouse.up()
+
+    expect(await entityCount(page)).toBe(4)
+    // The copy's own wire, alongside the original's.
+    expect(await wireCount(page)).toBe(2)
+})
+
+test('a wire whose other end was not selected is not copied', async ({ page }) => {
+    /*
+        A wire with one end outside the selection must not come along. The
+        original pair keeps its wire; the lone copy arrives with none.
+
+        Two checks enforce this and they cover each other, which is worth knowing
+        before touching either:
+
+          1. copy time - PaintBlueprintContainer builds its own Blueprint from
+             the selection and filters wires through an entity-number whitelist,
+             so a half-connected wire never enters the thing being pasted;
+          2. paste time - `en0 === undefined || en1 === undefined`, which drops a
+             wire whose ends did not both make it into the new-number map.
+
+        Weakening *either* on its own leaves this test passing, because the other
+        still catches it. Weakening both fails it, and loudly: serializeBpWires
+        throws "Wire connects to entity undefined", since it refuses to drop an
+        endpoint it cannot resolve rather than silently exporting a wire-less
+        blueprint.
+
+        So this is a backstop on the property, not coverage of either check. If
+        one of them ever looks redundant, it is - and this is what says removing
+        both is not.
+    */
+    await load(page)
+
+    const first = await screenOf(page, 1)
+
+    // A ctrl drag that starts and ends on the first combinator only.
+    await page.mouse.move(first.x, first.y)
+    await page.keyboard.down('Control')
+    await page.mouse.down()
+    await page.mouse.move(first.x + 4, first.y + 4)
+    await page.mouse.up()
+    await page.keyboard.up('Control')
+    expect(await page.evaluate(() => (window as any).__fbe_test.editorMode())).toBe('PAINT')
+
+    await page.mouse.move(first.x, first.y + 220)
+    await page.mouse.down()
+    await page.mouse.up()
+
+    expect(await entityCount(page)).toBe(3)
+    expect(await wireCount(page)).toBe(1)
+})


### PR DESCRIPTION
Gate **36 → 29** — the seven those three files held. Playwright 50 → 53.

The one error left in this area is `BlueprintContainer`'s `paintContainer = undefined`, which is the measured **+33 across 10 files** knot. It stays.

## The three files

| site | was | why |
| --- | --- | --- |
| `PaintBlueprintEntityContainer.placeEntityContainer` | `: Entity`, returned undefined on 3 of 4 paths | none of them is a failure — a fast replace and a rotate-in-place both reuse an entity that already exists, and an unavailable area places nothing. The one caller already skipped the undefined |
| `PaintContainer.setPosition` | `position?: IPoint`, read in every branch | all four call sites pass one. `setNewPosition`'s `size` stays optional — that one is genuine, `PaintWireContainer` omits it and the undefined arm is the one it takes |
| `PaintEntityContainer` | `bp.entities.get(...)` dereferenced unchecked | the variable was named `otherEntity` but `getOpposingEntity` answers an entity **number**. That name is how the resolve ended up inside the branch. Resolved before it instead, which is what both other callers of `getOpposingEntity` already do — degrading rather than throwing, to match them |

## This batch earns a test, unlike the last few

The types are behaviour-neutral, so by the #37/#49/#59/#65 precedent no fixture would be owed. But `placeEntityContainer`'s return value is different in kind: **it does not decide whether entities get placed — it decides whether their wires come with them.**

So counting entities after a paste cannot see a mistake in it, and nothing covered the paste path at all (`wire-connections.spec.ts` walks a blueprint it decoded itself; pasting only exists in the live editor).

Mutation-checked, and this is the whole argument:

| mutation | result |
| --- | --- |
| `placeEntityContainer` always answers undefined | **fails the new wire test**; "a paste rotated while hidden is still placeable" still **passes** |

Entities still place. Only the wires are silently lost.

## A correction I'd rather record than quietly drop

The third test asserts that a wire with one end outside the selection is not copied. My first comment on it claimed it covered the paste-time both-ends check. **Mutation testing showed that was wrong** — it survived three separate single mutations.

The reason is that two checks enforce the property and each covers the other:

1. **copy time** — `PaintBlueprintContainer` builds its own `Blueprint` from the selection and filters wires through an entity-number whitelist, so a half-connected wire never enters the thing being pasted;
2. **paste time** — `en0 === undefined || en1 === undefined`.

Weakening either alone leaves the test passing. Weakening **both** fails it, loudly:

```
Error: Wire connects to entity undefined, which is not in the blueprint
```

— because `serializeBpWires` refuses to drop an endpoint it cannot resolve rather than silently exporting a blueprint that is missing wires.

So it is a backstop on the property, not coverage of either check, and the comment now says exactly that. If one of those two ever looks redundant, it is — and this test is what says removing both is not.

`vp test` 75 passed · `npx playwright test` 53 passed · gate 29 at baseline 29 · `vp lint` and `vp fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJg7PoKTMaJuaVsL32jGJx