### PR TITLE
test: cover the straight-rail migration, and correct the comment saying it is missing (#47)

### DIFF
--- a/packages/editor/src/core/nameMigrations.ts
+++ b/packages/editor/src/core/nameMigrations.ts
@@ -51,11 +51,22 @@ const migrations: readonly Migration[] = [
             'effectivity-module-2': 'efficiency-module-2',
             'effectivity-module-3': 'efficiency-module-3',
             'used-up-uranium-fuel-cell': 'depleted-uranium-fuel-cell',
-            // 'straight-rail': 'legacy-straight-rail' is still missing. It could
-            // be added now that the renames are gated - straight-rail only had to
-            // stay out while they ran unconditionally, since it is still in the
-            // game post 2.0 - but it changes how existing pre-2.0 blueprints load,
-            // so it wants its own change.
+            /*
+                `straight-rail` -> `legacy-straight-rail` is absent from this
+                table on purpose, and is *not* missing behaviour: Blueprint.ts
+                does that rename in its entity loop, gated on the same pre-2.0
+                check this table is gated by. This comment used to say the row
+                "is still missing", which was true when it was written and had
+                gone stale unnoticed because nothing covered either statement -
+                see tests/name-migrations.spec.ts and issue #47.
+
+                Why it sits there rather than here is worth keeping: unlike every
+                name in this table, `straight-rail` is *also* a live 2.0
+                prototype, so it is the one rename that would corrupt modern
+                blueprints if the gating ever came off. Leaving it out of the
+                table keeps it from being swept along by a future change to how
+                the table is applied.
+            */
             'curved-rail': 'legacy-curved-rail',
             'logistic-chest-storage': 'storage-chest',
             'logistic-chest-buffer': 'buffer-chest',

--- a/tests/name-migrations.spec.ts
+++ b/tests/name-migrations.spec.ts
@@ -62,6 +62,52 @@ test.beforeEach(async ({ page }) => {
     await page.waitForFunction(() => (window as any).__fbe_test !== undefined, { timeout: 60_000 })
 })
 
+test('a pre-2.0 straight rail becomes a legacy one, and a 2.0 one does not (#47)', async ({
+    page,
+}) => {
+    /*
+        `straight-rail` is the awkward one in this family: it is a live 2.0
+        prototype *and* the pre-2.0 name for what 2.0 calls
+        `legacy-straight-rail`. So the rename can only be applied to blueprints
+        that declare below 2.0 - applying it unconditionally is exactly the
+        corruption #40 describes.
+
+        The rename does happen, and has for a while, but not from
+        nameMigrations.ts's table: it is a version-gated special case in
+        Blueprint.ts's entity loop. The table still carries a comment saying the
+        row "is still missing", which is what #47 was written against and is now
+        out of date. Nothing covered either statement, which is why the comment
+        could go stale unnoticed - this is that coverage.
+
+        Both directions in one test on purpose: the migration and the guard
+        against it are the same line, and a test for only one of them would pass
+        with that line deleted or with the version check dropped.
+    */
+    const migrated = await load(
+        page,
+        encode({
+            item: 'blueprint',
+            version: V_1_1,
+            entities: [{ entity_number: 1, name: 'straight-rail', position: { x: 0.5, y: 0.5 } }],
+        })
+    )
+    expect(migrated.entities).toEqual(['legacy-straight-rail'])
+
+    const untouched = await load(
+        page,
+        encode({
+            item: 'blueprint',
+            version: V_2_0,
+            entities: [{ entity_number: 1, name: 'straight-rail', position: { x: 0.5, y: 0.5 } }],
+        })
+    )
+    expect(untouched.entities).toEqual(['straight-rail'])
+
+    // The migrated name has to resolve against FD or bpString strips the entity,
+    // and it has to render, since load() draws.
+    expect(errors, `page errors: ${errors.join(' | ')}`).toEqual([])
+})
+
 test('a 2.0 blueprint keeps the names it was written with (issue #40)', async ({ page }) => {
     const loaded = await load(
         page,


### PR DESCRIPTION
Closes #47 — but **not by implementing it.** It is already implemented.

#47 asks for `straight-rail` → `legacy-straight-rail` to be restored now that renames are version-gated. It is already there, and has been: `Blueprint.ts`'s entity loop does the rename, gated on the same pre-2.0 check `nameMigrations.ts`'s table is gated by.

```ts
if (pre_2_0 && e.name === 'straight-rail') {
    e.name = 'legacy-straight-rail'
}
```

What was actually missing is **a test and an accurate comment**. The table still carried `"'straight-rail': 'legacy-straight-rail' is still missing"` — true when written, since gone stale, and able to go stale unnoticed *precisely because nothing covered either statement*.

## Coverage

One test in `tests/name-migrations.spec.ts`, **both directions in one case on purpose**: a pre-2.0 blueprint's straight rail becomes legacy, a 2.0 one does not. The migration and the guard against it are the same line, so a test for only one direction would pass with that line deleted **or** with the version check dropped.

| Mutation | Result |
| --- | --- |
| drop the rename entirely | exit 1, 1 failing test |
| drop the version gate (the #40 hazard) | exit 1, 1 failing test |

It also asserts no page errors, since `load()` renders — a migrated name has to resolve against FD or `bpString` strips the entity, and it has to draw.

## The comment

Rewritten to say why the row is deliberately *not* in the table, rather than that it is missing. `straight-rail` is the one rename whose source is **also a live 2.0 prototype**, so keeping it out of the table keeps it from being swept along by a future change to how the table is applied — which is exactly the shape of #40.

## A mistake worth recording

My first mutation check reported both mutations as **passing**. The command ended `grep -E "passed|failed" | tail -1`, and Playwright's line reporter prints `N passed` *after* `1 failed` — so `tail` took the wrong line and hid the failure. This is the exact mistake CLAUDE.md warns about, made while checking a fix for a different stale claim. Redone keying off the exit code, which reported both as properly caught.

## Verification

- `vp check .` — exit 0, 0 errors, 0 warnings
- `vp test` — 127 unit tests
- `npx playwright test` — **96 passed** (was 95)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ChyBgUr4sojYtLZipuRBC