### PR TITLE
refactor: replace factorioData's @ts-ignore with a named interface and a cast (#84)

### DIFF
--- a/packages/editor/src/core/factorioData.ts
+++ b/packages/editor/src/core/factorioData.ts
@@ -819,8 +819,13 @@ export function getColor(
     }
 }
 
-// @ts-ignore
-const FD: {
+/**
+ * Everything `data.json` carries, as the rest of the editor reads it.
+ *
+ * Named rather than inline so a fixture or a mock can say what shape it is
+ * standing in for, and so the assertion below has something to point at.
+ */
+export interface FactorioData {
     items: Record<string, ItemPrototype>
     fluids: Record<string, FluidPrototype>
     signals: Record<string, VirtualSignalPrototype>
@@ -835,7 +840,22 @@ const FD: {
     // treesAndRocks: Record<string, TreeOrRock>
 
     getModulesFor: (entityName: string) => ModulePrototype[]
-} = {}
+}
+
+/*
+    Empty until `loadData` runs, which fills in all twelve properties before
+    anything reads one - the same fill-in-later invariant `G` carries in
+    common/globals.ts, and asserted the same way it is there.
+
+    This used to be a `@ts-ignore` over the declaration. The claim was fine; the
+    suppression was the wrong shape for it. `@ts-ignore` silences *everything*
+    reported on the next line, so a property whose type stopped resolving would
+    have gone as quietly as the one error being waved through, and it would have
+    kept doing so after the reason for it went away. The assertion says the one
+    thing being claimed and leaves every other error on the line reported
+    (issue #84).
+*/
+const FD = {} as FactorioData
 
 export function loadData(str: string): void {
     const data = JSON.parse(str)


### PR DESCRIPTION
Closes #84.

`FD` was declared with its full shape, initialized `{}`, and the resulting TS2740 waved through with **the codebase's only `@ts-ignore`** outside the vendored basis transcoder.

The claim was fine — `loadData` fills in all twelve properties before anything reads one, the same fill-in-later invariant `G` carries in `common/globals.ts`. The *suppression* was the wrong shape for it:

- `@ts-ignore` silences **everything** reported on the following line, so a property whose type stopped resolving, or a typo'd type name, would have gone as quietly as the one error being waved through
- it never expires — if the initializer changed so the error went away, the comment would sit there suppressing nothing visible
- the type was anonymous, so nothing else could name the shape of `FD`

Now an exported `FactorioData` interface and `{} as FactorioData`, exactly what `globals.ts` already does for `G`. Still an unchecked assertion — unavoidable while the fill-in-later pattern stands — but scoped to the one claim being made, with every other error on the line left reported, and the shape now has a name a fixture or a mock could use.

**Confirmed load-bearing rather than assumed:** replacing the assertion with a plain annotation brings TS2740 straight back, now naming `FactorioData` instead of an anonymous type.

No `@ts-ignore`, `@ts-expect-error` or `@ts-nocheck` remains anywhere outside `src/basis`.

## Verification

- `vp check .` — exit 0, 0 errors, 0 warnings
- `npm run type-check:gate` — exit 0, 0 at baseline 0
- `vp test` — 127 unit tests
- `npx playwright test` — 95 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ChyBgUr4sojYtLZipuRBC