### PR TITLE
fix: clear packages/website's 15 type errors and turn on vp check's type check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,18 +37,25 @@ jobs:
       - name: Install dependencies
         run: vp install --frozen-lockfile
 
-      - name: Format check (oxfmt)
+      # Format + lint + type check, every package. This replaces the separate
+      # oxfmt and oxlint steps: `lint.options.typeCheck` is now true in
+      # vite.config.ts, which it could not be while packages/website carried 15
+      # unchecked type errors (issue #78).
+      - name: Check (oxfmt + oxlint + tsc)
         if: ${{ !cancelled() }}
-        run: vp fmt . --check
-
-      - name: Lint (oxlint)
-        if: ${{ !cancelled() }}
-        run: vp lint .
+        run: vp check .
 
       - name: Tests (vitest - units + gate)
         if: ${{ !cancelled() }}
         run: vp test
 
+      # Kept alongside `vp check` rather than folded into it. The two answer
+      # different questions: vp check asks "does this type-check under the flags
+      # that are on", the gate asks "has the count gone above the committed
+      # baseline". The baseline is 0 today, so this is currently redundant - it
+      # earns its place at the next flag flip, where the count starts non-zero
+      # and ratchets down (issue #77). Note that migration cannot use the
+      # ratchet while typeCheck is on, since vp check tolerates nothing.
       - name: Type-check gate
         if: ${{ !cancelled() }}
         run: npm run type-check:gate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,23 +31,26 @@ cd packages/website && vp build
 # Type check. strictNullChecks is on and this is clean - see issue #22, closed.
 npx tsc --noEmit -p packages/editor/tsconfig.json
 
-# CI type-check gate: fails only if the error count exceeds the committed
-# baseline in scripts/type-check-baseline.json, now 0. Raise maxErrors when
-# turning on a new strict flag, then ratchet it back down. Runs in CI via
-# .github/workflows/ci.yml (oxfmt + oxlint + vitest gate + tsc gate) on
-# PRs/pushes to wormeyman-space-age-support.
+# Format + lint + type check, every package, one command. This is the one to
+# run before pushing, and it is what CI runs. `lint.options.typeCheck` is true
+# in vite.config.ts, which it could not be until packages/website's 15 type
+# errors were cleared (issue #78). `--fix` applies the format and lint fixes.
 #
-# IMPORTANT: the gate covers packages/editor ONLY. packages/website has 15
-# type errors that nothing checks (packages/worker has 0) - see issue #78.
-npm run type-check:gate
-
-# Format + lint in one command. NOT a type check: `lint.options.typeCheck` is
-# false in vite.config.ts, and turning it true fails on exactly those 15
-# website errors, which is why it is off. Prefer this over running `vp fmt
-# --check` and `vp lint` separately - it prints an error/warning count on its
-# last line, so a tailed log still shows a failure. Tailing `vp lint` and
-# missing its one error line is a mistake that has reached CI.
+# Prefer it over `vp fmt --check` plus `vp lint`: it ends with an error and
+# warning count, so a tailed log still shows a failure. Tailing `vp lint` and
+# missing its single error line is a mistake that has reached CI here.
 vp check
+vp check --fix
+
+# CI type-check gate: fails only if the error count exceeds the committed
+# baseline in scripts/type-check-baseline.json, now 0. Kept alongside `vp check`
+# because the two answer different questions - vp check asks whether the code
+# type-checks under the flags that are on, the gate asks whether the count has
+# risen above a committed baseline. Redundant while the baseline is 0; it earns
+# its place at the next flag flip (issue #77), where the count starts non-zero.
+# Note that migration cannot use the ratchet while typeCheck is on, since
+# vp check tolerates nothing. Covers packages/editor only.
+npm run type-check:gate
 
 # Unit tests (editor + gate) - gate tests now run under vp test
 vp test
@@ -66,7 +69,7 @@ cd packages/website && npm run build:analyze
 
 ## Vite+ Toolchain
 
