### PR TITLE
fix: clear the UI cluster, mostly by reading localised_name once (#22)

### DIFF
--- a/packages/editor/src/UI/EntityInfoPanel.ts
+++ b/packages/editor/src/UI/EntityInfoPanel.ts
@@ -5,6 +5,7 @@ import FD, {
     isCraftingMachine,
     isInserter,
     isTransportBeltConnectable,
+    localisedName,
     recipeIngredients,
     recipeResults,
 } from '../core/factorioData'
@@ -109,7 +110,7 @@ export class EntityInfoPanel extends Panel {
         this.visible = true
         let nextY = this.title.position.y + this.title.height + 10
 
-        this.m_EntityName.text = `Name: ${FD.entities[entity.name].localised_name}`
+        this.m_EntityName.text = `Name: ${localisedName(FD.entities[entity.name])}`
         this.m_EntityName.position.set(10, nextY)
         nextY = this.m_EntityName.position.y + this.m_EntityName.height + 10
 
@@ -245,9 +246,18 @@ export class EntityInfoPanel extends Panel {
             e.entityData.type === 'loader'
 
         const inserterData = entity.entityData
-        if (isInserter(inserterData)) {
+        /*
+            stackSize is null only for an entity that is not an inserter and
+            carries no override_stack_size, so the isInserter narrowing beside it
+            already rules that out - but the narrowing is on entityData and the
+            getter reads it again, which TypeScript cannot connect. Tested rather
+            than asserted: if it ever is null the speed line is left off, which
+            is a missing line and not a thrown panel.
+        */
+        const stackSize = entity.inserterStackSize
+        if (isInserter(inserterData) && stackSize !== null) {
             // Details for inserters
-            let speed = containerToContainer(inserterData.rotation_speed, entity.inserterStackSize)
+            let speed = containerToContainer(inserterData.rotation_speed, stackSize)
             const tiles = entity.name === 'long-handed-inserter' ? 2 : 1
             // const fromP = util.rotatePointBasedOnDir([0, -tiles], entity.direction)
             const toP = util.rotatePointBasedOnDir([0, tiles], entity.direction)
@@ -261,11 +271,7 @@ export class EntityInfoPanel extends Panel {
             )
             const toData = to?.entityData
             if (to && isBelt(to) && toData && isTransportBeltConnectable(toData)) {
-                speed = containerToBelt(
-                    inserterData.rotation_speed,
-                    toData.speed,
-                    entity.inserterStackSize
-                )
+                speed = containerToBelt(inserterData.rotation_speed, toData.speed, stackSize)
             }
             this.m_entityInfo.text = `Speed: ${roundToTwo(
                 speed

--- a/packages/editor/src/UI/InventoryDialog.ts
+++ b/packages/editor/src/UI/InventoryDialog.ts
@@ -1,5 +1,5 @@
 import { Container, Graphics, Rectangle, Text } from 'pixi.js'
-import FD, { recipeIngredients, recipeResults } from '../core/factorioData'
+import FD, { localisedName, recipeIngredients, recipeResults } from '../core/factorioData'
 import G from '../common/globals'
 import F from './controls/functions'
 import { Dialog } from './controls/Dialog'
@@ -47,8 +47,8 @@ export class InventoryDialog extends Dialog {
     /** Container for Recipe Tooltip */
     private readonly m_RecipeContainer: Container
 
-    /** Hovered item for item pointerout check */
-    private m_hoveredItem: string
+    /** Hovered item for item pointerout check; undefined when nothing is hovered. */
+    private m_hoveredItem: string | undefined
 
     /** Content height (px) of each inventory group container, for scroll clamping */
     private readonly m_ContentHeights = new Map<Container, number>()
@@ -65,8 +65,11 @@ export class InventoryDialog extends Dialog {
 
     public constructor(
         title = 'Inventory',
-        itemsFilter?: string[],
-        selectedCallBack?: (selectedItem: string) => void
+        itemsFilter: string[] | undefined,
+        // Not optional: picking an item is the whole point of the dialog, and all
+        // five call sites pass one. Optional only made the invocation below a
+        // type error, with nothing to do about it that was not a fiction.
+        selectedCallBack: (selectedItem: string) => void
     ) {
         super(404, 442, title)
 
@@ -279,12 +282,12 @@ export class InventoryDialog extends Dialog {
 
         const item = FD.items[recipeName]
         if (item && item.subgroup === 'creative') {
-            this.m_RecipeLabel.text = `[CREATIVE] - ${item.localised_name}`
+            this.m_RecipeLabel.text = `[CREATIVE] - ${localisedName(item)}`
         }
 
         const recipe = FD.recipes[recipeName]
         if (recipe === undefined) return
-        this.m_RecipeLabel.text = recipe.localised_name
+        this.m_RecipeLabel.text = localisedName(recipe)
 
         F.CreateRecipe(
             this.m_RecipeContainer,

--- a/packages/editor/src/UI/UIContainer.ts
+++ b/packages/editor/src/UI/UIContainer.ts
@@ -58,9 +58,9 @@ export class UIContainer extends Container {
     }
 
     public createInventory(
-        title?: string,
-        itemsFilter?: string[],
-        selectedCallBack?: (selectedItem: string) => void
+        title: string | undefined,
+        itemsFilter: string[] | undefined,
+        selectedCallBack: (selectedItem: string) => void
     ): InventoryDialog {
         const inv = new InventoryDialog(title, itemsFilter, selectedCallBack)
         this.dialogsContainer.addChild(inv)

--- a/packages/editor/src/UI/WiresPanel.ts
+++ b/packages/editor/src/UI/WiresPanel.ts
@@ -6,7 +6,14 @@ import { Slot } from './controls/Slot'
 import F from './controls/functions'
 import { colors } from './style'
 
-class WireSlot extends Slot<string | undefined> {
+/*
+    Slot<string>, not the Slot<string | undefined> QuickbarSlot uses. The two
+    look alike but a quickbar slot can be emptied - unassignItem sets its data
+    back to undefined - while every wire slot is constructed and named in the
+    same breath below, and there are exactly three of them for as long as the
+    panel exists. Nothing ever clears one.
+*/
+class WireSlot extends Slot<string> {
     public get wireName(): string {
         return this.data
     }

--- a/packages/editor/src/UI/controls/Slider.ts
+++ b/packages/editor/src/UI/controls/Slider.ts
@@ -169,9 +169,11 @@ export class Slider extends Container {
     private readonly onButtonDragStart = (event: FederatedPointerEvent): void => {
         if (!this.m_Dragging) {
             this.m_Dragging = true
+            // `this`, not m_SliderButton.parent: the constructor addChild's the
+            // button to this Slider and nothing reparents it, so they are the
+            // same container - and this one cannot be null.
             this.m_Dragpoint =
-                this.m_SliderButton.parent.worldTransform.applyInverse(event.global).x -
-                this.m_SliderButton.x
+                this.worldTransform.applyInverse(event.global).x - this.m_SliderButton.x
             this.m_SliderButton.getChildAt<ContainerChild>(1).visible = true
         }
     }
@@ -179,7 +181,7 @@ export class Slider extends Container {
     /** Drag move event callback  */
     private readonly onButtonDragMove = (event: FederatedPointerEvent): void => {
         if (this.m_Dragging) {
-            const position = this.m_SliderButton.parent.worldTransform.applyInverse(event.global)
+            const position = this.worldTransform.applyInverse(event.global)
 
             let x = position.x - this.m_Dragpoint
             if (x > 0 && x < Slider.SLIDER_WIDTH) {

--- a/packages/editor/src/UI/editors/Editor.ts
+++ b/packages/editor/src/UI/editors/Editor.ts
@@ -1,5 +1,6 @@
 import EventEmitter from 'eventemitter3'
 import { Entity, EntityEvents } from '../../core/Entity'
+import { localisedName } from '../../core/factorioData'
 import { Dialog } from '../controls/Dialog'
 import { Preview } from './components/Preview'
 import { Recipe } from './components/Recipe'
@@ -22,7 +23,7 @@ export abstract class Editor extends Dialog {
      * @param entity - Reference to Entity Data
      */
     public constructor(width: number, height: number, entity: Entity) {
-        super(width, height, entity.entityData.localised_name as string)
+        super(width, height, localisedName(entity.entityData))
 
         // Store reference to entity for later use
         this.m_Entity = entity

--- a/packages/editor/src/UI/editors/factory.ts
+++ b/packages/editor/src/UI/editors/factory.ts
@@ -18,7 +18,9 @@ import { TrainStopEditor } from './TrainStopEditor'
  *
  * @param entityNumber - Entity Number for which to create Editor for
  */
-export function createEditor(entity: Entity): Editor {
+export function createEditor(entity: Entity): Editor | undefined {
+    // undefined is the common answer, not a failure: most entities have no
+    // editor at all, which is why the sole caller is already an `if (editor)`.
     let editor: Editor
     switch (entity.name) {
         // Assembly Machines

--- a/packages/editor/src/core/factorioData.test.ts
+++ b/packages/editor/src/core/factorioData.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test'
 import { RecipePrototype } from 'factorio:prototype'
-import { recipeIngredients, recipeResults } from './factorioData'
+import { localisedName, recipeIngredients, recipeResults } from './factorioData'
 
 /*
     recipeIngredients/recipeResults exist because the two fields arrive in three
@@ -45,5 +45,43 @@ describe('recipeIngredients / recipeResults', () => {
 
         expect(recipeIngredients(r)).toEqual([])
         expect(recipeResults(r)).toBe(results)
+    })
+})
+
+/*
+    localisedName covers the same kind of gap one field over: typed-factorio types
+    localised_name as the nested LocalisedString Factorio resolves at runtime,
+    while the exporter resolves it first, so every one of the 1352 in data.json is
+    a plain string. The four readers were split between assigning it to a pixi
+    Text (a type error), interpolating it into a template literal (silently
+    "[object Object]" for any other shape) and an `as string` cast.
+*/
+describe('localisedName', () => {
+    it('passes the resolved string every prototype in data.json actually carries', () => {
+        expect(localisedName({ localised_name: 'Iron plate' })).toBe('Iron plate')
+    })
+
+    it('answers an empty string where the optional field is absent', () => {
+        expect(localisedName({})).toBe('')
+    })
+
+    it('renders the nested form rather than dropping it', () => {
+        // The shape Factorio itself uses. Nothing in data.json has it today, and
+        // the point of joining rather than returning '' is that one arriving
+        // later looks wrong on screen instead of vanishing.
+        expect(localisedName({ localised_name: ['item-name.iron-plate'] })).toBe(
+            'item-name.iron-plate'
+        )
+    })
+
+    it('flattens a nested form with substitutions', () => {
+        expect(localisedName({ localised_name: ['item-name.plate', ['metal.iron'], 'x2'] })).toBe(
+            'item-name.plate metal.iron x2'
+        )
+    })
+
+    it('stringifies the number and boolean forms LocalisedString allows', () => {
+        expect(localisedName({ localised_name: 42 })).toBe('42')
+        expect(localisedName({ localised_name: false })).toBe('false')
     })
 })

--- a/packages/editor/src/core/factorioData.ts
+++ b/packages/editor/src/core/factorioData.ts
@@ -1,5 +1,5 @@
 import { CircuitConnectorDefinition } from 'factorio:prototype'
-import { IconData } from 'factorio:prototype'
+import { IconData, LocalisedString } from 'factorio:prototype'
 import {
     RecipePrototype,
     IngredientPrototype,
@@ -129,6 +129,29 @@ export function recipeIngredients(recipe: RecipePrototype): readonly IngredientP
 /** @see recipeIngredients - same three shapes. */
 export function recipeResults(recipe: RecipePrototype): readonly ProductPrototype[] {
     return Array.isArray(recipe.results) ? recipe.results : []
+}
+
+/**
+ * A prototype's display name, as a string that can go straight into a `Text`.
+ *
+ * typed-factorio types `localised_name` as `LocalisedString`, which is the
+ * nested form Factorio resolves at runtime - `['item-name.iron-plate']`, or a
+ * number, or an array of those. The exporter resolves it before writing
+ * data.json, so all 1352 in the current output are plain strings, and the field
+ * is also optional on most prototypes while every one of them has it.
+ *
+ * Neither of those is worth trusting silently: a `LocalisedString` assigned to a
+ * pixi `Text` is a type error, and the two sites that read it around a template
+ * literal would have quietly rendered `[object Object]` instead. So the array
+ * form is joined rather than dropped - a name that ever does arrive nested shows
+ * up on screen looking wrong, which is findable, rather than not showing at all.
+ */
+export function localisedName(proto: { localised_name?: LocalisedString }): string {
+    const name = proto.localised_name
+    if (name === undefined) return ''
+    if (Array.isArray(name))
+        return name.map(part => localisedName({ localised_name: part })).join(' ')
+    return String(name)
 }
 
 export function recipeSupportsModule(recipe: string, module: ModulePrototype): boolean {

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 16
+    "maxErrors": 7
 }


### PR DESCRIPTION
Nine errors across five files. Gate **16 -> 7**.

## Four of them were one field

`localised_name` is typed `LocalisedString` - the nested form Factorio resolves at runtime, `['item-name.iron-plate']`. The exporter resolves it *before* writing data.json, so all **1352** in the current output are plain strings. I checked rather than assumed:

```
items:string 340   recipes:string 653   entities:string 149
fluids:string 33   signals:string 155   tiles:string 22
```

Zero array forms. The four readers had each coped differently:

| site | what it did |
| --- | --- |
| `InventoryDialog:287` | assigned it to a pixi `Text` - the actual type error |
| `InventoryDialog:282` | interpolated into a template literal |
| `EntityInfoPanel:112` | interpolated into a template literal |
| `editors/Editor.ts:25` | `as string` cast |

The two template literals are the interesting ones: they compile, and would have quietly rendered `[object Object]` for any shape that is not a string. Added `localisedName()` in `factorioData.ts` beside `recipeIngredients`/`recipeResults` - where the shape-tolerant readers live by convention - and pointed all four at it, cast included.

It **joins** the nested form rather than dropping it. A name that ever does arrive nested then looks wrong on screen, which is findable, instead of not appearing at all.

## The rest, one per site

- **`Slider`** read `m_SliderButton.parent.worldTransform` twice, and `parent` is nullable. The constructor `addChild`s the button to the Slider and nothing reparents it, so the parent *is* `this` - which cannot be null. Two errors, no guard, no assertion.
- **`WireSlot`** was `Slot<string | undefined>`, copied from `QuickbarSlot`. They only look alike: the quickbar can be emptied (`unassignItem` sets undefined), while a wire slot is constructed and named in the same breath and there are exactly three for the panel's lifetime. `Slot<string>`.
- **`createEditor`** declared `Editor` and returned undefined in its default arm. undefined is the *common* answer - most entities have no editor - and the sole caller is already `if (editor)`.
- **`InventoryDialog`'s `selectedCallBack`** was optional and invoked unconditionally. All five call sites pass one and the dialog does nothing without it, so it is required now rather than guarded into a fiction.
- **`m_hoveredItem`** was `string` and assigned undefined on pointerout. undefined means nothing is hovered.
- **`EntityInfoPanel`** read `entity.inserterStackSize`, null for a non-inserter. The `isInserter` narrowing beside it rules that out, but it narrows `entityData` while the getter reads it again - a connection TypeScript cannot make. Read once and tested, so a null would leave the speed line off rather than throw the panel.

## Verification

`InventoryDialog` and `Slider` have **no test at all**, and I changed a constructor signature and drag arithmetic in them. So I drove both by hand rather than inferring from a green suite:

- inventory opens on `E` and labels a hovered item **"Transport belt"** through the new reader, ingredients and results beside it, no console errors
- the Move Speed slider drags **10 -> 5** on the rewritten transform read

`localisedName` is pure, so its five shapes (resolved string, absent, nested, nested-with-substitutions, number/boolean) are unit tested in `factorioData.test.ts`.

- `npm run type-check:gate` - 7 errors, at the lowered baseline
- `vp test` - 114 tests
- `npx playwright test` - 61 passed
- `vp lint` / `vp fmt --check` - both exit 0

## What is left

7 errors: `common/globals.ts` (5) and `containers/BlueprintContainer.ts` (2), which are the knot - globals holds `BPC` and `bp`, and BlueprintContainer's two are the measured +33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRQWNPB54Wbd4CdJH1meUA