### PR TITLE
fix: give the text input's font size a CSS unit (#60)

### DIFF
--- a/packages/editor/src/UI/controls/TextInput.ts
+++ b/packages/editor/src/UI/controls/TextInput.ts
@@ -506,7 +506,17 @@ export class TextInput extends OriginalTextInput {
             input: {
                 fontFamily: styles.controls.textbox.fontFamily,
                 fontWeight: styles.controls.textbox.fontWeight,
-                fontSize: `${styles.controls.textbox.fontSize}`,
+                /*
+                    The `px` is the fix for issue #60. `styles.controls.textbox`
+                    is shaped like a pixi TextStyle, where `fontSize` is a
+                    number and wants to stay one, so the unit belongs here at
+                    the CSS end rather than in style.ts - which is what the
+                    `width` line below has always done. Without it the element
+                    was asked for `font-size: 14`, which has no unit, is
+                    invalid, and was dropped by the CSSOM, leaving every text
+                    box in the editor at the browser default instead of 14px.
+                */
+                fontSize: `${styles.controls.textbox.fontSize}px`,
                 width: `${width}px`,
                 color: `black`,
             },

--- a/tests/text-input.spec.ts
+++ b/tests/text-input.spec.ts
@@ -161,16 +161,14 @@ test('the input carries the styles TextInput was constructed with', async ({ pag
         lineHeight: '1',
         fontFamily: 'Roboto, sans-serif',
         /*
-            Empty, and that is a bug being recorded rather than the expected
-            answer. style.ts has `fontSize: 14`, a number, and TextInput
-            interpolates it straight into a CSS value - so the element is asked
-            for `font-size: 14`, which has no unit, is invalid, and is dropped.
-            Every text box in the editor renders at the browser default instead
-            of 14px. Left alone here because fixing it changes what the UI looks
-            like, which does not belong in a type-error batch; this line moves
-            when someone fixes it.
+            This line used to read `''`, recording issue #60 rather than the
+            expected answer: style.ts has `fontSize: 14`, a number, and
+            TextInput interpolated it straight into a CSS value, so the element
+            was asked for `font-size: 14` - no unit, invalid, dropped by the
+            CSSOM - and every text box rendered at the browser default. The
+            comment said this line would move when someone fixed it. It has.
         */
-        fontSize: '',
+        fontSize: '14px',
     })
 })
 


### PR DESCRIPTION
Closes #60.

`style.ts` declares `textbox.fontSize` as the **number** 14 and `TextInput` interpolated it straight into a CSS value, so the element was asked for `font-size: 14`. No unit, invalid, dropped by the CSSOM — leaving **every text box in the editor at the browser default** rather than 14px.

Fixed at the point of use rather than in `style.ts`, as the issue recommended. `styles.controls.textbox` is shaped like a pixi `TextStyle`, where `fontSize` is a number and wants to stay one — and the `width` line immediately below has always appended its own `px`, so this now matches the pattern sitting right beside it.

Affects every `TextInput`: both boxes in `TrainStopEditor`, and the count box in `ChestEditor`, which became reachable again in #87.

## The one intended assertion change

`tests/text-input.spec.ts` recorded the old behaviour as `fontSize: ''` with a comment saying the line would move when someone fixed it. It has — now `'14px'`, with the comment **rewritten to say what happened** rather than deleted, so the history stays readable.

Mutation-checked by dropping the `px` again: that fails the styles test alone.

## Verification

- `vp check .` — exit 0, 0 errors, 0 warnings
- `vp test` — 127 unit tests
- `npx playwright test` — 95 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ChyBgUr4sojYtLZipuRBC