### PR TITLE
docs: correct three comments that still say the chest editor is disabled

### DIFF
--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -297,8 +297,9 @@ document.addEventListener('paste', (e: ClipboardEvent) => {
         the paste-settings path a spec can drive with real input; writing covers
         what that path cannot say, since paste always sends a full list copied
         off another entity - clearing a chest, and the partial slot lists the
-        chest editor sends. That editor is commented out of the editor factory
-        (see UI/editors/factory.ts), so the setter has no other way in.
+        chest editor sends. The chest editor drives those through real clicks in
+        tests/chest-editor.spec.ts now that #87 has it back in the factory; this
+        stays because it says them directly, without a dialog layout in between.
     */
     entityFilters: (entityNumber: number) => entityOf(entityNumber).filters,
     setEntityFilters: (

--- a/tests/chest-filters.spec.ts
+++ b/tests/chest-filters.spec.ts
@@ -22,9 +22,10 @@ import {
     The rest go through the `setEntityFilters` hook, because paste cannot say
     what they need to say: it always sends a full list copied off another
     entity, so it can neither clear a chest nor send the partial slot lists the
-    chest editor sends. That editor is commented out of
-    UI/editors/factory.ts ("TODO: update using sections"), so the UI has no
-    other way to the setter at all.
+    chest editor sends. Those two now have a UI route as well - #87 put
+    `ChestEditor` back in the factory and `tests/chest-editor.spec.ts` clicks
+    real slots - but this stays separate on purpose: it says the value directly,
+    where the other has to go through a dialog layout to say anything at all.
 
     The shapes here are the ones the corpus actually holds. Measured over
     wormeyman-tests/: 4631 entities carry a `request_filters` object, every

--- a/tests/helpers/fbe-test-api.ts
+++ b/tests/helpers/fbe-test-api.ts
@@ -103,11 +103,11 @@ export interface FbeTestApi {
      */
     entityFilters: (entityNumber: number) => TestFilter[] | undefined
     /**
-     * A write through `Entity.set filters`. Real input reaches that setter only
-     * via paste-settings, which always sends a full list taken from another
-     * entity; this covers what paste cannot say - clearing a chest, and the
-     * partial slot lists the chest editor sends, which is commented out of the
-     * editor factory and so unreachable through the UI.
+     * A write through `Entity.set filters`, saying the value directly where the
+     * UI can only say it through a dialog layout. Paste-settings always sends a
+     * full list taken from another entity, so it can express neither clearing a
+     * chest nor a partial slot list; the chest editor can do both since #87, and
+     * tests/chest-editor.spec.ts drives it that way.
      */
     setEntityFilters: (entityNumber: number, list: TestFilterSlot[] | undefined) => void
     /**


### PR DESCRIPTION
PR #92 put `ChestEditor` back in the editor factory, but three comments written while it was commented out still assert in the **present tense** that it is not:

| File | Stale claim |
| --- | --- |
| `packages/website/src/index.ts` | "That editor is commented out of the editor factory ... so the setter has no other way in" |
| `tests/chest-filters.spec.ts` | "That editor is commented out of UI/editors/factory.ts ... so the UI has no other way to the setter at all" |
| `tests/helpers/fbe-test-api.ts` | "which is commented out of the editor factory and so unreachable through the UI" |

All three were the stated justification for the `setEntityFilters` hook existing, and that justification **changed rather than disappeared**. The hook is still worth having: it states a filter list directly, where the UI can only state one through a dialog layout, so clearing a chest and sending a partial slot list remain cheaper to express here than through clicks. The comments now say that, and point at `tests/chest-editor.spec.ts` for the UI route.

Comments only, no behaviour change. The past-tense references in `tests/chest-editor.spec.ts` and CLAUDE.md were already correct and are untouched.

Found while sweeping the codebase for TODO comments deserving issues, which is also where #93 to #96 came from.

## Verification

- `vp check .` - exit 0, 0 errors, 0 warnings
- `vp test` - 114 unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ChyBgUr4sojYtLZipuRBC