### PR TITLE
fix: give Book's search result a type that says which half is the answer (#22)

### DIFF
--- a/packages/editor/src/core/Book.ts
+++ b/packages/editor/src/core/Book.ts
@@ -33,12 +33,12 @@ class Book {
 
     private saveActiveBlueprint(): number {
         if (this._active) {
-            const [, activeIndex] = saveBlueprint(
-                this.blueprints,
-                this._activeIndex,
-                this._active.serialize()
-            )
-            return activeIndex
+            const res = saveBlueprint(this.blueprints, this._activeIndex, this._active.serialize())
+            // Not finding a slot used to answer undefined, which serialize() then
+            // wrote into `active_index` - a required number - and JSON.stringify
+            // dropped, producing a book with no active_index at all. 0 is what
+            // the no-active-blueprint branch below already answers.
+            return res.saved ? res.index : 0
         }
         return 0
     }
@@ -117,7 +117,16 @@ function getFlattenedActiveIndex(bps: IBlueprintBookEntry[] = [], active_index: 
     return res
 }
 
-function getBlueprintAtFlattenedActiveIndex(bps: IBlueprintBookEntry[], index: number): IBlueprint {
+/**
+ * The blueprint at flattened index `index`, or undefined where the index does
+ * not land on one - `selectBlueprint` feeds the answer straight to the
+ * `Blueprint` constructor, whose parameter is optional, so undefined degrades
+ * to an empty blueprint rather than throwing.
+ */
+function getBlueprintAtFlattenedActiveIndex(
+    bps: IBlueprintBookEntry[],
+    index: number
+): IBlueprint | undefined {
     const search = (bps: IBlueprintBookEntry[] = [], index: number): number | IBlueprint => {
         let i = index
         for (const { blueprint, blueprint_book } of bps) {
@@ -140,31 +149,39 @@ function getBlueprintAtFlattenedActiveIndex(bps: IBlueprintBookEntry[], index: n
     return typeof ret === 'number' ? undefined : ret
 }
 
-function saveBlueprint(
-    bps: IBlueprintBookEntry[] = [],
-    index: number,
-    bp: IBlueprint
-): [number, number] {
+/**
+ * The outcome of searching a book's entries for a flattened index. Exactly one
+ * of the two cases holds, which the `[number, number]` tuple this replaces could
+ * not say: it carried the answer in whichever slot was not undefined, and the
+ * recursive call read `newI === undefined` to mean "saved" - a meaning nothing
+ * in the type mentioned.
+ */
+type SaveResult =
+    /** Written into the entry at top-level index `index`. */
+    | { saved: true; index: number }
+    /** Not in these entries; `remaining` blueprints of the search index are left to skip. */
+    | { saved: false; remaining: number }
+
+function saveBlueprint(bps: IBlueprintBookEntry[] = [], index: number, bp: IBlueprint): SaveResult {
     let i = index
     for (let j = 0; j < bps.length; j++) {
         const { blueprint, blueprint_book } = bps[j]
         if (blueprint) {
             if (i === 0) {
                 bps[j].blueprint = bp
-                return [undefined, j]
+                return { saved: true, index: j }
             }
             i -= 1
         } else if (blueprint_book) {
-            const [newI, activeIndex] = saveBlueprint(blueprint_book.blueprints, i, bp)
-            if (newI === undefined) {
-                blueprint_book.active_index = activeIndex
-                return [undefined, j]
-            } else {
-                i = newI
+            const res = saveBlueprint(blueprint_book.blueprints, i, bp)
+            if (res.saved) {
+                blueprint_book.active_index = res.index
+                return { saved: true, index: j }
             }
+            i = res.remaining
         }
     }
-    return [i, undefined]
+    return { saved: false, remaining: i }
 }
 
 export { Book }

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -248,6 +248,14 @@ document.addEventListener('paste', (e: ClipboardEvent) => {
         await editor.loadBlueprint(bp)
     },
     /*
+        The blueprint string a copy would put on the clipboard, which for a loaded
+        book is Book.serialize(). Nothing else reaches that method: the round-trip
+        spec serializes the selected Blueprint, never the book around it, so the
+        active_index Book writes - its own and each nested book's - was read by
+        nothing at all.
+    */
+    encodeLoaded: () => encode(book || bp),
+    /*
         The size of EntityContainer.mappings, the static entity-number -> container
         index. Loading a blueprint should leave it holding exactly that
         blueprint's containers; anything above is retention from a previously

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 20
+    "maxErrors": 16
 }

--- a/tests/book-serialize.spec.ts
+++ b/tests/book-serialize.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprintBook, decodeBlueprintString, packVersion } from './helpers/encode-blueprint'
+import { waitForEditor } from './helpers/fbe-test-api'
+
+/*
+    Book's index arithmetic, which four specs walk through and none of them
+    assert on.
+
+    A book addresses its blueprints by a *flattened* index - nested books
+    contribute their contents to the count rather than themselves - while the
+    `active_index` it serializes is a *top-level* entry index, with each nested
+    book carrying its own. Book.ts converts between the two in three places, and
+    only one of them is observable through the editor: `selectBlueprint` hands
+    back a Blueprint, so entity-accessors, sprite-data, round-trip and
+    entity-container-mappings would all notice it resolving to the wrong one.
+
+    Nothing notices the other two. `saveBlueprint`'s answer becomes the
+    `active_index` on the serialized book and on every nested book it passed
+    through, and that value is written by `Book.serialize()` - a method the
+    round-trip spec never calls, because it serializes the selected Blueprint and
+    not the book around it. So both could be wrong, or absent, with the whole
+    suite green: nothing about which entities come back depends on active_index.
+
+    The corpus cannot stand in for this either. Its books are real exports whose
+    nesting this spec did not choose, so there is no index it can name and say
+    which blueprint should answer to it.
+*/
+
+const VERSION = packVersion(2, 0, 55)
+
+/** A one-entity blueprint, identifiable by its label. */
+const blueprint = (label: string): Record<string, unknown> => ({
+    item: 'blueprint',
+    version: VERSION,
+    label,
+    entities: [{ entity_number: 1, name: 'wooden-chest', position: { x: 0.5, y: 0.5 } }],
+})
+
+/*
+    Flattened index -> label:
+
+      entry 0  blueprint A            0
+      entry 1  book                     entry 0  blueprint B    1
+                                        entry 1  blueprint C    2
+      entry 2  blueprint D            3
+
+    Four blueprints across three top-level entries is the smallest shape where a
+    flattened index differs from the top-level one in both directions, so an
+    off-by-one in either conversion lands on the wrong blueprint.
+*/
+const BOOK = {
+    item: 'blueprint-book',
+    version: VERSION,
+    active_index: 0,
+    label: 'outer',
+    blueprints: [
+        { index: 0, blueprint: blueprint('A') },
+        {
+            index: 1,
+            blueprint_book: {
+                item: 'blueprint-book',
+                version: VERSION,
+                active_index: 0,
+                label: 'inner',
+                blueprints: [
+                    { index: 0, blueprint: blueprint('B') },
+                    { index: 1, blueprint: blueprint('C') },
+                ],
+            },
+        },
+        { index: 2, blueprint: blueprint('D') },
+    ],
+}
+
+async function loadBook(page: import('@playwright/test').Page): Promise<void> {
+    await waitForEditor(page)
+    await page.evaluate(async (src: string) => {
+        const t = window.__fbe_test
+        await t.loadBp(await t.getBlueprintOrBookFromSource(src))
+    }, encodeBlueprintBook(BOOK))
+}
+
+test('a flattened index reaches the blueprint at that position', async ({ page }) => {
+    await loadBook(page)
+
+    const labels = await page.evaluate(async () => {
+        const t = window.__fbe_test
+        const book = await t.getBlueprintOrBookFromSource(await t.encodeLoaded())
+        const out: (string | undefined)[] = []
+        for (let i = 0; i <= 3; i++) {
+            out.push((book.selectBlueprint(i) as { name?: string }).name)
+        }
+        return out
+    })
+
+    expect(labels).toEqual(['A', 'B', 'C', 'D'])
+})
+
+test('the book reports its last flattened index, counting nested entries', async ({ page }) => {
+    await loadBook(page)
+
+    // Three top-level entries, four blueprints - the nested book contributes its
+    // contents rather than itself.
+    const last = await page.evaluate(async () => {
+        const t = window.__fbe_test
+        const book = await t.getBlueprintOrBookFromSource(await t.encodeLoaded())
+        return book.lastBookIndex
+    })
+
+    expect(last).toBe(3)
+})
+
+test('serializing writes active_index at every level it passed through', async ({ page }) => {
+    await loadBook(page)
+
+    /*
+        Flattened 2 is blueprint C, the second entry of the nested book. The
+        serialized outer book should point at entry 1 - the nested book, not the
+        flattened position - and the nested book at its own entry 1.
+    */
+    const encoded = await page.evaluate(async () => {
+        const t = window.__fbe_test
+        await t.selectBookIndex(2)
+        return t.encodeLoaded()
+    })
+
+    const book = decodeBlueprintString(encoded).blueprint_book
+
+    expect(book.active_index).toBe(1)
+    expect(book.blueprints[1].blueprint_book.active_index).toBe(1)
+})
+
+test('selecting a top-level entry after a nested one points back at it', async ({ page }) => {
+    await loadBook(page)
+
+    // D is flattened 3 but top-level entry 2. Going through the nested book
+    // first means the walk has to unwind its offset again.
+    const encoded = await page.evaluate(async () => {
+        const t = window.__fbe_test
+        await t.selectBookIndex(2)
+        await t.selectBookIndex(3)
+        return t.encodeLoaded()
+    })
+
+    const book = decodeBlueprintString(encoded).blueprint_book
+
+    expect(book.active_index).toBe(2)
+})
+
+test('every blueprint survives a select and serialize round trip', async ({ page }) => {
+    await loadBook(page)
+
+    /*
+        Saving the active blueprint writes it back into its entry, so a walk of
+        the whole book rewrites all four. A save that landed on the wrong slot
+        would duplicate one label and lose another.
+    */
+    const encoded = await page.evaluate(async () => {
+        const t = window.__fbe_test
+        for (let i = 0; i <= 3; i++) await t.selectBookIndex(i)
+        return t.encodeLoaded()
+    })
+
+    const book = decodeBlueprintString(encoded).blueprint_book
+    const labels = [
+        book.blueprints[0].blueprint.label,
+        book.blueprints[1].blueprint_book.blueprints[0].blueprint.label,
+        book.blueprints[1].blueprint_book.blueprints[1].blueprint.label,
+        book.blueprints[2].blueprint.label,
+    ]
+
+    expect(labels).toEqual(['A', 'B', 'C', 'D'])
+})

--- a/tests/helpers/encode-blueprint.ts
+++ b/tests/helpers/encode-blueprint.ts
@@ -1,4 +1,4 @@
-import { deflateSync } from 'zlib'
+import { deflateSync, inflateSync } from 'zlib'
 
 /*
     Builds the blueprint strings bpString.decode() reads, for the specs whose case
@@ -13,7 +13,30 @@ import { deflateSync } from 'zlib'
 
 /** The encoding decode() expects: a version byte, then deflated JSON. */
 export function encodeBlueprint(blueprint: Record<string, unknown>): string {
-    return `0${deflateSync(Buffer.from(JSON.stringify({ blueprint }))).toString('base64')}`
+    return wrap({ blueprint })
+}
+
+/**
+ * The same, for a book. The corpus has books, but every one of them is a real
+ * export whose nesting and active_index the spec did not choose - which is no
+ * use for asserting that a particular index resolves to a particular blueprint.
+ */
+export function encodeBlueprintBook(blueprint_book: Record<string, unknown>): string {
+    return wrap({ blueprint_book })
+}
+
+function wrap(data: Record<string, unknown>): string {
+    return `0${deflateSync(Buffer.from(JSON.stringify(data))).toString('base64')}`
+}
+
+/**
+ * The inverse, for reading back what the editor encoded. Asserting on the
+ * decoded object rather than on a reload is the point where a book is concerned:
+ * `active_index` decides nothing about which entities come back, so a reload
+ * cannot see it being written wrong.
+ */
+export function decodeBlueprintString(source: string): Record<string, any> {
+    return JSON.parse(inflateSync(Buffer.from(source.slice(1), 'base64')).toString())
 }
 
 /** How Factorio packs a version into the blueprint's `version` field. */

--- a/tests/helpers/fbe-test-api.ts
+++ b/tests/helpers/fbe-test-api.ts
@@ -72,6 +72,13 @@ export interface FbeTestApi {
     wireCount: () => number
     /** How many tile sprites the canvas is drawing. See tests/tiles.spec.ts. */
     tileSpriteCount: () => number
+    /**
+     * The blueprint string a copy would produce - `Book.serialize()` when a book
+     * is loaded, which nothing else reaches. See tests/book-serialize.spec.ts.
+     */
+    encodeLoaded: () => Promise<string>
+    /** Make the book's blueprint at this flattened index the active one. */
+    selectBookIndex: (index: number) => Promise<void>
 }
 
 /**


### PR DESCRIPTION
Gate **20 -> 16**. Three of `Book.ts`'s four errors were one lying type.

## The tuple

`saveBlueprint` returned `[number, number]` and carried its answer in whichever slot was not undefined:

- `[undefined, j]` - saved into top-level entry `j`
- `[i, undefined]` - not in these entries, `i` blueprints left to skip

The recursive call tested `newI === undefined` to mean *saved*, a meaning nothing in the type mentions and the reader has to reconstruct. Replaced with a two-case union discriminated on `saved`, so neither slot can be read in the case where it is meaningless.

`getBlueprintAtFlattenedActiveIndex` was declared `IBlueprint` while returning `undefined` for an index that lands on no blueprint. That undefined is a *supported answer*, not a bug - `selectBlueprint` hands it to the `Blueprint` constructor, whose parameter is optional, so it degrades to an empty blueprint. Widened to `IBlueprint | undefined`.

**Scope, plainly:** both are defensive. Neither not-found path looks reachable through the editor - `selectBlueprint` clamps to `lastBookIndex`, and a book declaring an out-of-range `active_index` throws in `getFlattenedActiveIndex` before it ever gets here. The one intentional behaviour change is that a failed save now answers `0` instead of `undefined`, which `serialize()` was writing into `active_index` - a required number that `JSON.stringify` then dropped from the output entirely. `0` is what the no-active-blueprint branch beside it already answers.

## The gap this found

`Book` converts between a **flattened** index (nested books contribute their contents, not themselves) and a **per-level entry** index, in three places. Only one of the three is observable through the editor: `selectBlueprint` returns a Blueprint, so `entity-accessors`, `sprite-data`, `blueprint-round-trip` and `entity-container-mappings` would all notice it resolving to the wrong one.

Nothing observed the other two. Their only output is `active_index`, written by `Book.serialize()` - **and no spec called that method.** The round-trip spec serializes the selected `Blueprint`, never the book around it. So the `active_index` on the copied book, and on every nested book the save passed through, could have been wrong or missing entirely with the whole suite green, because nothing about which entities come back depends on it.

`tests/book-serialize.spec.ts` builds a book whose shape it chose:

```
entry 0  blueprint A                              flattened 0
entry 1  book -> entry 0  blueprint B             flattened 1
                 entry 1  blueprint C             flattened 2
entry 2  blueprint D                              flattened 3
```

Four blueprints across three top-level entries is the smallest shape where the two indices differ in both directions. Selecting flattened 2 must write `active_index: 1` on the outer book (the nested book's entry, not the flattened position) and `1` on the nested one.

The corpus cannot stand in for this: its books are real exports whose nesting the spec did not pick, so there is no index it can name and say which blueprint should answer to it.

**The five tests pass identically against `Book.ts` before and after this change.** That is the evidence the union refactor moved no behaviour - I ran them against the stashed original rather than assuming it.

## New test surface

- `__fbe_test.encodeLoaded()` - the string a copy would produce, which for a loaded book is `Book.serialize()`
- `encodeBlueprintBook` / `decodeBlueprintString` in the encode helper - asserting on decoded JSON rather than on a reload is the point, since `active_index` decides nothing about which entities come back

## Verification

- `npm run type-check:gate` - 16 errors, at the lowered baseline
- `vp test` - 109 tests
- `npx playwright test` - 61 passed (56 + 5 new)
- `vp lint` and `vp fmt --check` - both exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRQWNPB54Wbd4CdJH1meUA