### PR TITLE
chore: drop the modules TODO whose symptom #100 fixed

### DIFF
--- a/packages/editor/src/core/Entity.ts
+++ b/packages/editor/src/core/Entity.ts
@@ -78,8 +78,6 @@ export interface IFilterSlot extends Omit<IFilter, 'name'> {
     name: string | undefined
 }
 
-// TODO: Handle the modules within the class differently so that modules would stay in the same place during editing the blueprint
-
 export interface EntityEvents {
     destroy: []
     position: [newValue: IPoint, oldValue: IPoint]


### PR DESCRIPTION
The loose end from #100, on your call.

`packages/editor/src/core/Entity.ts` carried:

```ts
// TODO: Handle the modules within the class differently so that modules
// would stay in the same place during editing the blueprint
```

Its one reproducible symptom was `pasteSettings` copying modules with a `filter` that compacted the positional array, so every module behind an empty slot slid forward. #100 fixed that with a `map`, and `tests/paste-modules.spec.ts` pins it.

I left the comment in place at the time rather than deleting it as the issue suggested, because — unlike the chest-editor comments #97 corrected — it was not a *false* claim, just a vague refactor note, and I could not prove the 2019-era author meant only the case that got fixed. That is a reason to ask, not a reason to keep it indefinitely.

What the comment was gesturing at is now written down where it can be acted on:

- `Entity.ts:1079`, at the fix: "`map`, not `filter`. `modules` is positional - one entry per slot".
- `CLAUDE.md`, on `tests/paste-modules.spec.ts`: the getter, setter and `Modules` UI all keep it positional; `pasteSettings` was the exception.

Comment-only change, no behaviour.

## Verification

- `vp check .` — exit 0, 0 errors, 0 warnings
- `vp test` — 127 unit tests
- `npx playwright test` — 98 passed (the merged base after #104-#108)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KCMVZGxh3G8hekxFugth5