-`vp` is the unified CLI for this project (lint, format, test, build). Configuration lives in the root `vite.config.ts` (`lint`, `fmt`, and `test` blocks). The commands `npm run lint` and `npm run format` delegate to `vp` and require it on PATH - install with `VP_VERSION=0.2.6 VP_NODE_MANAGER=yes curl -fsSL https://vite.plus | bash` and add `~/.vite-plus/bin` to PATH.
+`vp` is the unified CLI for this project (check, lint, format, test, build). Configuration lives in the root `vite.config.ts` (`lint`, `fmt`, and `test` blocks); `lint.options.typeCheck` is true, which is what makes `vp check` a type check as well as a lint. The commands `npm run lint` and `npm run format` delegate to `vp` and require it on PATH - install with `VP_VERSION=0.2.6 VP_NODE_MANAGER=yes curl -fsSL https://vite.plus | bash` and add `~/.vite-plus/bin` to PATH.
 
 ## Dev Server Setup
 
@@ -243,6 +246,6 @@ Mobile devices get a read-only viewer with touch gestures (single-finger pan, pi
 - Complex visualizations (crane arms, plasma effects, thruster flames) show only static base sprites
 - Blueprint book icons using planet names show no icon
 - Some entity types may have missing or incorrectly mapped textures
-- `strictNullChecks` is on and `packages/editor` is clean - the gate baseline is 0. Two things that scope is not: `packages/website` has 15 errors nothing checks, which are also what keeps `vp check` from type-checking (issue #78); and `strict: true` still needs `strictPropertyInitialization`, 24 errors, almost all TS2564 in `UI/controls/` and the paint containers (issue #77 - the tsconfig comment used to guess ~1, which was wrong). Use `need(e, 'field')` in the sprite builder rather than reading an optional prototype field directly - see issue #22, closed
+- `strictNullChecks` is on and **every package is clean** - editor, website and worker all type-check at 0, and `vp check` enforces it in CI. What is left before `strict: true` is `strictPropertyInitialization`, 24 errors, almost all TS2564 in `UI/controls/` and the paint containers (issue #77 - the tsconfig comment used to guess ~1, which was wrong). Use `need(e, 'field')` in the sprite builder rather than reading an optional prototype field directly - see issue #22, closed
 - `util.getDirName` throws for non-cardinal directions, so any `draw_*` that calls it fails for an entity placed diagonally and renders a placeholder box. `railgun-turret` hits this: the test corpus places it at directions 2 and 14. Pinned as current behaviour in `tests/__fixtures__/sprite-data.json`
 - Mobile is view-only - no editing, inventory, or keyboard shortcuts

--- a/packages/editor/src/actions.ts
+++ b/packages/editor/src/actions.ts
@@ -531,7 +531,12 @@ function resetKeybinds(): void {
     })
 }
 
-function importKeybinds(keybinds: Record<string, string>): void {
+/**
+ * Apply persisted keybinds. Takes `undefined` because that is what a first
+ * visit reads out of localStorage, and the body has always handled it - the
+ * parameter type was the only thing saying otherwise.
+ */
+function importKeybinds(keybinds: Record<string, string> | undefined): void {
     if (!keybinds) return
 
     for (const [name, kc] of Object.entries(keybinds)) {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -9,7 +9,7 @@ import {
     exportKeybinds,
 } from './actions'
 import { Editor } from './Editor'
-import FD from './core/factorioData'
+import FD, { localisedName } from './core/factorioData'
 import { OverlayContainer } from './containers/OverlayContainer'
 import { EntityContainer } from './containers/EntityContainer'
 import { EntitySprite } from './containers/EntitySprite'
@@ -31,6 +31,10 @@ export {
     Blueprint,
     GridPattern,
     FD,
+    // For settingsPane.ts, which built its module dropdown keys with
+    // `localised_name as string` - the same cast this reader replaced in the
+    // editor, and the same silent "[object Object]" if a name is ever nested.
+    localisedName,
     OverlayContainer,
     EntityContainer,
     EntitySprite,

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -23,20 +23,39 @@ import EDITOR, {
 } from '@fbe/editor'
 import { initToasts } from './toasts'
 import { initSettingsPane } from './settingsPane'
+import { storedJson } from './storage'
 
 document.addEventListener('contextmenu', e => e.preventDefault())
+
+/**
+ * An element this page's own index.html declares, by id.
+ *
+ * `getElementById` answers `HTMLElement | null` because in general an id may
+ * not be there. Every id read here is written statically in index.html and
+ * shipped with it, so absence means the markup and this file have drifted -
+ * which is worth a sentence naming the id rather than a null that reaches
+ * `.classList` a line later. Same shape as the editor's `PositionGrid.entityAt`
+ * and `EntityContainer.containerOf`.
+ */
+function element<T extends HTMLElement = HTMLElement>(id: string): T {
+    const el = document.getElementById(id)
+    if (el === null) throw new Error(`index.html has no element with id "${id}"`)
+    return el as T
+}
 
 const editor = new Editor()
 
 let t0 = performance.now()
 
-const CANVAS = document.getElementById('editor') as HTMLCanvasElement
+const CANVAS = element<HTMLCanvasElement>('editor')
 
 let bp: Blueprint
-let book: Book
+// undefined whenever a bare blueprint is loaded rather than a book, which is
+// what loadBp's else branch assigns and what getBook/encodeLoaded read.
+let book: Book | undefined
 
 const loadingScreen = {
-    el: document.getElementById('loadingScreen'),
+    el: element('loadingScreen'),
     show() {
         this.el.classList.add('active')
         t0 = performance.now()
@@ -102,14 +121,18 @@ let changeBookForIndexSelector: (bpOrBook: Book | Blueprint) => void
 editor
     .init(CANVAS, createToast)
     .then(() => {
-        if (localStorage.getItem('quickbarItemNames')) {
-            const quickbarItems = JSON.parse(localStorage.getItem('quickbarItemNames'))
+        const quickbarItems = storedJson<string[]>('quickbarItemNames')
+        if (quickbarItems) {
             editor.quickbarItems = quickbarItems
         }
 
         registerActions()
 
         const changeBookIndex = async (index: number): Promise<void> => {
+            // The settings pane only shows a book index selector while a book is
+            // loaded, so this cannot fire without one - same check, and the same
+            // reason for it, as the selectBookIndex test hook below.
+            if (!book) throw new Error('No book loaded')
             bp = book.selectBlueprint(index)
             await editor.loadBlueprint(bp)
         }
@@ -500,7 +523,9 @@ function registerActions(): void {
         modifiers: { control: true },
         callbacks: {
             onPress: () => {
-                if (bp.isEmpty()) return
+                // false, not a bare return: onPress answers whether the action was
+                // handled, and an empty blueprint takes no picture.
+                if (bp.isEmpty()) return false
 
                 editor
                     .getPicture()
@@ -520,7 +545,7 @@ function registerActions(): void {
     window.addEventListener('keydown', e => {
         if (e.target instanceof HTMLInputElement) return
         if (e.target instanceof HTMLTextAreaElement) return
-        const infoPanel = document.getElementById('info-panel')
+        const infoPanel = element('info-panel')
         if (e.key === 'i') {
             if (infoPanel.classList.contains('active')) {
                 infoPanel.classList.remove('active')
@@ -532,7 +557,7 @@ function registerActions(): void {
         }
     })
 
-    EDITOR.importKeybinds(JSON.parse(localStorage.getItem('keybinds2')))
+    EDITOR.importKeybinds(storedJson<Record<string, string>>('keybinds2'))
 
     window.addEventListener('visibilitychange', () => {
         const keybinds = EDITOR.exportKeybinds()

--- a/packages/website/src/settingsPane.ts
+++ b/packages/website/src/settingsPane.ts
@@ -1,5 +1,6 @@
 import { GUI } from 'dat.gui'
-import EDITOR, { Blueprint, Book, GridPattern, Editor, FD } from '@fbe/editor'
+import EDITOR, { Blueprint, Book, GridPattern, Editor, FD, localisedName } from '@fbe/editor'
+import { storedJson } from './storage'
 
 GUI.TEXT_CLOSED = 'Close Settings'
 GUI.TEXT_OPEN = 'Open Settings'
@@ -129,9 +130,9 @@ export function initSettingsPane(
             editor.limitWireReach = limitWireReach
         })
 
-    if (localStorage.getItem('oilOutpostSettings')) {
-        const settings = JSON.parse(localStorage.getItem('oilOutpostSettings'))
-        editor.oilOutpostSettings = settings
+    const oilOutpostStored = storedJson<typeof editor.oilOutpostSettings>('oilOutpostSettings')
+    if (oilOutpostStored) {
+        editor.oilOutpostSettings = oilOutpostStored
     }
     window.addEventListener('visibilitychange', () =>
         localStorage.setItem('oilOutpostSettings', JSON.stringify(editor.oilOutpostSettings))
@@ -146,15 +147,21 @@ export function initSettingsPane(
     })
 
     function getModulesObjFor(entityName: string): Record<string, string> {
-        return FD.getModulesFor(entityName)
-            .sort((a, b) => a.order.localeCompare(b.order))
-            .reduce<Record<string, string>>(
-                (obj, item) => {
-                    obj[item.localised_name as string] = item.name
-                    return obj
-                },
-                { None: 'none' }
-            )
+        return (
+            FD.getModulesFor(entityName)
+                // `order` is optional on ItemPrototype and 7 of the 340 items in
+                // data.json omit it - no module does today, but a comparator that
+                // can throw would take the whole settings pane with it, and there
+                // is nothing catching above this. Unordered sorts first.
+                .sort((a, b) => (a.order ?? '').localeCompare(b.order ?? ''))
+                .reduce<Record<string, string>>(
+                    (obj, item) => {
+                        obj[localisedName(item)] = item.name
+                        return obj
+                    },
+                    { None: 'none' }
+                )
+        )
     }
 
     const oilOutpostFolder = gui.addFolder('Oil Outpost Generator Settings')

--- a/packages/website/src/storage.ts
+++ b/packages/website/src/storage.ts
@@ -1,0 +1,16 @@
+/**
+ * A value this page previously wrote with `localStorage.setItem`, or undefined
+ * where nothing is stored - a first visit, or a key the user cleared.
+ *
+ * `getItem` answers `string | null` and `JSON.parse` does not take null. Every
+ * caller used to test the key and then read it a *second* time inside the
+ * branch, which is what left the type unnarrowed; reading once is both the fix
+ * and one fewer chance for the two reads to disagree.
+ *
+ * Lives in its own module because `index.ts` imports `settingsPane.ts`, so the
+ * two cannot share a helper through either of them.
+ */
+export function storedJson<T>(key: string): T | undefined {
+    const raw = localStorage.getItem(key)
+    return raw === null ? undefined : (JSON.parse(raw) as T)
+}

--- a/tests/sprite-generation.spec.ts
+++ b/tests/sprite-generation.spec.ts
@@ -90,7 +90,7 @@ test('every entity type produces sprites', async ({ page }) => {
         const bp = await api.getBlueprintOrBookFromSource(bpStr)
         await api.loadBp(bp)
         // distinct names that survived parsing and actually got rendered
-        return [...new Set([...bp.entities.values()].map((e: any) => e.name))].length
+        return new Set([...bp.entities.values()].map((e: any) => e.name)).size
     }, source)
 
     // give async sprite work a chance to log

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,9 @@
         // codebase is cleaned. `strictNullChecks` is on and its baseline in
         // scripts/type-check-baseline.json has reached 0.
         //
+        // Every package type-checks at 0 under these flags - editor, website and
+        // worker - and `vp check` enforces that in CI via lint.options.typeCheck.
+        //
         // What is left before `strict: true` can replace this block is
         // `strictPropertyInitialization`, which this comment used to put at
         // ~1 error. Measured after strictNullChecks hit 0, it is 24 - a batch of

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -161,7 +161,7 @@ export default defineConfig({
         ],
         options: {
             typeAware: true,
-            typeCheck: false,
+            typeCheck: true,
         },
         jsPlugins: [
             {


### PR DESCRIPTION
Closes #78. **`vp check` now runs format, lint and type check across every package, and passes.** CI runs it in place of the separate oxfmt and oxlint steps.

```
$ vp check
Found 0 errors and 30 warnings in 117 files
exit 0
```

## Why there were 15

The website package was never in the type-check gate — `scripts/type-check-baseline.json` names `packages/editor` and nothing else — so these accumulated unchecked while #22 took the editor to 0. They are the same shapes that migration spent its batches on.

## Two helpers carry most of it

**`element(id)`** in `index.ts`, for the four ids `index.html` declares statically (`editor`, `loadingScreen`, `info-panel`). `getElementById` answers `| null` because in general an id may be absent; these ship in the same file, so absence means the markup and the script have drifted — worth a sentence naming the id rather than a null that reaches `.classList` a line later. Same idiom as `PositionGrid.entityAt`. It also replaces the pre-existing `as HTMLCanvasElement` cast on `CANVAS`.

**`storedJson(key)`** in a new `storage.ts`, for the three `localStorage` reads feeding `JSON.parse` a `string | null`. All three tested the key and then read it a **second** time inside the branch — which is both what left the type unnarrowed and one more chance for the two reads to disagree. Its own module because `index.ts` imports `settingsPane.ts`, so neither can host it.

## The rest, one per site

- **`let book: Book`** → `Book | undefined`. `loadBp`'s else branch assigns undefined, and `getBook`/`encodeLoaded` already read it as possibly absent. The one ripple is `changeBookIndex`, which gets the same `No book loaded` throw the `selectBookIndex` test hook beside it already had.
- **`takePicture`'s `onPress`** returned bare on an empty blueprint. `onPress` answers whether the action was *handled*, so that is `return false`.
- **`importKeybinds`'s parameter** → `Record<string, string> | undefined`. Its body has always opened `if (!keybinds) return`, because undefined is exactly what a first visit reads out of localStorage. The type was the only thing saying otherwise.
- **`settingsPane`'s module sort** was on `order`, which is optional and absent on 7 of the 340 items in `data.json` (no module today — I probed). Nothing catches above it and a throwing comparator would take the whole settings pane, so unordered sorts first.
- **`settingsPane`'s dropdown keys** used `localised_name as string`. That is the cast #73 replaced throughout the editor, with the same silent `[object Object]` if a name is ever nested — so `localisedName` is now exported from the editor package and used here too.

## One unrelated line, called out

`vp check --fix` applied an oxlint autofix in `tests/sprite-generation.spec.ts`: `[...new Set(x)].length` → `new Set(x).size`. Semantically identical, and the Playwright run below came after it. Not part of the subject, so naming it rather than burying it.

## Why the gate stays

`vp check` and `npm run type-check:gate` answer different questions — the first asks whether the code type-checks under the flags that are on, the second whether the count has risen above a committed baseline. Redundant while the baseline is 0; it earns its place at the next flag flip.

**Worth knowing for #77:** that migration cannot use the ratchet while `typeCheck` is on, because `vp check` tolerates nothing. Either fix all 24 in one PR, or turn `typeCheck` off for the duration. Noted in the workflow and CLAUDE.md.

## Verification

- **`vp check`** — exit 0 (format + lint + tsc, all packages)
- `npm run type-check:gate` — 0 errors, baseline 0
- `vp test` — 114 tests
- `npx playwright test` — 61 passed, which covers the touched startup path: `keybinds.spec.ts` drives `importKeybinds`, and every spec goes through `element('editor')` and `loadBp`
- `vp build` (website) — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRQWNPB54Wbd4CdJH1meUA