### PR TITLE
fix: draw what tiles you can instead of failing the load (#54)

### DIFF
--- a/packages/editor/src/Editor.ts
+++ b/packages/editor/src/Editor.ts
@@ -172,6 +172,11 @@ export class Editor {
      * destroyed whenever the pointer leaves the canvas, and `mode` reports
      * PAINT either way (issue #53).
      */
+    /** How many tile sprites the canvas is drawing. See tests/tiles.spec.ts. */
+    public get tileSpriteCount(): number {
+        return G.BPC.tileSpriteCount
+    }
+
     public get paintContainerVisible(): boolean | undefined {
         return G.BPC.paintContainer?.visible
     }

--- a/packages/editor/src/containers/BlueprintContainer.ts
+++ b/packages/editor/src/containers/BlueprintContainer.ts
@@ -929,6 +929,15 @@ export class BlueprintContainer extends Container {
         }
     }
 
+    /**
+     * How many tile sprites are currently drawn. One per tile of the loaded
+     * blueprint, unless a tile had nothing to draw with - see
+     * TileContainer.generateSprite.
+     */
+    public get tileSpriteCount(): number {
+        return this.tileSprites.children.length
+    }
+
     public addTileSprites(tileSprites: EntitySprite[]): void {
         if (tileSprites.length === 0) return
         this.tileSprites.addChild(...tileSprites)

--- a/packages/editor/src/containers/PaintTileContainer.ts
+++ b/packages/editor/src/containers/PaintTileContainer.ts
@@ -46,7 +46,16 @@ export class PaintTileContainer extends PaintContainer {
     }
 
     public override getItemName(): string {
-        return Tile.getItemName(this.name)
+        // Same shape as PaintEntityContainer's, and for the same reason: the
+        // abstract stays `string` because PaintContainer's constructor draws an
+        // icon from it, and something being painted is by definition something
+        // with an item to place it with. Naming the invariant beats widening
+        // the base and pushing a check onto the quickbar.
+        const itemName = Tile.getItemName(this.name)
+        if (itemName === undefined) {
+            throw new Error(`${this.name} is being painted but has no item to place it with`)
+        }
+        return itemName
     }
 
     public increaseSize(): void {
@@ -90,7 +99,11 @@ export class PaintTileContainer extends PaintContainer {
             this.position,
             PaintTileContainer.getTilePositions()
         )
-        this.addChild(...sprites)
+        // generateSprites can now come back empty, and pixi's addChild reads
+        // children[0] before checking the length.
+        if (sprites.length > 0) {
+            this.addChild(...sprites)
+        }
     }
 
     public override moveAtCursor(): void {

--- a/packages/editor/src/containers/TileContainer.ts
+++ b/packages/editor/src/containers/TileContainer.ts
@@ -9,13 +9,32 @@ export class TileContainer {
 
     public constructor(tile: Tile) {
         const sprite = TileContainer.generateSprite(tile.name, tile.x, tile.y)
-        this.tileSprites.push(sprite)
-        G.BPC.addTileSprites([sprite])
+        // A tile that could not be drawn contributes nothing rather than
+        // stopping the load - see generateSprite.
+        if (sprite !== undefined) {
+            this.tileSprites.push(sprite)
+            G.BPC.addTileSprites([sprite])
+        }
 
         tile.on('destroy', () => this.tileSprites.forEach(s => s.destroy()))
     }
 
-    public static generateSprite(name: string, x: number, y: number): EntitySprite {
+    /**
+     * Undefined where the prototype carries nothing to draw this tile with.
+     *
+     * Deliberately not a `need()`, which is how spriteDataBuilder reads optional
+     * prototype fields: that works there because `getSpriteData` wraps every
+     * generator in a try/catch and degrades to a placeholder box. Nothing wraps
+     * this - it is called straight from `BlueprintContainer.initBP`, so a throw
+     * takes the entire blueprint load down. That is the failure mode of issue
+     * #46, and issue #54 is the note not to reintroduce it at the read.
+     *
+     * Warned rather than skipped quietly, because the alternative outcome is an
+     * invisible hole in a floor, which is not something anyone would report
+     * accurately. Every tile in data.json draws today, so this is a guard on a
+     * shape the types permit and the data has never produced.
+     */
+    public static generateSprite(name: string, x: number, y: number): EntitySprite | undefined {
         const width = 64
         const height = 64
         const scale = 0.5
@@ -28,7 +47,13 @@ export class TileContainer {
 
         const variants = FD.tiles[name].variants
         if (variants.material_background === undefined) {
-            const variant = variants.main.find(v => (v.size || 1) === 1)
+            const variant = variants.main?.find(v => (v.size || 1) === 1)
+            if (variant?.picture === undefined || variant.count === undefined) {
+                console.warn(
+                    `Tile "${name}" has no single-tile "main" variant to draw with; leaving it blank.`
+                )
+                return undefined
+            }
             filename = variant.picture
             countX = variant.count
             countY = 1
@@ -67,11 +92,14 @@ export class TileContainer {
         position: IPoint,
         positions: IPoint[]
     ): EntitySprite[] {
-        return positions.map(p => {
+        // flatMap rather than map, so a tile with nothing to draw drops out
+        // instead of leaving an undefined for the caller to spread into pixi.
+        return positions.flatMap(p => {
             const s = TileContainer.generateSprite(name, p.x + position.x, p.y + position.y)
+            if (s === undefined) return []
             s.position.set(p.x * 32, p.y * 32)
             s.alpha = 0.5
-            return s
+            return [s]
         })
     }
 }

--- a/packages/editor/src/core/Tile.ts
+++ b/packages/editor/src/core/Tile.ts
@@ -18,9 +18,21 @@ export class Tile extends EventEmitter<TileEvents> {
         this._y = y
     }
 
-    public static getItemName(name: string): string {
+    /**
+     * The item a tile is placed with, or undefined for one that has none.
+     *
+     * Matches `Entity.getItemName`, which answers the same question for entities
+     * and had to widen for the 20 with no `minable.result` - that read used to
+     * throw a TypeError and took blueprint icon generation down with it.
+     * `generateIcons` already accepts `(name: string) => string | undefined` for
+     * both and drops the ones with nothing to show.
+     *
+     * Every tile in data.json does have `minable.result` today, so this is the
+     * type catching up with a shape the data has not exercised, not a fix.
+     */
+    public static getItemName(name: string): string | undefined {
         if (name === 'landfill') return 'landfill'
-        return FD.tiles[name].minable.result
+        return FD.tiles[name].minable?.result
     }
 
     public get name(): string {

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -223,6 +223,11 @@ document.addEventListener('paste', (e: ClipboardEvent) => {
     */
     paintContainerVisible: () => editor.paintContainerVisible,
     /*
+        How many tile sprites are drawn. Nothing else asserts that tiles render
+        at all - the round-trip spec only checksums their positions in the model.
+    */
+    tileSpriteCount: () => editor.tileSpriteCount,
+    /*
         The keybinds that differ from their defaults, which is what
         importKeybinds was asked to apply and what exportKeybinds would persist.
         Empty means every action is on its default combo.

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 29
+    "maxErrors": 23
 }

--- a/tests/helpers/fbe-test-api.ts
+++ b/tests/helpers/fbe-test-api.ts
@@ -70,6 +70,8 @@ export interface FbeTestApi {
     keyCombos: () => Record<string, string>
     /** How many wires the loaded blueprint would serialize. */
     wireCount: () => number
+    /** How many tile sprites the canvas is drawing. See tests/tiles.spec.ts. */
+    tileSpriteCount: () => number
 }
 
 /**

--- a/tests/tiles.spec.ts
+++ b/tests/tiles.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprint as encode, packVersion as version } from './helpers/encode-blueprint'
+
+/*
+    That tiles actually render, which nothing asserted.
+
+    blueprint-round-trip checksums tile positions in the *model*, and
+    unknown-prototypes covers tiles being stripped before they get that far, but
+    nothing looked at whether a tile that survives produces a sprite. So the
+    whole of TileContainer.generateSprite could stop drawing and the suite would
+    stay green - the load succeeds either way, the floor is just empty.
+
+    Both branches of that function are covered here, because they read entirely
+    different prototype fields and only one of them can fail: of the 22 tiles in
+    data.json, 16 carry `variants.material_background` and 6 do not and fall back
+    to picking a single-tile entry out of `variants.main`.
+
+    Runs against the dev server like the rest of tests/ - see CLAUDE.md for the
+    two servers that have to be up.
+*/
+
+type Page = import('@playwright/test').Page
+
+const tilesAt = (
+    name: string,
+    count: number
+): { name: string; position: { x: number; y: number } }[] =>
+    [...Array(count).keys()].map(i => ({ name, position: { x: i, y: 0 } }))
+
+const tileSpriteCount = (page: Page): Promise<number> =>
+    page.evaluate(() => (window as any).__fbe_test.tileSpriteCount())
+
+async function load(page: Page, source: string): Promise<string[]> {
+    const warnings: string[] = []
+    page.on('console', m => {
+        if (m.type() === 'warning' || m.type() === 'error') warnings.push(m.text())
+    })
+    await page.goto('/')
+    await page.waitForFunction(() => (window as any).__fbe_test !== undefined, { timeout: 60_000 })
+    await page.evaluate(async (src: string) => {
+        const t = (window as any).__fbe_test
+        await t.loadBp(await t.getBlueprintOrBookFromSource(src))
+    }, source)
+    return warnings
+}
+
+test('a tile taking the material_background branch draws one sprite each', async ({ page }) => {
+    // concrete is one of the 16 that carry material_background.
+    const warnings = await load(
+        page,
+        encode({
+            item: 'blueprint',
+            version: version(2, 0, 55),
+            entities: [],
+            tiles: tilesAt('concrete', 5),
+        })
+    )
+
+    expect(await tileSpriteCount(page)).toBe(5)
+    expect(warnings.join(' | ')).not.toContain('leaving it blank')
+})
+
+test('a tile falling back to variants.main draws one sprite each', async ({ page }) => {
+    /*
+        stone-path is one of the 6 with no material_background, so it takes the
+        branch that searches `main` for a single-tile variant and reads `picture`
+        and `count` off it. That is the branch with something to fail at, and the
+        one that would take the whole load down if it threw rather than degraded
+        - see issue #54.
+    */
+    const warnings = await load(
+        page,
+        encode({
+            item: 'blueprint',
+            version: version(2, 0, 55),
+            entities: [],
+            tiles: tilesAt('stone-path', 4),
+        })
+    )
+
+    expect(await tileSpriteCount(page)).toBe(4)
+    expect(warnings.join(' | ')).not.toContain('leaving it blank')
+})
+
+test('both branches draw side by side in one blueprint', async ({ page }) => {
+    const warnings = await load(
+        page,
+        encode({
+            item: 'blueprint',
+            version: version(2, 0, 55),
+            entities: [],
+            tiles: [
+                ...tilesAt('concrete', 3),
+                { name: 'stone-path', position: { x: 0, y: 1 } },
+                { name: 'space-platform-foundation', position: { x: 1, y: 1 } },
+                { name: 'refined-concrete', position: { x: 2, y: 1 } },
+            ],
+        })
+    )
+
+    expect(await tileSpriteCount(page)).toBe(6)
+    expect(warnings.join(' | ')).not.toContain('leaving it blank')
+})


### PR DESCRIPTION
Gate **29 → 23** — the six across `Tile.ts` and `TileContainer.ts`. Playwright 53 → 56.

## Why this had its own issue

The obvious fix is `need()`, the way `spriteDataBuilder` reads optional prototype fields. **That would be wrong here.** `need()` works there because `getSpriteData` wraps every generator in a try/catch that degrades to a placeholder box. Nothing wraps `generateSprite` — it is called straight from `BlueprintContainer.initBP`, so a throw takes the whole blueprint down. That is exactly the failure mode of #46, which was fixed at the boundary rather than at the read.

## Measured, not argued

Breaking the variant lookup and loading a blueprint of one `stone-path` and one `concrete`:

| | before | after |
| --- | --- | --- |
| `loadBp` | **threw** `Cannot read properties of undefined (reading 'picture')` | succeeds |
| the blueprint | never appeared — **including the concrete tile, which had nothing wrong with it** | loads |
| concrete | lost | draws |
| diagnosis | none | `Tile "stone-path" has no single-tile "main" variant to draw with; leaving it blank.` |

Warned rather than skipped quietly, because the alternative outcome is an invisible hole in a floor — not something anyone reports accurately.

`generateSprite` now answers `EntitySprite | undefined`; the constructor adds nothing, `generateSprites` drops it with `flatMap`, and `PaintTileContainer` guards its spread — pixi's `addChild` reads `children[0]` before checking length.

## The two in Tile.ts

`Tile.getItemName` widened to `string | undefined`, matching **`Entity.getItemName`** — the same read for entities, which had to widen for the 20 with no `minable.result` after it threw and took blueprint icon generation down. `generateIcons` already accepts `(name: string) => string | undefined` for both.

That rippled one place, and the sibling had the answer again: `PaintEntityContainer.getItemName` already throws a named error rather than widening, because `PaintContainer`'s constructor draws an icon from it and a thing being painted has by definition an item to place it with. `PaintTileContainer` now does the same, so the abstract stays `string` and no check lands on the quickbar.

## Scope note

**This is defensive, not a live bug.** Every tile in `data.json` draws today, and #48 keeps unknown ones from reaching the container at all. The types are right that the shape permits undefined; the data never does. What changes is what happens if that ever stops being true.

## Tests — because nothing asserted tiles render at all

`blueprint-round-trip` checksums tile positions in the *model* and stops there; `unknown-prototypes` covers tiles being stripped before they get this far. So `generateSprite` could stop drawing entirely and the suite would stay green — the load succeeds either way, the floor is just empty.

Both branches covered separately, since they read different fields: of the 22 tiles, **16** carry `variants.material_background` and **6** fall back to `variants.main`.

| mutation | fails |
| --- | --- |
| the `main` lookup never finds its variant | the two `main`-branch tests; the `material_background` one **passes** |
| the constructor never adds the sprite | all three |

`vp test` 75 passed · `npx playwright test` 56 passed · gate 23 at baseline 23 · `vp lint` and `vp fmt` clean.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJg7PoKTMaJuaVsL32jGJx