### PR TITLE
tools: add a Factorio oracle, and settle #91 with it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,32 @@ Common patterns for `draw_*` functions:
 - **`EnergySource` is a discriminated union on `type`, but `getEnergySource` can also answer `undefined`,** and `undefined` has no `type` for the check to narrow through. `if (es.type === 'heat')` therefore narrows nothing and `.connections` / `.pipe_covers` stay unreadable - the guard has to be `if (es && es.type === 'heat')`.
 - **The same layer key is not uniformly present across a family of entities.** Ground rails carry all five picture layers for every non-empty direction; elevated rails have no `ties`, `rail-ramp` has no `backplates` or `metals`, and `heating-tower` is a reactor with no `lower_layer_picture`. So `draw_rail` can use `need()` and `draw_elevated_rail` has to filter - probe `data.json` per entity rather than per type.
 
+## Asking the real game (tools/oracle/)
+
+When the editor has to agree with Factorio and the answer is not in the data,
+ask the game rather than reasoning about it. `tools/oracle/` runs the real binary
+headless - a throwaway mod imports a blueprint string with `import_stack`, dumps
+`get_blueprint_entities()` as JSON and `error()`s out - against an isolated
+config so it never touches the real install. See its README for the gotchas;
+the method is borrowed from `/Users/ericjohnson/GitHub/FactorioMapWebUI/test/oracle/`.
+
+**Try the sources in this order**: the Lua prototypes in
+`github.com/wube/factorio-data` (a git tag per release - check out the version
+you target, not the newest), then the oracle, then the unstripped binary. Most
+questions stop at the first. Grep the **definition site**
+(`name *= *"<thing>"`), not a bare name.
+
+Fixtures live in `tools/oracle/fixtures/` and carry their provenance, including
+the binary version they came from - the installed game is 2.1.12 while this
+editor targets 2.0.45 to 2.0.73, so a capture is evidence about 2.1 unless
+stated otherwise. Never hand-edit a fixture to make something pass; a mismatch is
+a finding. Nothing under `tests/` needs Factorio - the committed fixtures do the
+asserting, so CI stays offline.
+
+What it has settled so far: a `LogisticSection` at `index: 0` makes the **whole
+blueprint string fail to import** (issue #91), which is why both pre-2.0 shape
+migrations in `Blueprint.ts` number from 1.
+
 ## Cloudflare Deployment
 
 The editor is deployed to Cloudflare Workers at https://fbe.factorygamefan.com (custom

--- a/tests/pre-2-0-shape-migrations.spec.ts
+++ b/tests/pre-2-0-shape-migrations.spec.ts
@@ -153,10 +153,18 @@ test('a migrated section is numbered the way Factorio numbers sections', async (
         1 is what the corpus says: measured over wormeyman-tests/, all 4645
         `request_filters` sections are at index 1 or 2, and all 1452
         `control_behavior` sections run 1 through 15, contiguous from 1. Nothing
-        anywhere is at 0. Writing 1 makes the migrated output indistinguishable
-        from what Factorio itself writes, which is the safe answer whether or
-        not Factorio would also have tolerated a 0 - a question that needs the
-        game to settle and is recorded in #89 rather than assumed here.
+        anywhere is at 0.
+
+        Factorio has since been asked directly (#91), and the answer is stronger
+        than "1 is tidier": a section at index 0 makes **the whole blueprint
+        string fail to import** - `import_stack` answers -1 and no entities
+        arrive at all. Not the section dropped, not the entity dropped, the
+        string refused. So before this was fixed, any pre-2.0 blueprint with a
+        logistic chest or a constant combinator became, on export, a string the
+        game would not take.
+
+        Measured with tools/oracle/, recorded in
+        tools/oracle/fixtures/section-index.json against Factorio 2.1.12.
     */
     await load(page, OLD_COMBINATOR)
     const cb = (await serializedEntity(page, 1)).control_behavior

--- a/tools/oracle/README.md
+++ b/tools/oracle/README.md
@@ -1,0 +1,83 @@
+# Factorio oracle
+
+Asks the real game what it does, so a behaviour this editor reimplements can be
+checked against Factorio rather than against our own assumptions.
+
+Method borrowed from the sibling project at
+`/Users/ericjohnson/GitHub/FactorioMapWebUI/test/oracle/`, which uses it for the
+map generator's noise functions. The subsystem differs - that one routes a
+`noise-expression` and samples tile properties, this one imports a blueprint
+string with `LuaItemStack.import_stack` and reads `get_blueprint_entities()` back
+
+- but the shape is the same: write a throwaway mod, run the binary headless
+  against an isolated config so it never touches the real install, have the mod
+  dump JSON and `error()` out.
+
+## Order of attack
+
+This is the part that saves time, and it is not "open a disassembler":
+
+1. **`factorio-data` first.** Most behaviour is Lua shipped in the clear at
+   github.com/wube/factorio-data, one git tag per release. Grep for the
+   **definition site** (`name *= *"<thing>"`), not a bare name, which matches
+   every caller. Check out the tag matching what you target - this editor's
+   corpus is 2.0.45 to 2.0.73, not 2.1.
+2. **Then the oracle** - this directory. Use it for anything the Lua does not
+   answer because it is engine behaviour: import rules, validation, numeric
+   primitives.
+3. **Only then the binary**, which ships unstripped, for the short list of
+   genuinely compiled things. Nothing here has needed it yet.
+
+## Scripts
+
+| Script                          | What it asks                                                                  |
+| ------------------------------- | ----------------------------------------------------------------------------- |
+| `probe-section-index.mjs`       | First pass at #91, all cases in one blueprint                                 |
+| `probe-section-index-cases.mjs` | The same, one blueprint per case so each import code is attributable          |
+| `probe-editor-output.mjs`       | Imports a string from a file - used to feed the game this editor's own output |
+
+```sh
+node tools/oracle/probe-section-index-cases.mjs
+node tools/oracle/probe-editor-output.mjs /tmp/some-blueprint.txt
+```
+
+Needs a local Factorio. Found via `FACTORIO_BIN`, else the macOS Steam default.
+Nothing in `tests/` depends on these - the committed fixtures do the asserting,
+so CI stays offline.
+
+## Gotchas, each of which cost a run
+
+- **`helpers.write_file` / `helpers.table_to_json`**, not `game.*`. They moved in
+  2.1 and the old names are gone.
+- **`factorio_version` must be `"2.1"`** in the mod's `info.json` for a 2.1.x
+  game, or the mod is silently skipped and no dump appears.
+- **Embed the blueprint string in a Lua long bracket** (`[==[ ... ]==]`) so its
+  base64 survives verbatim.
+- **`error("DUMPED-OK")` makes Factorio exit non-zero.** That is success. Key off
+  the dump file existing, never the exit code.
+- **Blueprint import needs no `--map-gen-settings`.** The sibling's noise oracle
+  does; this one does not, since nothing is being generated.
+- **One case per blueprint string.** The first probe put four cases in one
+  string and got a single `import_stack` code of -1 for the lot, which could not
+  be attributed - and worse, entities _did_ come back, so -1 looked like it might
+  mean something other than what it does. Splitting them made the answer obvious.
+
+## Fixture policy
+
+Capture once, commit the JSON with its provenance, assert offline. Copied from
+the sibling repo, and the reasons are theirs:
+
+- **Never hand-edit a fixture to make a test pass.** A mismatch is a finding.
+- **Version-stamp every capture.** Steam updates the binary without asking.
+
+`fixtures/section-index.json` records what was asked, what came back, the exact
+binary it came from, and - importantly - that the only Factorio on this machine
+is **2.1.12 while this editor targets 2.0.45 to 2.0.73**. The behaviour is
+assumed stable across that range and was not measured on a 2.0.x binary.
+`factorio.com/download/archive/` has every release if that ever needs settling.
+
+## Scope
+
+Behavioural reverse-engineering for interoperability - understanding what the
+game computes so this editor can agree with it. Not extracting or redistributing
+game code or assets. Keep it that way.

--- a/tools/oracle/fixtures/section-index.json
+++ b/tools/oracle/fixtures/section-index.json
@@ -1,0 +1,76 @@
+{
+    "question": "Does Factorio import a LogisticSection whose index is 0?",
+    "issue": 91,
+    "answer": "No. The entire blueprint string fails to import: import_stack returns -1 and no entities arrive. Not the section dropped, not the entity dropped - the whole string is refused.",
+    "provenance": {
+        "capturedFrom": "2.1.12 (build 87038, mac-arm64, steam)",
+        "capturedOn": "2026-07-26",
+        "method": "tools/oracle/probe-section-index-cases.mjs - headless import_stack + get_blueprint_entities",
+        "blueprintVersionStamp": "2.0.73",
+        "caveat": "The only Factorio on this machine is 2.1.12; this editor targets 2.0.45-2.0.73. The behaviour is assumed stable across that range but was not measured on a 2.0.x binary. factorio.com/download/archive/ has 2.0.73 if it ever needs settling."
+    },
+    "cases": [
+        {
+            "subject": "storage-chest request_filters",
+            "sectionIndex": 0,
+            "filters": 1,
+            "importCode": -1,
+            "entities": 0
+        },
+        {
+            "subject": "storage-chest request_filters",
+            "sectionIndex": 1,
+            "filters": 1,
+            "importCode": 0,
+            "entities": 1,
+            "returnedIndex": 1,
+            "returnedFilters": 1
+        },
+        {
+            "subject": "storage-chest request_filters",
+            "sectionIndex": 2,
+            "filters": 1,
+            "importCode": 0,
+            "entities": 1,
+            "returnedIndex": 1,
+            "returnedFilters": 0
+        },
+        {
+            "subject": "storage-chest request_filters",
+            "sectionIndex": 0,
+            "filters": 0,
+            "importCode": -1,
+            "entities": 0
+        },
+        {
+            "subject": "storage-chest request_filters",
+            "sectionIndex": 1,
+            "filters": 0,
+            "importCode": 0,
+            "entities": 1,
+            "returnedIndex": 1,
+            "returnedFilters": 0
+        },
+        {
+            "subject": "constant-combinator control_behavior.sections",
+            "sectionIndex": 0,
+            "filters": 1,
+            "importCode": -1,
+            "entities": 0
+        },
+        {
+            "subject": "constant-combinator control_behavior.sections",
+            "sectionIndex": 1,
+            "filters": 1,
+            "importCode": 0,
+            "entities": 1,
+            "returnedIndex": 1,
+            "returnedFilters": 1
+        }
+    ],
+    "endToEnd": {
+        "note": "This editor's own output for a pre-2.0 blueprint whose migrations ran, imported into the game.",
+        "beforePR90_index0": { "importCode": -1, "entities": 0 },
+        "afterPR90_index1": { "importCode": 0, "entities": 2, "settingsIntact": true }
+    }
+}

--- a/tools/oracle/probe-editor-output.mjs
+++ b/tools/oracle/probe-editor-output.mjs
@@ -1,0 +1,79 @@
+/*
+    The end-to-end check for #91: does the real game accept a blueprint string
+    this editor produced from a pre-2.0 blueprint?
+
+    The per-case probe proved `index: 0` fails to import and `index: 1` does not.
+    That is a fact about Factorio, not about us. This closes the loop against
+    something outside our own test suite: take the editor's actual output for a
+    blueprint whose migrations ran, hand it to the game, and read back what
+    arrives.
+
+    Reads the string from a file so the editor half stays in Playwright.
+    Usage: node tools/oracle/probe-editor-output.mjs <file>
+*/
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const BIN =
+    process.env.FACTORIO_BIN ??
+    `${process.env.HOME}/Library/Application Support/Steam/steamapps/common/Factorio/factorio.app/Contents/MacOS/factorio`
+const src = readFileSync(process.argv[2] ?? '/tmp/fbe-migrated-output.txt', 'utf8').trim()
+
+const MOD = 'bp_editor_output'
+const DUMP = 'editor-output-dump.json'
+const work = mkdtempSync(join(tmpdir(), 'fbe-oracle-'))
+const writeData = join(work, 'write-data')
+const modPath = join(work, 'mods', `${MOD}_0.0.1`)
+mkdirSync(writeData, { recursive: true })
+mkdirSync(modPath, { recursive: true })
+
+writeFileSync(
+    join(modPath, 'info.json'),
+    JSON.stringify({
+        name: MOD,
+        version: '0.0.1',
+        title: 'Editor output probe',
+        author: 'oracle',
+        factorio_version: '2.1',
+        dependencies: ['base'],
+    })
+)
+writeFileSync(
+    join(modPath, 'control.lua'),
+    `script.on_init(function()
+  local inv = game.create_inventory(1)
+  inv[1].set_stack{name = "blueprint"}
+  local code = inv[1].import_stack([==[${src}]==])
+  helpers.write_file("${DUMP}", helpers.table_to_json({
+    import_code = code,
+    entities = inv[1].get_blueprint_entities(),
+  }))
+  error("DUMPED-OK")
+end)
+`
+)
+writeFileSync(
+    join(work, 'config.ini'),
+    `[path]\nread-data=__PATH__executable__/../data\nwrite-data=${writeData}\n[general]\n[other]\n`
+)
+
+const res = spawnSync(
+    BIN,
+    [
+        '--create',
+        join(work, 'p.zip'),
+        '--mod-directory',
+        join(work, 'mods'),
+        '--config',
+        join(work, 'config.ini'),
+    ],
+    { encoding: 'utf8' }
+)
+const dumpPath = join(writeData, 'script-output', DUMP)
+if (!existsSync(dumpPath)) {
+    console.error('No dump. tail:\n' + ((res.stdout ?? '') + (res.stderr ?? '')).slice(-2500))
+    process.exit(1)
+}
+console.log(readFileSync(dumpPath, 'utf8'))

--- a/tools/oracle/probe-section-index-cases.mjs
+++ b/tools/oracle/probe-section-index-cases.mjs
@@ -1,0 +1,153 @@
+/*
+    Issue #91, isolated. The first probe put all four cases in one blueprint,
+    which showed the index-0 entities missing but could not attribute the single
+    `import_stack` return code to any one of them. This imports one blueprint
+    per case so every code and entity count stands alone.
+
+    Usage: node tools/oracle/probe-section-index-cases.mjs
+*/
+import { deflateSync } from 'node:zlib'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const BIN =
+    process.env.FACTORIO_BIN ??
+    `${process.env.HOME}/Library/Application Support/Steam/steamapps/common/Factorio/factorio.app/Contents/MacOS/factorio`
+
+const MOD = 'bp_section_cases'
+const DUMP = 'section-cases-dump.json'
+const version = (a, b, c, d = 0) => a * 2 ** 48 + b * 2 ** 32 + c * 2 ** 16 + d
+const encode = blueprint =>
+    `0${deflateSync(Buffer.from(JSON.stringify({ blueprint }))).toString('base64')}`
+
+const F = { index: 1, name: 'iron-plate', quality: 'normal', comparator: '=', count: 7 }
+
+const chest = section => ({
+    item: 'blueprint',
+    version: version(2, 0, 73),
+    icons: [{ index: 1, signal: { type: 'item', name: 'storage-chest' } }],
+    entities: [
+        {
+            entity_number: 1,
+            name: 'storage-chest',
+            position: { x: 0.5, y: 0.5 },
+            request_filters: { sections: [section] },
+        },
+    ],
+})
+const combinator = section => ({
+    item: 'blueprint',
+    version: version(2, 0, 73),
+    icons: [{ index: 1, signal: { type: 'item', name: 'constant-combinator' } }],
+    entities: [
+        {
+            entity_number: 1,
+            name: 'constant-combinator',
+            position: { x: 0.5, y: 0.5 },
+            control_behavior: { sections: { sections: [section] } },
+        },
+    ],
+})
+
+const CASES = {
+    'chest section index 0, with filters': chest({ index: 0, filters: [F] }),
+    'chest section index 1, with filters (control)': chest({ index: 1, filters: [F] }),
+    'chest section index 2, with filters': chest({ index: 2, filters: [F] }),
+    'chest section index 0, no filters': chest({ index: 0 }),
+    'chest section index 1, no filters (control)': chest({ index: 1 }),
+    'combinator section index 0, with filters': combinator({
+        index: 0,
+        filters: [{ ...F, type: 'item' }],
+    }),
+    'combinator section index 1, with filters (control)': combinator({
+        index: 1,
+        filters: [{ ...F, type: 'item' }],
+    }),
+}
+
+const work = mkdtempSync(join(tmpdir(), 'fbe-oracle-'))
+const writeData = join(work, 'write-data')
+const modDir = join(work, 'mods')
+const modPath = join(modDir, `${MOD}_0.0.1`)
+mkdirSync(writeData, { recursive: true })
+mkdirSync(modPath, { recursive: true })
+
+writeFileSync(
+    join(modPath, 'info.json'),
+    JSON.stringify({
+        name: MOD,
+        version: '0.0.1',
+        title: 'Blueprint section index cases',
+        author: 'oracle',
+        factorio_version: '2.1',
+        dependencies: ['base'],
+    })
+)
+
+const luaCases = Object.entries(CASES)
+    .map(([label, bp]) => `  {label = [==[${label}]==], bp = [==[${encode(bp)}]==]},`)
+    .join('\n')
+
+writeFileSync(
+    join(modPath, 'control.lua'),
+    `script.on_init(function()
+  local cases = {
+${luaCases}
+  }
+  local inv = game.create_inventory(1)
+  local out = {}
+  for _, c in ipairs(cases) do
+    inv[1].set_stack{name = "blueprint"}
+    local code = inv[1].import_stack(c.bp)
+    local ents = inv[1].get_blueprint_entities()
+    out[#out + 1] = {
+      label = c.label,
+      import_code = code,
+      entity_count = ents and #ents or 0,
+      entities = ents,
+    }
+  end
+  helpers.write_file("${DUMP}", helpers.table_to_json(out))
+  error("DUMPED-OK")
+end)
+`
+)
+
+writeFileSync(
+    join(work, 'config.ini'),
+    `[path]\nread-data=__PATH__executable__/../data\nwrite-data=${writeData}\n[general]\n[other]\n`
+)
+
+const res = spawnSync(
+    BIN,
+    [
+        '--create',
+        join(work, 'p.zip'),
+        '--mod-directory',
+        modDir,
+        '--config',
+        join(work, 'config.ini'),
+    ],
+    { encoding: 'utf8' }
+)
+
+const dumpPath = join(writeData, 'script-output', DUMP)
+if (!existsSync(dumpPath)) {
+    console.error(
+        'No dump. Factorio tail:\n' + ((res.stdout ?? '') + (res.stderr ?? '')).slice(-3000)
+    )
+    process.exit(1)
+}
+
+for (const r of JSON.parse(readFileSync(dumpPath, 'utf8'))) {
+    const sec =
+        r.entities?.[0]?.request_filters?.sections?.[0] ??
+        r.entities?.[0]?.control_behavior?.sections?.sections?.[0]
+    console.log(
+        `${String(r.import_code).padStart(2)}  entities=${r.entity_count}  ` +
+            `section=${sec ? `index ${sec.index}, filters ${sec.filters ? sec.filters.length : 0}` : 'none'}` +
+            `   ${r.label}`
+    )
+}

--- a/tools/oracle/probe-section-index.mjs
+++ b/tools/oracle/probe-section-index.mjs
@@ -1,0 +1,154 @@
+/*
+    Issue #91: does Factorio import a LogisticSection whose `index` is 0?
+
+    Until #89 both pre-2.0 shape migrations in Blueprint.ts built their section
+    with `index: 0`, where every section Factorio itself writes is numbered from
+    1. Every reader in this editor is positional - `sections[0]` is the first
+    array element, not the section whose index is 0 - so a 0 round-tripped here
+    perfectly and could only ever be wrong in the game. This asks the game.
+
+    Method is the sibling project's (FactorioMapWebUI/test/oracle): write a
+    throwaway mod, run the real binary headless against an isolated config so it
+    never touches the real install, have the mod dump JSON and `error()` out.
+    The subsystem differs - this imports a blueprint string with
+    `LuaItemStack.import_stack` and reads `get_blueprint_entities()` back, which
+    is exactly the path a user takes pasting a string into the game.
+
+    Usage: node tools/oracle/probe-section-index.mjs
+*/
+import { deflateSync } from 'node:zlib'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const BIN =
+    process.env.FACTORIO_BIN ??
+    `${process.env.HOME}/Library/Application Support/Steam/steamapps/common/Factorio/factorio.app/Contents/MacOS/factorio`
+
+if (!existsSync(BIN)) {
+    console.error(`No Factorio binary at ${BIN}. Set FACTORIO_BIN.`)
+    process.exit(1)
+}
+
+const MOD = 'bp_section_probe'
+const DUMP = 'section-index-dump.json'
+
+/** How Factorio packs a version. 2.0.73, matching what this editor's corpus declares. */
+const version = (main, major, minor, dev = 0) =>
+    main * 2 ** 48 + major * 2 ** 32 + minor * 2 ** 16 + dev
+
+const encode = blueprint =>
+    `0${deflateSync(Buffer.from(JSON.stringify({ blueprint }))).toString('base64')}`
+
+/* A logistic section and a combinator section, each at index 0 and again at
+   index 1 as the control. If the game tolerates 0 the two halves come back
+   alike; if it renumbers, the 0s come back as something else; if it drops the
+   section, the 0 halves come back without one. */
+const filter = { index: 1, name: 'iron-plate', quality: 'normal', comparator: '=', count: 7 }
+
+const BP = encode({
+    item: 'blueprint',
+    version: version(2, 0, 73),
+    icons: [{ index: 1, signal: { type: 'item', name: 'storage-chest' } }],
+    entities: [
+        {
+            entity_number: 1,
+            name: 'storage-chest',
+            position: { x: 0.5, y: 0.5 },
+            request_filters: { sections: [{ index: 0, filters: [filter] }] },
+        },
+        {
+            entity_number: 2,
+            name: 'storage-chest',
+            position: { x: 2.5, y: 0.5 },
+            request_filters: { sections: [{ index: 1, filters: [filter] }] },
+        },
+        {
+            entity_number: 3,
+            name: 'constant-combinator',
+            position: { x: 4.5, y: 0.5 },
+            control_behavior: {
+                sections: { sections: [{ index: 0, filters: [{ ...filter, type: 'item' }] }] },
+            },
+        },
+        {
+            entity_number: 4,
+            name: 'constant-combinator',
+            position: { x: 6.5, y: 0.5 },
+            control_behavior: {
+                sections: { sections: [{ index: 1, filters: [{ ...filter, type: 'item' }] }] },
+            },
+        },
+    ],
+})
+
+const work = mkdtempSync(join(tmpdir(), 'fbe-oracle-'))
+const writeData = join(work, 'write-data')
+const modDir = join(work, 'mods')
+const modPath = join(modDir, `${MOD}_0.0.1`)
+mkdirSync(writeData, { recursive: true })
+mkdirSync(modPath, { recursive: true })
+
+writeFileSync(
+    join(modPath, 'info.json'),
+    // factorio_version must be "2.1" for a 2.1.x game or the mod is skipped.
+    JSON.stringify({
+        name: MOD,
+        version: '0.0.1',
+        title: 'Blueprint section index probe',
+        author: 'oracle',
+        factorio_version: '2.1',
+        dependencies: ['base'],
+    })
+)
+
+/* The blueprint string is embedded in a Lua long bracket so its base64 (which
+   can contain + and /) survives verbatim. import_stack returns 0 on a clean
+   import, 1 when it imported with errors, -1 when it failed outright - worth
+   recording, since "dropped the section" and "refused the string" are
+   different answers. */
+writeFileSync(
+    join(modPath, 'control.lua'),
+    `script.on_init(function()
+  local bp = [==[${BP}]==]
+  local inv = game.create_inventory(1)
+  inv[1].set_stack{name = "blueprint"}
+  local code = inv[1].import_stack(bp)
+  local out = {
+    import_code = code,
+    entities = inv[1].get_blueprint_entities(),
+  }
+  helpers.write_file("${DUMP}", helpers.table_to_json(out))
+  error("DUMPED-OK")
+end)
+`
+)
+
+writeFileSync(
+    join(work, 'config.ini'),
+    `[path]\nread-data=__PATH__executable__/../data\nwrite-data=${writeData}\n[general]\n[other]\n`
+)
+
+const res = spawnSync(
+    BIN,
+    [
+        '--create',
+        join(work, 'probe.zip'),
+        '--mod-directory',
+        modDir,
+        '--config',
+        join(work, 'config.ini'),
+    ],
+    { encoding: 'utf8' }
+)
+
+const dumpPath = join(writeData, 'script-output', DUMP)
+if (!existsSync(dumpPath)) {
+    console.error('No dump produced. Factorio output tail:\n')
+    console.error(((res.stdout ?? '') + (res.stderr ?? '')).slice(-3000))
+    process.exit(1)
+}
+
+const dump = JSON.parse(readFileSync(dumpPath, 'utf8'))
+console.log(JSON.stringify({ binary: BIN, work, dump }, null, 2))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -159,10 +159,16 @@ export default defineConfig({
                 },
             },
             {
-                files: ['scripts/**/*.mjs'],
+                // tools/ joins scripts/ here: the oracle probes are Node
+                // scripts run by hand against a local Factorio, not part of any
+                // build or test, and they reach for the same globals.
+                files: ['scripts/**/*.mjs', 'tools/**/*.mjs'],
                 globals: {
                     console: 'readonly',
                     process: 'readonly',
+                    // zlib round trips through Buffer, which the oracle probes
+                    // use to build blueprint strings.
+                    Buffer: 'readonly',
                     // Node's timer family. Declared as a group rather than
                     // one at a time so the next script reaching for the other
                     // half of a pair does not fail lint for it.


### PR DESCRIPTION
Closes #91.

**A section at `index: 0` makes the whole blueprint string fail to import.** Not the section dropped, not the entity dropped - `import_stack` answers `-1` and no entities arrive at all.

That is the worst of the three outcomes #91 listed, and it means **#89 was not cosmetic**: before PR #90, any pre-2.0 blueprint carrying a logistic chest or a constant combinator became, on export from this editor, a string Factorio refuses outright.

## Method

Borrowed from the sibling project's noise oracle (`FactorioMapWebUI/test/oracle`), subsystem swapped: a throwaway mod imports a blueprint string with `LuaItemStack.import_stack` and dumps `get_blueprint_entities()` as JSON, run headless against an isolated config so it never touches the real install.

Sources tried in the prescribed order. `factorio-data` **at 2.0.73, not the newest tag** - it carries no constant bounding a section index, so this is engine behaviour and step 1 could not answer it. The binary was never needed. (Step 1 did turn up `max_logistic_filter_count = 1000`, a real number for #93's hardcoded 30.)

## Evidence

One blueprint per case, so every import code is attributable:

| code | entities | returned | case |
| --- | --- | --- | --- |
| **-1** | **0** | - | chest, section index **0**, with filters |
| 0 | 1 | index 1, 1 filter | chest, section index 1 (control) |
| 0 | 1 | index 1, 0 filters | chest, section index 2 |
| **-1** | **0** | - | chest, section index **0**, no filters |
| 0 | 1 | index 1, 0 filters | chest, section index 1, no filters (control) |
| **-1** | **0** | - | combinator, section index **0** |
| 0 | 1 | index 1, 1 filter | combinator, section index 1 (control) |

Not filter-dependent, not chest-specific; the controls differ only in that one integer. A lone section at index 2 is a separate oddity - it imports but comes back renumbered to 1 with its filters gone - noted in the fixture, not chased.

Then **end to end, against something outside our own test suite**: this editor's actual output for a pre-2.0 blueprint whose migrations ran.

| | import code | entities |
| --- | --- | --- |
| before PR #90 (`index: 0`) | **-1** | **0** |
| after PR #90 (`index: 1`) | 0 | 2, settings intact |

Same blueprint, one integer apart. The "before" string was produced by decoding the editor's real output and putting the indices back, so it is what we used to emit rather than a hand-written approximation.

## The first probe was wrong in an instructive way

It put all four cases in one blueprint and got a single `-1` for the lot - while two entities still came back, which made `-1` look like it might mean something other than what it does. One case per string made it obvious. Recorded in the README, since it is exactly the kind of mistake that reads as a finding.

## Version caveat, stated rather than buried

The only Factorio here is **2.1.12**; this editor targets **2.0.45 – 2.0.73**. The capture is stamped with the binary it came from and says so in `fixtures/section-index.json`. The behaviour is assumed stable across that range and was **not** measured on a 2.0.x binary; `factorio.com/download/archive/` has 2.0.73 if that ever needs settling.

## Housekeeping

Nothing under `tests/` depends on Factorio - the committed fixture does the asserting and CI stays offline. `tools/**/*.mjs` joins `scripts/**/*.mjs` in the lint config's node-globals override rather than getting a mechanism of its own.

Scope is behavioural RE for interoperability: understanding what the game computes so this editor can agree with it. No game code or assets are extracted or redistributed.

## Verification

- `vp check .` - exit 0, 0 errors, 0 warnings
- `npm run type-check:gate` - exit 0, 0 at baseline 0
- `vp test` - 114 unit tests
- all three probes re-run clean after formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ChyBgUr4sojYtLZipuRBC