### PR TITLE
fix: clear the last six lint warnings, and cover the rail path one of them found

### DIFF
--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -1911,8 +1911,17 @@ function draw_straight_rail(e: RailPrototype): (data: IDrawData) => readonly Spr
                 .map(e => util.sumprod(e.position, -1, data.position))
                 // Rotate relative to mid point
                 .map(p => util.rotatePointBasedOnDir(p, dir).y)
-                // Remove duplicates
-                .sort()
+                /*
+                    Sorts to group duplicates for the dedupe below. Numeric, not
+                    the default: `.sort()` compares stringified numbers, which is
+                    wrong in general even though it cannot bite here - the only
+                    offsets a 2x2 rail can produce are -0.5 and 0.5, and those
+                    happen to order the same either way. Measured across the
+                    corpus: this runs 24 times and every one is a single value,
+                    so nothing here was ever exercised with two. tests/rail-gate-bases.spec.ts
+                    is the case that does.
+                */
+                .sort((a, b) => a - b)
                 .filter((y, i, arr) => i === 0 || y !== arr[i - 1])
                 // Reverse rotate relative to mid point
                 .map(y => util.rotatePointBasedOnDir([0, y], (16 - dir) % 16))

--- a/tests/name-migrations.spec.ts
+++ b/tests/name-migrations.spec.ts
@@ -37,12 +37,15 @@ async function load(page: import('@playwright/test').Page, source: string): Prom
         await api.loadBp(bp)
         const entities = [...bp.entities.values()]
         return {
-            entities: entities.map((e: any) => e.name).sort(),
+            entities: entities.map((e: any): string => e.name).sort(),
             recipes: entities
-                .map((e: any) => e.recipe)
-                .filter(Boolean)
+                .map((e: any): string | undefined => e.recipe)
+                // A predicate rather than `Boolean`: the latter narrows nothing, so
+                // the result stays (string | undefined)[] and sort() has no
+                // string-array exemption to claim.
+                .filter((r): r is string => Boolean(r))
                 .sort(),
-            tiles: [...new Set([...bp.tiles.values()].map((t: any) => t.name))].sort(),
+            tiles: [...new Set([...bp.tiles.values()].map((t: any): string => t.name))].sort(),
         }
     }, source)
 }

--- a/tests/rail-gate-bases.spec.ts
+++ b/tests/rail-gate-bases.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprint, packVersion } from './helpers/encode-blueprint'
+import { waitForEditor } from './helpers/fbe-test-api'
+
+/*
+    Gates standing on a straight rail, which `draw_straight_rail` draws an extra
+    rail-base sprite for - one per distinct gate offset, deduped.
+
+    The corpus reaches this branch 24 times and every one of them produces a
+    single offset, so the dedupe and the sort that feeds it have never actually
+    run on more than one element. Measured: reversing that sort left every
+    fixture in sprite-data.spec.ts green, because a one-element array sorts to
+    itself whatever the comparator. This spec is the case that is not a
+    singleton.
+
+    Asserting on the layer count rather than a digest, because the count is what
+    carries the meaning here: one extra layer per distinct gate offset on top of
+    the five a bare rail draws.
+*/
+
+const VERSION = packVersion(2, 0, 55)
+
+/** A straight rail at (1,1) with gates standing on it. */
+const railWithGates = (gates: { x: number; y: number }[]): Record<string, unknown> => ({
+    item: 'blueprint',
+    version: VERSION,
+    entities: [
+        { entity_number: 1, name: 'straight-rail', position: { x: 1, y: 1 }, direction: 0 },
+        ...gates.map((position, i) => ({
+            entity_number: i + 2,
+            name: 'gate',
+            position,
+            direction: 4,
+        })),
+    ],
+})
+
+async function railLayerCount(
+    page: import('@playwright/test').Page,
+    gates: { x: number; y: number }[]
+): Promise<number> {
+    const tally = await page.evaluate(
+        async (src: string) => {
+            const t = window.__fbe_test
+            return t.spriteDataTally(await t.getBlueprintOrBookFromSource(src))
+        },
+        encodeBlueprint(railWithGates(gates))
+    )
+
+    const entries = tally['straight-rail']
+    expect(entries, 'the rail should have generated sprite data').toHaveLength(1)
+    // Digest is "<layer count>:<hash>".
+    return Number(entries[0].split(':')[0])
+}
+
+test('a bare straight rail draws its five picture layers', async ({ page }) => {
+    await waitForEditor(page)
+    expect(await railLayerCount(page, [])).toBe(5)
+})
+
+test('a gate on the rail adds one rail-base layer', async ({ page }) => {
+    await waitForEditor(page)
+    expect(await railLayerCount(page, [{ x: 0.5, y: 0.5 }])).toBe(6)
+})
+
+test('three gates at two distinct offsets add two, not three', async ({ page }) => {
+    await waitForEditor(page)
+
+    /*
+        Two of these share a rotated y offset, so the dedupe collapses them. This
+        is the only place that dedupe is exercised at all - and the only place
+        the sort feeding it sees more than one element.
+    */
+    const count = await railLayerCount(page, [
+        { x: 0.5, y: 0.5 },
+        { x: 1.5, y: 1.5 },
+        { x: 0.5, y: 1.5 },
+    ])
+
+    expect(count).toBe(7)
+})

