### PR TITLE
chore: drop the stale root `tsc` type-check script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,13 +28,27 @@ npx serve packages/exporter/data/output -l 8081 --cors
 # Build
 cd packages/website && vp build
 
-# Type check. strictNullChecks is on and this is clean - see issue #22, closed.
-npx tsc --noEmit -p packages/editor/tsconfig.json
-
 # Format + lint + type check, every package, one command. This is the one to
 # run before pushing, and it is what CI runs. `lint.options.typeCheck` is true
 # in vite.config.ts, which it could not be until packages/website's 15 type
 # errors were cleared (issue #78). `--fix` applies the format and lint fixes.
+#
+# This is the type check, and it is a real one - measured, it reports plain tsc
+# diagnostics (a `const x: number = 'nope'` comes back as typescript(TS2322)),
+# not only type-aware lint rules, and it covers tests/ as well as src. It
+# resolves each file against the tsconfig that owns it, so editor files are
+# checked under packages/editor/tsconfig.json rather than the root one.
+#
+# There is deliberately no root `tsc` script any more. The root tsconfig is a
+# base to extend - no `include`, no `lib`, and `node` in `types` for the
+# Playwright specs - so running bare `tsc` against it compiled the whole tree
+# under settings no package builds with and reported 5 errors that neither a
+# build nor `vp check` sees: editor code checked against node's fetch types
+# (`r.json()` gives `unknown`, not `any`) and website code against node
+# globals. Every package is at 0 under its own project. To check one package
+# on its own, name its project - that is what the gate below does:
+#
+#   npx tsc --noEmit -p packages/editor/tsconfig.json
 #
 # Prefer it over `vp fmt --check` plus `vp lint`: it ends with an error and
 # warning count, so a tailed log still shows a failure. Tailing `vp lint` and

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
         "preview:website": "npm --workspace=@fbe/website run preview",
         "start:exporter": "cd ./packages/exporter && cargo run --release",
         "build:website": "npm --workspace=@fbe/website run build",
-        "type-check": "tsc",
         "type-check:gate": "node scripts/type-check-gate.mjs",
         "test:unit": "npm --workspace=@fbe/editor run test:unit",
         "lint": "vp lint .",


### PR DESCRIPTION
`npm run type-check` ran bare `tsc` against the root tsconfig, which nothing else uses that way. The root config is a base to extend - no `include`, no `lib`, and `node` in `types` for the Playwright specs - so running it directly compiled the whole tree under settings no package builds with. Measured, it reported 5 errors:

```
packages/editor/src/core/bpString.ts(256,39): error TS18046: 'data' is of type 'unknown'.   (x4)
packages/website/src/toasts.ts(58,27): error TS2345: Argument of type 'HTMLDivElement' is not
  assignable to parameter of type 'string | ReadableStream<any> | Response'.
```

None are real. The `bpString` ones are node's fetch types making `r.json()` return `unknown` instead of DOM's `any` - the editor project narrows `types` to typed-factorio precisely so that cannot happen. The `toasts` one is the same leak from the other direction. Each package is clean under its own project (`tsc -p packages/editor/tsconfig.json` and `-p packages/website/tsconfig.json` both exit 0), and `vp check .` reports 0 errors and 0 warnings.

The script was already dead: CI does not call it, and the 2026-06-26 gate plan records it being knowingly left broken as out of scope at the time. Nothing referenced it outside historical plan docs. Removed rather than repointed at `vp check`, since an alias is worth less than the line it costs.

## What I checked before deleting

`vp check`'s "type check" could have meant only type-aware lint rules. If so, the root script would have been the only full check and deleting it would have quietly dropped coverage - including of `tests/`, which no package tsconfig includes. So I probed it instead of assuming:

| Probe | Result |
| --- | --- |
| `const x: number = 'nope'` appended to `packages/editor/src/core/factorioVersion.ts` | `typescript(TS2322)`, exit 1 |
| same appended to `tests/name-migrations.spec.ts` | `typescript(TS2322)`, exit 1 |

So `vp check` reports plain tsc diagnostics, and it covers `tests/` as well as `src`. Both probes reverted before committing.

The reason it disagrees with the old root script is that it resolves each file against the tsconfig that owns it, rather than compiling everything under the base config - the more correct answer, not a laxer one.

## What stays

`type-check:gate` and the `typescript` devDependency. The gate runs `tsc -p packages/editor/tsconfig.json`, sits at 0, and CI keeps it deliberately for the `strict: true` flip in #77.

## Also

Updated the `CLAUDE.md` command block: dropped the standalone `npx tsc` recipe, said plainly that `vp check` is the type check and what it resolves against, and recorded why a root `tsc` script should not come back.

## Verification

- `vp check .` - exit 0, 0 errors, 0 warnings, 155 files formatted / 118 linted
- `npm run type-check:gate` - exit 0, 0 errors at baseline 0
- `vp test` - exit 0, 114 tests in 8 files
- `npm run type-check` - now `Missing script`, as intended

Not run: Playwright (needs both dev servers, and this change touches no runtime code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ChyBgUr4sojYtLZipuRBC