### PR TITLE
fix: type util's weight state and equivalence constraint honestly (#22)

### DIFF
--- a/packages/editor/src/common/util.test.ts
+++ b/packages/editor/src/common/util.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vite-plus/test'
 import util from './util'
 
 // util.ts is pure and FD-free, so it can be unit tested - but nothing did.
@@ -8,67 +8,67 @@ import util from './util'
 // edits silently no-opped. These pin what they answer today.
 
 describe('sumprod', () => {
-    test('sums vectors with no weights', () => {
+    it('sums vectors with no weights', () => {
         expect(util.sumprod({ x: 1, y: 2 }, { x: 10, y: 20 })).toEqual({ x: 11, y: 22 })
     })
 
-    test('accepts tuples and points interchangeably', () => {
+    it('accepts tuples and points interchangeably', () => {
         expect(util.sumprod([1, 2], { x: 10, y: 20 })).toEqual({ x: 11, y: 22 })
     })
 
-    test('applies a weight to the vector that follows it', () => {
+    it('applies a weight to the vector that follows it', () => {
         expect(util.sumprod(2, { x: 1, y: 3 })).toEqual({ x: 2, y: 6 })
     })
 
-    test('multiplies consecutive weights together', () => {
+    it('multiplies consecutive weights together', () => {
         expect(util.sumprod(2, 3, { x: 1, y: 1 })).toEqual({ x: 6, y: 6 })
     })
 
     // The subtraction form every caller uses: sumprod(a, -1, b) is a - b.
-    test('negative weights subtract', () => {
+    it('negative weights subtract', () => {
         expect(util.sumprod({ x: 5, y: 5 }, -1, { x: 2, y: 1 })).toEqual({ x: 3, y: 4 })
     })
 
     // A weight applies to one vector only - it is cleared after being consumed.
     // Drop that reset and this becomes { x: 4, y: 4 }.
-    test('a weight does not carry over to the next vector', () => {
+    it('a weight does not carry over to the next vector', () => {
         expect(util.sumprod(2, { x: 1, y: 1 }, { x: 1, y: 1 })).toEqual({ x: 3, y: 3 })
     })
 
-    test('no arguments is the origin', () => {
+    it('no arguments is the origin', () => {
         expect(util.sumprod()).toEqual({ x: 0, y: 0 })
     })
 
-    test('a trailing weight with no vector throws', () => {
+    it('a trailing weight with no vector throws', () => {
         expect(() => util.sumprod({ x: 1, y: 1 }, 2)).toThrow(TypeError)
     })
 })
 
 describe('areObjectsEquivalent', () => {
-    test('equal own properties are equivalent', () => {
+    it('equal own properties are equivalent', () => {
         expect(util.areObjectsEquivalent({ x: 1, y: 2 }, { x: 1, y: 2 })).toBe(true)
     })
 
-    test('a differing value is not', () => {
+    it('a differing value is not', () => {
         expect(util.areObjectsEquivalent({ x: 1, y: 2 }, { x: 1, y: 3 })).toBe(false)
     })
 
-    test('a differing property count is not', () => {
+    it('a differing property count is not', () => {
         expect(util.areObjectsEquivalent({ x: 1 }, { x: 1, y: 2 })).toBe(false)
     })
 
     // Same count, different keys: b has no `y`, so the read is undefined.
-    test('same count with different keys is not', () => {
+    it('same count with different keys is not', () => {
         expect(util.areObjectsEquivalent({ x: 1, y: 2 }, { x: 1, z: 2 })).toBe(false)
     })
 
     // The comparison is shallow - nested objects compare by reference.
-    test('equal nested objects are not equivalent', () => {
+    it('equal nested objects are not equivalent', () => {
         expect(util.areObjectsEquivalent({ p: { x: 1 } }, { p: { x: 1 } })).toBe(false)
     })
 
     // An explicit undefined is still an own property, so it counts toward length.
-    test('an explicit undefined property counts', () => {
+    it('an explicit undefined property counts', () => {
         expect(util.areObjectsEquivalent({ x: 1, y: undefined }, { x: 1 })).toBe(false)
     })
 })
@@ -79,13 +79,13 @@ describe('areArraysEquivalent', () => {
         name,
     })
 
-    test('element-wise equal arrays are equivalent', () => {
+    it('element-wise equal arrays are equivalent', () => {
         expect(util.areArraysEquivalent([filter(1, 'iron-plate')], [filter(1, 'iron-plate')])).toBe(
             true
         )
     })
 
-    test('order matters', () => {
+    it('order matters', () => {
         expect(
             util.areArraysEquivalent(
                 [filter(1, 'iron-plate'), filter(2, 'copper-plate')],
@@ -94,33 +94,33 @@ describe('areArraysEquivalent', () => {
         ).toBe(false)
     })
 
-    test('differing lengths are not equivalent', () => {
+    it('differing lengths are not equivalent', () => {
         expect(util.areArraysEquivalent([filter(1, 'iron-plate')], [])).toBe(false)
     })
 
-    test('two empty arrays are equivalent', () => {
+    it('two empty arrays are equivalent', () => {
         expect(util.areArraysEquivalent([], [])).toBe(true)
     })
 
     // undefined is never equivalent to anything, including another undefined.
     // Entity's setters rely on this: they return early when both sides are
     // undefined *before* calling, so reaching here with one means "changed".
-    test('undefined is not equivalent to undefined', () => {
+    it('undefined is not equivalent to undefined', () => {
         expect(util.areArraysEquivalent(undefined, undefined)).toBe(false)
     })
 
-    test('undefined is not equivalent to an empty array', () => {
+    it('undefined is not equivalent to an empty array', () => {
         expect(util.areArraysEquivalent(undefined, [])).toBe(false)
         expect(util.areArraysEquivalent([], undefined)).toBe(false)
     })
 })
 
 describe('Point', () => {
-    test('converts a tuple to a point', () => {
+    it('converts a tuple to a point', () => {
         expect(util.Point([1, 2])).toEqual({ x: 1, y: 2 })
     })
 
-    test('copies a point rather than aliasing it', () => {
+    it('copies a point rather than aliasing it', () => {
         const p = { x: 1, y: 2 }
         expect(util.Point(p)).not.toBe(p)
         expect(util.Point(p)).toEqual(p)
@@ -128,7 +128,7 @@ describe('Point', () => {
 })
 
 describe('rotatePointBasedOnDir', () => {
-    test.each([
+    it.each([
         [0, { x: 1, y: 2 }],
         [4, { x: -2, y: 1 }],
         [8, { x: -1, y: -2 }],
@@ -140,13 +140,13 @@ describe('rotatePointBasedOnDir', () => {
     // Unlike getDirName, a non-cardinal direction does not throw here - the
     // switch has no default, so the point stays at its initialised origin.
     // Recorded as current behaviour, not as the desired answer.
-    test('a diagonal direction silently returns the origin', () => {
+    it('a diagonal direction silently returns the origin', () => {
         expect(util.rotatePointBasedOnDir([1, 2], 2)).toEqual({ x: 0, y: 0 })
     })
 })
 
 describe('getDirName', () => {
-    test.each([
+    it.each([
         [0, 'north'],
         [4, 'east'],
         [8, 'south'],
@@ -155,17 +155,17 @@ describe('getDirName', () => {
         expect(util.getDirName(dir)).toBe(expected)
     })
 
-    test('a diagonal direction throws', () => {
+    it('a diagonal direction throws', () => {
         expect(() => util.getDirName(2)).toThrow('Unexpected direction!')
     })
 })
 
 describe('vectorToTuple', () => {
-    test('passes a tuple through', () => {
+    it('passes a tuple through', () => {
         expect(util.vectorToTuple([1, 2])).toEqual([1, 2])
     })
 
-    test('converts the struct form', () => {
+    it('converts the struct form', () => {
         expect(util.vectorToTuple({ x: 1, y: 2 })).toEqual([1, 2])
     })
 })

--- a/packages/editor/src/common/util.test.ts
+++ b/packages/editor/src/common/util.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from 'vitest'
+import util from './util'
+
+// util.ts is pure and FD-free, so it can be unit tested - but nothing did.
+// The two equivalence helpers are reached only from Entity's setters, which no
+// spec drives: entity-accessors.spec.ts tallies getters. So both could start
+// answering true for every pair and the whole suite would stay green while
+// edits silently no-opped. These pin what they answer today.
+
+describe('sumprod', () => {
+    test('sums vectors with no weights', () => {
+        expect(util.sumprod({ x: 1, y: 2 }, { x: 10, y: 20 })).toEqual({ x: 11, y: 22 })
+    })
+
+    test('accepts tuples and points interchangeably', () => {
+        expect(util.sumprod([1, 2], { x: 10, y: 20 })).toEqual({ x: 11, y: 22 })
+    })
+
+    test('applies a weight to the vector that follows it', () => {
+        expect(util.sumprod(2, { x: 1, y: 3 })).toEqual({ x: 2, y: 6 })
+    })
+
+    test('multiplies consecutive weights together', () => {
+        expect(util.sumprod(2, 3, { x: 1, y: 1 })).toEqual({ x: 6, y: 6 })
+    })
+
+    // The subtraction form every caller uses: sumprod(a, -1, b) is a - b.
+    test('negative weights subtract', () => {
+        expect(util.sumprod({ x: 5, y: 5 }, -1, { x: 2, y: 1 })).toEqual({ x: 3, y: 4 })
+    })
+
+    // A weight applies to one vector only - it is cleared after being consumed.
+    // Drop that reset and this becomes { x: 4, y: 4 }.
+    test('a weight does not carry over to the next vector', () => {
+        expect(util.sumprod(2, { x: 1, y: 1 }, { x: 1, y: 1 })).toEqual({ x: 3, y: 3 })
+    })
+
+    test('no arguments is the origin', () => {
+        expect(util.sumprod()).toEqual({ x: 0, y: 0 })
+    })
+
+    test('a trailing weight with no vector throws', () => {
+        expect(() => util.sumprod({ x: 1, y: 1 }, 2)).toThrow(TypeError)
+    })
+})
+
+describe('areObjectsEquivalent', () => {
+    test('equal own properties are equivalent', () => {
+        expect(util.areObjectsEquivalent({ x: 1, y: 2 }, { x: 1, y: 2 })).toBe(true)
+    })
+
+    test('a differing value is not', () => {
+        expect(util.areObjectsEquivalent({ x: 1, y: 2 }, { x: 1, y: 3 })).toBe(false)
+    })
+
+    test('a differing property count is not', () => {
+        expect(util.areObjectsEquivalent({ x: 1 }, { x: 1, y: 2 })).toBe(false)
+    })
+
+    // Same count, different keys: b has no `y`, so the read is undefined.
+    test('same count with different keys is not', () => {
+        expect(util.areObjectsEquivalent({ x: 1, y: 2 }, { x: 1, z: 2 })).toBe(false)
+    })
+
+    // The comparison is shallow - nested objects compare by reference.
+    test('equal nested objects are not equivalent', () => {
+        expect(util.areObjectsEquivalent({ p: { x: 1 } }, { p: { x: 1 } })).toBe(false)
+    })
+
+    // An explicit undefined is still an own property, so it counts toward length.
+    test('an explicit undefined property counts', () => {
+        expect(util.areObjectsEquivalent({ x: 1, y: undefined }, { x: 1 })).toBe(false)
+    })
+})
+
+describe('areArraysEquivalent', () => {
+    const filter = (index: number, name: string): { index: number; name: string } => ({
+        index,
+        name,
+    })
+
+    test('element-wise equal arrays are equivalent', () => {
+        expect(util.areArraysEquivalent([filter(1, 'iron-plate')], [filter(1, 'iron-plate')])).toBe(
+            true
+        )
+    })
+
+    test('order matters', () => {
+        expect(
+            util.areArraysEquivalent(
+                [filter(1, 'iron-plate'), filter(2, 'copper-plate')],
+                [filter(2, 'copper-plate'), filter(1, 'iron-plate')]
+            )
+        ).toBe(false)
+    })
+
+    test('differing lengths are not equivalent', () => {
+        expect(util.areArraysEquivalent([filter(1, 'iron-plate')], [])).toBe(false)
+    })
+
+    test('two empty arrays are equivalent', () => {
+        expect(util.areArraysEquivalent([], [])).toBe(true)
+    })
+
+    // undefined is never equivalent to anything, including another undefined.
+    // Entity's setters rely on this: they return early when both sides are
+    // undefined *before* calling, so reaching here with one means "changed".
+    test('undefined is not equivalent to undefined', () => {
+        expect(util.areArraysEquivalent(undefined, undefined)).toBe(false)
+    })
+
+    test('undefined is not equivalent to an empty array', () => {
+        expect(util.areArraysEquivalent(undefined, [])).toBe(false)
+        expect(util.areArraysEquivalent([], undefined)).toBe(false)
+    })
+})
+
+describe('Point', () => {
+    test('converts a tuple to a point', () => {
+        expect(util.Point([1, 2])).toEqual({ x: 1, y: 2 })
+    })
+
+    test('copies a point rather than aliasing it', () => {
+        const p = { x: 1, y: 2 }
+        expect(util.Point(p)).not.toBe(p)
+        expect(util.Point(p)).toEqual(p)
+    })
+})
+
+describe('rotatePointBasedOnDir', () => {
+    test.each([
+        [0, { x: 1, y: 2 }],
+        [4, { x: -2, y: 1 }],
+        [8, { x: -1, y: -2 }],
+        [12, { x: 2, y: -1 }],
+    ])('direction %i', (dir, expected) => {
+        expect(util.rotatePointBasedOnDir([1, 2], dir)).toEqual(expected)
+    })
+
+    // Unlike getDirName, a non-cardinal direction does not throw here - the
+    // switch has no default, so the point stays at its initialised origin.
+    // Recorded as current behaviour, not as the desired answer.
+    test('a diagonal direction silently returns the origin', () => {
+        expect(util.rotatePointBasedOnDir([1, 2], 2)).toEqual({ x: 0, y: 0 })
+    })
+})
+
+describe('getDirName', () => {
+    test.each([
+        [0, 'north'],
+        [4, 'east'],
+        [8, 'south'],
+        [12, 'west'],
+    ])('direction %i is %s', (dir, expected) => {
+        expect(util.getDirName(dir)).toBe(expected)
+    })
+
+    test('a diagonal direction throws', () => {
+        expect(() => util.getDirName(2)).toThrow('Unexpected direction!')
+    })
+})
+
+describe('vectorToTuple', () => {
+    test('passes a tuple through', () => {
+        expect(util.vectorToTuple([1, 2])).toEqual([1, 2])
+    })
+
+    test('converts the struct form', () => {
+        expect(util.vectorToTuple({ x: 1, y: 2 })).toEqual([1, 2])
+    })
+})

--- a/packages/editor/src/common/util.ts
+++ b/packages/editor/src/common/util.ts
@@ -19,7 +19,10 @@ const Point = (p: IPoint | readonly [number, number]): IPoint => {
 /** Computes a weighted sum of vectors. Weights are preceding their corresponding vector, and equal to 1 if not specified */
 const sumprod = (...args: (number | (number[] | IPoint))[]): IPoint => {
     const ans: IPoint = { x: 0, y: 0 }
-    let coef: number = undefined
+    // undefined is a value here, not a missing one: it means "no weight is
+    // pending", which is why every read is `coef ?? 1` and why consuming a
+    // vector resets it. The trailing-weight check below is the same state read.
+    let coef: number | undefined = undefined
     for (let arg of args) {
         if (typeof arg === 'number') {
             coef = (coef ?? 1) * arg
@@ -132,8 +135,16 @@ const nearestPowerOf2 = (n: number): number => Math.pow(2, Math.ceil(Math.log2(n
 
 const uniqueInArray = <T>(array: T[]): T[] => [...new Set(array)]
 
-const areObjectsEquivalent = <T extends Record<string, any>>(a: T, b: T): boolean => {
-    const aProps = Object.getOwnPropertyNames(a)
+/**
+ * Shallow own-property equality. The constraint is `object` rather than
+ * `Record<string, any>` because the callers pass interfaces (`IPoint`,
+ * `IFilter`), and an interface has no implicit index signature to satisfy a
+ * `Record` constraint with. `keyof T` on the property names is what that buys
+ * back: the own property names of a `T` are its keys, and any extra one present
+ * only at runtime is caught by the length check before it is read.
+ */
+const areObjectsEquivalent = <T extends object>(a: T, b: T): boolean => {
+    const aProps = Object.getOwnPropertyNames(a) as (keyof T)[]
     const bProps = Object.getOwnPropertyNames(b)
 
     if (aProps.length !== bProps.length) return false
@@ -145,7 +156,9 @@ const areObjectsEquivalent = <T extends Record<string, any>>(a: T, b: T): boolea
     return true
 }
 
-const areArraysEquivalent = <T>(a: T[] | undefined, b: T[] | undefined): boolean =>
+/** Element-wise {@link areObjectsEquivalent}. Note two undefined arrays are not
+ * equivalent - the callers guard that case before reaching here. */
+const areArraysEquivalent = <T extends object>(a: T[] | undefined, b: T[] | undefined): boolean =>
     a !== undefined &&
     b !== undefined &&
     a.length === b.length &&

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 23
+    "maxErrors": 20
 }


### PR DESCRIPTION
Third-to-last cluster of the strictNullChecks ratchet. Gate **23 -> 20**, no ripple into any other file.

## The two lies

**`sumprod`'s `coef`** was annotated `number` and initialised to `undefined`. undefined is a *value* there, not a missing one - it means "no weight is pending". The code already treats it that way: every read is `coef ?? 1`, consuming a vector resets it, and the trailing-weight check tests for it explicitly. Widened to `number | undefined`.

**`areObjectsEquivalent`'s constraint** was `Record<string, any>`, but its only callers pass interfaces (`IPoint`, `IFilter`) and an interface has no implicit index signature to satisfy a `Record` constraint with - which is why `areArraysEquivalent` could not forward its element type through it. Constrained both to `object`, and read the own property names as `keyof T`. That is accurate rather than convenient: the own property names of a `T` are its keys, and any extra one present only at runtime is caught by the length check before it is read.

No runtime change in either.

## The gap this found

`util.ts` is pure and FD-free - unit-testable with no editor, no data.json, no browser - and nothing tested it.

The two equivalence helpers are reached only from `Entity`'s setters, and no spec drives a setter (`entity-accessors.spec.ts` tallies getters). So both could have started answering `true` for every pair, silently no-opping every inserter-filter edit, and the entire suite would have stayed green. Same question as the last two batches: *if this were wrong, what would the existing tests report?* Answer: nothing.

`util.test.ts` adds 34 tests pinning current behaviour. They pass against the **unmodified** file, so they characterise rather than describe the fix. Two pin exactly what the changes touch:

- a weight is cleared after one vector - `sumprod(2, {x:1,y:1}, {x:1,y:1})` is `{x:3,y:3}`, not `{x:4,y:4}`
- `areArraysEquivalent(undefined, undefined)` is **false** - `Entity`'s setters return early on both-undefined *before* calling, so reaching the helper with one means "changed"

## Recorded, not changed

Two things found while reading, left alone:

- `rotatePointBasedOnDir` has no `default` arm, so a diagonal direction returns the origin instead of throwing the way `getDirName` does
- the comparison is shallow, so equal nested objects are not equivalent

Both are pinned as current behaviour with a comment saying so.

## Verification

- `npm run type-check:gate` - 20 errors, at the lowered baseline
- `vp test` - 8 files, 109 tests
- `npx playwright test` - 56 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRQWNPB54Wbd4CdJH1meUA