--- a/tests/unknown-prototypes.spec.ts
+++ b/tests/unknown-prototypes.spec.ts
@@ -50,8 +50,8 @@ async function load(
         // unresolvable name actually throws.
         await api.loadBp(bp)
         return {
-            entities: [...bp.entities.values()].map((e: any) => e.name).sort(),
-            tiles: [...bp.tiles.values()].map((t: any) => t.name).sort(),
+            entities: [...bp.entities.values()].map((e: any): string => e.name).sort(),
+            tiles: [...bp.tiles.values()].map((t: any): string => t.name).sort(),
         }
     }, encodeBlueprint(blueprint))
 


### PR DESCRIPTION
```
$ vp check
Found no warnings, lint errors, or type errors in 118 files
```

**0 errors, 0 warnings** — down from 30 at the start of this thread, with only 5 suppressed (tracked in #81).

## The five in specs were not about sorting

`ignoreStringArrays` defaults to `true`, so a string array needs no comparator. These arrays were `any[]` — the map callbacks are written `(e: any) => e.name` inside `page.evaluate`, where the browser-side types are not available:

```ts
entities.map((e: any) => e.name).sort()          // any[]  → rule fires
entities.map((e: any): string => e.name).sort()  // string[] → exempt
```

Annotating the callback return makes them provably `string[]`. No comparator added, five `any` leaks gone. The `recipes` one needed a type predicate rather than `.filter(Boolean)`, which narrows nothing.

## The sixth was real, and checking it was the point

`draw_straight_rail` sorted **numbers** with the default comparator, which compares them stringified. You asked for it to be checked against `sprite-data.json` rather than fixed blind. Doing that turned up more than expected:

1. **Reversing the sort left every fixture green.** So the fixture does not observe this path's ordering.
2. **Instrumenting the corpus says why.** The branch runs **24 times**, and every one produces a *single* offset:
   ```
   [[-0.5],[0.5],[-0.5],[0.5],[-0.5],[0.5], ... ]   24 sets, all singletons
   ```
   A one-element array sorts to itself whatever the comparator — so the sort, and the dedupe it feeds, have never run on more than one element.
3. **It could not have bitten anyway.** A straight rail is 2x2, so the only offsets it can produce are `-0.5` and `0.5`, and those order the same stringified as numerically.

Added the numeric comparator regardless — the general case is wrong, and the reason it is safe here is not something a reader can see — with the finding written beside it.

## Then covered the gap

A branch reached 24 times with nothing asserting its distinguishing behaviour is worth more than the one-line fix. `tests/rail-gate-bases.spec.ts` builds the case the corpus never produces: three gates at two distinct offsets on one rail.

| blueprint | straight-rail layers |
| --- | --- |
| bare rail | 5 |
| one gate | 6 |
| three gates, two distinct offsets | **7** |

That third row is the only place the dedupe runs at all, and the only place the sort sees more than one element.

**Verified it fails rather than passing vacuously** — breaking the dedupe to `.filter(() => true)` gives 8, and only the third test fails, which is right: the other two are empty and singleton.

## Verification

- `vp check` — 0 errors, **0 warnings**
- `npm run type-check:gate` — 0 errors, baseline 0
- `vp test` — 114 tests
- `npx playwright test` — **64 passed** (61 + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRQWNPB54Wbd4CdJH1meUA