### PR TITLE
chore: cut vp check's warnings 30 → 6, mostly by fixing rather than suppressing

### DIFF
--- a/packages/editor/src/UI/EntityInfoPanel.ts
+++ b/packages/editor/src/UI/EntityInfoPanel.ts
@@ -17,6 +17,11 @@ import { Panel } from './controls/Panel'
 import { styles } from './style'
 
 function template(strings: TemplateStringsArray, ...keys: (number | string)[]) {
+    // `unknown | X` is `unknown`, so the Record arm is absorbed and this
+    // annotation says nothing - which is why the body casts twice below. The
+    // intent (positional values, or one object keyed by name) wants a real
+    // union, and the casts should go with it: issue #81.
+    // oxlint-disable-next-line typescript/no-redundant-type-constituents
     return (...values: (unknown | Record<string, unknown>)[]) => {
         const result = [strings[0].replace('\n', '')]
         keys.forEach((key, i) => {

--- a/packages/editor/src/UI/QuickbarPanel.ts
+++ b/packages/editor/src/UI/QuickbarPanel.ts
@@ -43,7 +43,14 @@ export class QuickbarPanel extends Panel {
 
         this.rows = rows
         this.iHeight = 24 + rows * 38
-        this.slots = new Array<QuickbarSlot>(rows * 10)
+        // Dense, not sparse. generateSlots below fills every index 0..rows*10-1
+        // before anything reads this, so the two are equivalent today - but
+        // serialize() maps over it, and `.map` *skips* holes while it would call
+        // `s.itemName` on a dense undefined. So if a slot ever did go unfilled,
+        // sparse would silently return a shorter array and slide the quickbar one
+        // place left on the next load, where dense throws instead. Loud beats
+        // silently wrong for something that persists.
+        this.slots = Array.from<QuickbarSlot>({ length: rows * 10 })
 
         this.slotsContainer = new Container()
         this.slotsContainer.position.set(12, 12)
@@ -53,7 +60,7 @@ export class QuickbarPanel extends Panel {
 
         const t = QuickbarPanel.createTriangleButton(15, 14)
         t.position.set((this.iWidth - t.width) / 2, (this.iHeight - t.height) / 2)
-        t.on('pointerdown', this.changeActiveQuickbar, this)
+        t.on('pointerdown', this.changeActiveQuickbar)
         this.addChild(t)
     }
 
@@ -148,7 +155,8 @@ export class QuickbarPanel extends Panel {
         G.BPC.spawnPaintContainer(itemName)
     }
 
-    public changeActiveQuickbar(): void {
+    /** Arrow property: handed to a pointerdown listener. @see EntityContainer.redrawEntityInfo */
+    public readonly changeActiveQuickbar = (): void => {
         this.slotsContainer.removeChildren()
 
         let itemNames = this.serialize()

--- a/packages/editor/src/UI/controls/TextInput.ts
+++ b/packages/editor/src/UI/controls/TextInput.ts
@@ -2,6 +2,10 @@ import { Renderer, Container, DestroyOptions, Graphics, Matrix } from 'pixi.js'
 import { FunctionKeys } from 'utility-types'
 import { colors, styles } from '../style'
 
+// A union of literals with `string` *is* `string`, so these three check
+// nothing - `boxGenerator(w, h, 'DEFULT')` compiles. Dropping `| string`
+// needs checking against what reaches BoxGenerator first: issue #81.
+// oxlint-disable-next-line typescript/no-redundant-type-constituents
 type State = 'FOCUSED' | 'DISABLED' | 'DEFAULT' | string
 
 type BoxGenerator = (w: number, h: number, state: State) => Container

--- a/packages/editor/src/UI/editors/components/Filters.ts
+++ b/packages/editor/src/UI/editors/components/Filters.ts
@@ -148,7 +148,7 @@ export class Filters extends Container<Slot<number>> {
     private m_UpdateFilters(): void {
         const slots = this.m_Entity.filterSlots
         if (slots > 0) {
-            this.m_Filters = new Array(slots)
+            this.m_Filters = Array.from<IFilterSlot>({ length: slots })
             const filters = this.m_Entity.filters
             if (filters !== undefined) {
                 for (const item of filters) {

--- a/packages/editor/src/UI/editors/components/Modules.ts
+++ b/packages/editor/src/UI/editors/components/Modules.ts
@@ -32,7 +32,7 @@ export class Modules extends Container<Slot<number>> {
             const slot = new Slot<number>()
             slot.position.set(slotIndex * 38, 0)
             slot.data = slotIndex
-            slot.on('pointerdown', this.onSlotPointerDown, this)
+            slot.on('pointerdown', this.onSlotPointerDown)
             // Read into a local first: `slotIndex` is a loop `let`, so
             // TypeScript will not carry a narrowing of `m_Modules[slotIndex]`
             // from the test to the use.
@@ -72,7 +72,8 @@ export class Modules extends Container<Slot<number>> {
     }
 
     /** Event handler for click on slot */
-    private onSlotPointerDown(e: FederatedPointerEvent): void {
+    /** Arrow property: handed to a pointerdown listener. */
+    private readonly onSlotPointerDown = (e: FederatedPointerEvent): void => {
         e.stopPropagation()
         const slot = e.target as Slot<number>
         const index = slot.data

--- a/packages/editor/src/UI/editors/components/Recipe.ts
+++ b/packages/editor/src/UI/editors/components/Recipe.ts
@@ -15,7 +15,7 @@ export class Recipe extends Slot<undefined> {
 
         this.m_Entity = entity
         this.updateContent(this.m_Entity.recipe)
-        this.on('pointerdown', this.onSlotPointerDown, this)
+        this.on('pointerdown', this.onSlotPointerDown)
 
         this.onEntityChange('recipe', recipe => this.updateContent(recipe))
     }
@@ -41,7 +41,8 @@ export class Recipe extends Slot<undefined> {
     }
 
     /** Event handler for click on slot */
-    private onSlotPointerDown(e: FederatedPointerEvent): void {
+    /** Arrow property: handed to a pointerdown listener. */
+    private readonly onSlotPointerDown = (e: FederatedPointerEvent): void => {
         e.stopPropagation()
         if (e.button === 0) {
             G.UI.createInventory('Select Recipe', this.m_Entity.acceptedRecipes, name => {

--- a/packages/editor/src/containers/BlueprintContainer.ts
+++ b/packages/editor/src/containers/BlueprintContainer.ts
@@ -401,11 +401,11 @@ export class BlueprintContainer extends Container {
 
         this.pasteEntitySettingsStart = (): boolean => {
             const isValid = this.pasteEntitySettings()
-            if (isValid) this.gridData.on('update32', this.pasteEntitySettings, this)
+            if (isValid) this.gridData.on('update32', this.pasteEntitySettings)
             return isValid
         }
         this.pasteEntitySettingsEnd = (): void => {
-            this.gridData.off('update32', this.pasteEntitySettings, this)
+            this.gridData.off('update32', this.pasteEntitySettings)
         }
         this.pasteEntitySettingsModifiersStart = (): boolean => {
             this.copySettingsActive = true
@@ -539,7 +539,11 @@ export class BlueprintContainer extends Container {
         return false
     }
 
-    public pasteEntitySettings(): boolean {
+    /*
+        Arrow property: registered on gridData for the duration of a paste drag
+        and removed again, so it needs one identity across the on/off pair.
+    */
+    public readonly pasteEntitySettings = (): boolean => {
         if (this._entityForCopyData && this.mode === EditorMode.EDIT) {
             // Hand over reference of source entity to target entity for pasting data
             this.hovered.entity.pasteSettings(this._entityForCopyData)

--- a/packages/editor/src/containers/EntityContainer.ts
+++ b/packages/editor/src/containers/EntityContainer.ts
@@ -131,9 +131,9 @@ export class EntityContainer {
         this.m_Entity.on('position', onPositionChange)
         this.m_Entity.on('modules', onModulesChange)
 
-        this.m_Entity.on('filters', this.redrawEntityInfo, this)
-        this.m_Entity.on('splitterInputPriority', this.redrawEntityInfo, this)
-        this.m_Entity.on('splitterOutputPriority', this.redrawEntityInfo, this)
+        this.m_Entity.on('filters', this.redrawEntityInfo)
+        this.m_Entity.on('splitterInputPriority', this.redrawEntityInfo)
+        this.m_Entity.on('splitterOutputPriority', this.redrawEntityInfo)
 
         this.m_Entity.on('destroy', onEntityDestroy)
 
@@ -144,9 +144,9 @@ export class EntityContainer {
             this.m_Entity.off('position', onPositionChange)
             this.m_Entity.off('modules', onModulesChange)
 
-            this.m_Entity.off('filters', this.redrawEntityInfo, this)
-            this.m_Entity.off('splitterInputPriority', this.redrawEntityInfo, this)
-            this.m_Entity.off('splitterOutputPriority', this.redrawEntityInfo, this)
+            this.m_Entity.off('filters', this.redrawEntityInfo)
+            this.m_Entity.off('splitterInputPriority', this.redrawEntityInfo)
+            this.m_Entity.off('splitterOutputPriority', this.redrawEntityInfo)
 
             this.m_Entity.off('destroy', onEntityDestroy)
 
@@ -315,7 +315,13 @@ export class EntityContainer {
         }
     }
 
-    private redrawEntityInfo(): void {
+    /*
+        An arrow property, not a method, because it is handed to Entity's
+        emitter as a listener. That gives it one stable identity per container
+        for the paired off() to match on, and its own `this` - so the emitter's
+        third context argument is no longer needed at either end.
+    */
+    private readonly redrawEntityInfo = (): void => {
         if (
             this.m_Entity.moduleSlots !== 0 ||
             this.m_Entity.type === 'splitter' ||

--- a/packages/editor/src/core/Blueprint.ts
+++ b/packages/editor/src/core/Blueprint.ts
@@ -672,7 +672,9 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
             }
             entity.direction = p.direction
             if (PUMPJACK_MODULE !== 'none') {
-                entity.modules = new Array(entity.moduleSlots).fill(PUMPJACK_MODULE)
+                entity.modules = Array.from<string>({ length: entity.moduleSlots }).fill(
+                    PUMPJACK_MODULE
+                )
             }
         }
 

--- a/packages/editor/src/core/Entity.ts
+++ b/packages/editor/src/core/Entity.ts
@@ -333,7 +333,7 @@ export class Entity extends EventEmitter<EntityEvents> {
     /** List of all modules. Slots that are undefined don't have a populated module. */
     public get modules(): (string | undefined)[] {
         const items = this.m_rawEntity.items
-        const out = new Array(this.moduleSlots)
+        const out = Array.from<string | undefined>({ length: this.moduleSlots })
         if (!items) return out
         if (!Array.isArray(items)) {
             throw new Error('Old format for items!')

--- a/tests/blueprint-loading.spec.ts
+++ b/tests/blueprint-loading.spec.ts
@@ -28,6 +28,11 @@ for (const bp of blueprintFiles) {
                 if (text.includes('[Object]') || text.includes('[Array]')) {
                     try {
                         const args = await Promise.all(
+                            // `a` is a JSHandle, whose toString() yields
+                            // "JSHandle@object" rather than anything about the
+                            // value - so this fallback puts junk in the report on
+                            // exactly the args that would not serialise: issue #81.
+                            // oxlint-disable-next-line typescript/no-base-to-string
                             msg.args().map(a => a.jsonValue().catch(() => a.toString()))
                         )
                         fullText = args

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -90,6 +90,20 @@ export default defineConfig({
             'typescript/no-dynamic-delete': 'error',
             'typescript/no-empty-object-type': 'error',
             'typescript/no-explicit-any': 'off',
+            /*
+                ignoreStatic, because four of this rule's reports are static
+                methods passed as plain functions - EntitySprite.compareFn to
+                Array#sort, and Entity/Tile.getItemName to getIconPairs. All
+                three take everything they use as parameters and never touch
+                `this`, so there is nothing to unbind. The rule's own option for
+                exactly this, rather than a suppression.
+
+                The instance-method reports it still makes are real and are
+                fixed at the source: those handlers are arrow properties now, so
+                they carry their own `this` and keep one stable identity per
+                instance for `off()` to match on.
+            */
+            'typescript/unbound-method': ['warn', { ignoreStatic: true }],
             'typescript/no-extra-non-null-assertion': 'error',
             'typescript/no-extraneous-class': 'error',
             'typescript/no-invalid-void-type': 'error',


### PR DESCRIPTION
`vp check` reported **30 warnings** — enough noise that a new one would go unnoticed. It now reports **6**, and only 5 of the original 30 were suppressed.

The short version: I was wrong about two of the three rules when I first triaged them, and only found out by reading the rule docs and testing instead of reasoning from memory. Thanks for the nudge to check.

## 1. Five real defects → issue #81, suppressed inline

Each with a comment saying what is wrong and where it is tracked, so the remaining list stays meaningful.

- **`TextInput`'s `type State = 'FOCUSED' | 'DISABLED' | 'DEFAULT' | string`** is just `string`. The literals check nothing — `boxGenerator(w, h, 'DEFULT')` compiles. Dropping `| string` needs checking against what reaches `BoxGenerator`, so it is not a one-liner.
- **`EntityInfoPanel`'s template helper** takes `(unknown | Record<string, unknown>)[]`, which is `unknown[]` — the annotation says nothing, which is why the body casts twice.
- **`blueprint-loading.spec`** falls back to `a.toString()` on a Playwright `JSHandle`, yielding `JSHandle@object` — junk in the diagnostic report on exactly the args that would not serialise.

## 2. `no-new-array` (3, then a 4th) — I was wrong, these were fine

I had written these off as deliberately sparse arrays whose holes `Entity.modules` depends on. Not true. The sparse/dense difference is real —

```
new Array(3).forEach       visits 1 element
Array.from({length:3})     visits 3
```

— but no site depended on it. `Blueprint.ts` calls `.fill()` immediately (densifies either way); `Filters.ts` is sparse only inside `m_UpdateFilters`, whose next loop assigns every index; `Entity.modules` is genuinely sparse but its consumers read by index, `for-of` or `.entries()`, all of which yield `undefined` for a hole.

Verified against the three fixtures that would have moved — `entity-accessors`, `sprite-data` (all five corpora), `overlay-container`. None did.

A **seventh** site turned up later that my grep had missed because it uses the generic form `new Array<QuickbarSlot>(n)`. That one *is* load-bearing: `serialize()` maps over the slot array, and `.map` skips a hole while it would call `s.itemName` on a dense `undefined`. `generateSlots` fills every index in the constructor so they are equivalent today — but if a slot ever went unfilled, sparse silently returns a short array and slides the quickbar one place left on the next load, where dense throws. Converted deliberately, with that written down.

## 3. `unbound-method` (15) — refactored, not suppressed

These were **not one thing**. Four are *static* methods passed as plain functions — `EntitySprite.compareFn` to `Array#sort`, `Entity.getItemName` and `Tile.getItemName` to `getIconPairs`. All three take everything they use as parameters and never touch `this`, so there is nothing to unbind. Handled with the rule's own `ignoreStatic` option.

The other 11 are five instance methods handed to emitters as listeners. They are arrow properties now. The old form was already correct — eventemitter3 takes the context as a third argument — but an arrow property is correct for a reason visible locally, and does not depend on every call site remembering to pass `this`. Dropped that argument at both ends of each `on`/`off` pair, which `removeListener` allows: its check is `(!context || listeners.context === context)`, so a falsy context matches on `fn` alone.

**Verified the identity property rather than assuming it**, since a listener that cannot be removed is the failure mode and no spec counts listeners:

```
ArrowProp   after on: 1  after off: 0  REMOVED
MethodCtx   after on: 1  after off: 0  REMOVED
BindInline  after on: 1  after off: 1  LEAKED
```

The third is the fix the rule's own docs recommend (`instance.method.bind(instance)`) — and it leaks, because a fresh function object each call gives `off()` nothing to match.

**Cost, stated plainly:** `EntityContainer` is constructed per entity, so `redrawEntityInfo` is now one closure per container rather than one shared prototype method. Against the pixi sprites each container already holds that is noise, and it is the only one of the five with a large instance count.

## What is left: 6 `require-array-sort-compare`

Not in this PR, and #81 now records why they are not what I first said. `ignoreStringArrays` defaults to **true**, so these are not firing because they sort strings — they fire because the arrays are `any[]`:

- **5 in specs** — `.map((e: any) => e.name).sort()`. The `any` is what defeats the exemption; typing the callbacks silences them with no comparator and removes 5 `any` leaks.
- **1 in application code** — `spriteDataBuilder.ts:1903` sorts **numbers** with no comparator, which is the case this rule exists for. Harmless today (the sort only groups duplicates for the adjacent-dedupe filter that follows, and equal numbers stringify equal) but fragile, and a numeric comparator could reorder gate rail-base sprites — so it wants checking against `sprite-data.json`, not a blind fix.

## Verification

- `vp check` — 0 errors, 6 warnings (from 30)
- `npm run type-check:gate` — 0 errors, baseline 0
- `vp test` — 114 tests
- `npx playwright test` — 61 passed, run after each of the three commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRQWNPB54Wbd4CdJH1meUA