### PR TITLE
fix: give globals a declared shape instead of five unassigned placeholders (#22)

### DIFF
--- a/packages/editor/src/common/globals.ts
+++ b/packages/editor/src/common/globals.ts
@@ -30,13 +30,29 @@ const logger: Logger = msg => {
     }
 }
 
-/* oxlint-disable no-unassigned-vars -- type placeholders for the exported globals object; values are set on its properties at runtime */
-let app: Application<Renderer<HTMLCanvasElement>>
-let BPC: BlueprintContainer
-let UI: UIContainer
-let bp: Blueprint
-let actions: ActionRegistry
-/* oxlint-enable no-unassigned-vars */
+/**
+ * The globals Editor.init assigns on its way up, before anything reads them.
+ *
+ * These five used to be `let` declarations with no initialiser, there only to
+ * give the exported object its property types - the values were always assigned
+ * to the object's properties (`G.BPC = ...`), never to the variables, which
+ * stayed undefined for the life of the module. So the object literal captured
+ * five undefineds and each of them was a "used before being assigned" error,
+ * held off with an oxlint-disable that had to explain the same thing in prose.
+ *
+ * Declaring the shape says it once, in the type, and lets the object literal
+ * carry only what genuinely has a value at module scope.
+ */
+interface Globals {
+    debug: boolean
+    app: Application<Renderer<HTMLCanvasElement>>
+    BPC: BlueprintContainer
+    UI: UIContainer
+    bp: Blueprint
+    actions: ActionRegistry
+    getTexture: typeof getTexture
+    logger: Logger
+}
 
 const started = new Map<string, Promise<Texture>>()
 const textureCache = new Map<string, Texture>()
@@ -86,13 +102,10 @@ function getTexture(path: string, x = 0, y = 0, w = 0, h = 0): Texture {
     return t
 }
 
+// The cast is the whole of the "assigned by Editor.init" protocol, in one place
+// rather than spread across five declarations.
 export default {
     debug,
-    BPC,
-    UI,
-    app,
-    bp,
-    actions,
     getTexture,
     logger,
-}
+} as Globals

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.json",
-    "maxErrors": 7
+    "maxErrors": 2
 }


### PR DESCRIPTION
Gate **7 -> 2**.

## What was there

`globals.ts` held five `let` declarations with no initialiser:

```ts
/* oxlint-disable no-unassigned-vars -- type placeholders for the exported globals object; values are set on its properties at runtime */
let app: Application<Renderer<HTMLCanvasElement>>
let BPC: BlueprintContainer
let UI: UIContainer
let bp: Blueprint
let actions: ActionRegistry
/* oxlint-enable no-unassigned-vars */
```

They existed only to give the exported object its property types. The values are assigned to the *object's properties* (`G.BPC = ...`, from `Editor.init`) and never to the variables, so the variables stayed undefined for the life of the module and the object literal captured five undefineds - five "used before being assigned" errors, held off by a lint suppression that had to restate the whole arrangement in prose.

## What it is now

A declared `Globals` interface, with the literal cast to it. The object carries only what genuinely has a value at module scope; the "assigned by `Editor.init` before anything reads it" protocol is stated once, in the type, instead of five times in declarations that were never true. The oxlint-disable goes away with them.

No ripple - every consumer reads through `G.x`, and those property types are unchanged.

## The knot, measured

The remaining 2 are `BlueprintContainer.hoverContainer` and `.paintContainer`. Widening both to `| undefined` - which is what they are, both are assigned undefined - takes the count **2 -> 35**:

```
28  containers/BlueprintContainer.ts
 5  UI/QuickbarPanel.ts
 2  UI/WiresPanel.ts
```

I measured that rather than trusting the figure in my notes. The useful part is what the 35 look like: **every one sits behind a `mode === EditorMode.PAINT` or `mode === EditorMode.EDIT` check that already implies the container exists.** TypeScript cannot connect a mode enum to a field's definedness, but that is one invariant, not 35 problems, and it wants the accessor treatment `PositionGrid.entityAt()` and `EntityContainer.containerOf()` already use in this codebase - throw with a name if the invariant is broken, rather than let a silent undefined deref happen.

That is its own batch in the most input-driven file in the project, so it is not riding along here.

## Verification

- `npm run type-check:gate` - 2 errors, at the lowered baseline
- `vp test` - 114 tests
- `npx playwright test` - 61 passed
- `vp lint` / `vp fmt --check` - both exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRQWNPB54Wbd4CdJH1meUA