### PR TITLE
fix: cap a filter paste by what the chest holds, not by what its dialog draws

### DIFF
--- a/packages/editor/src/core/Entity.ts
+++ b/packages/editor/src/core/Entity.ts
@@ -422,8 +422,24 @@ export class Entity extends EventEmitter<EntityEvents> {
             .commit()
     }
 
-    /** Count of filter slots */
-    public get filterSlots(): number {
+    /**
+     * How many filters the entity can hold, which is a different question from
+     * how many slots `filterSlots` draws for it.
+     *
+     * Every branch here reads the data. The one that cannot - a requester or
+     * buffer chest, which declares no `max_logistic_slots` because 2.0 keeps
+     * requests in sections that hold as many filters as they like - falls to the
+     * game's own limit rather than to a number someone picked.
+     *
+     * `max_logistic_filter_count` is 1000, and the oracle says it is enforced
+     * **per section**: two sections of 1000 on one chest import cleanly, one
+     * section of 1001 makes `import_stack` return -1 and refuses the entire
+     * blueprint string - not the extra filters, the whole string, the same
+     * failure shape as the index-0 section in #91. The editor writes section 0
+     * and stops (see `logisticChestFilters`), so per section is per chest here.
+     * Captured in `tools/oracle/fixtures/filter-count-cap.json`.
+     */
+    public get maxFilters(): number {
         if (this.type === 'splitter') return 1
         const ed = this.entityData
         if (
@@ -435,13 +451,33 @@ export class Entity extends EventEmitter<EntityEvents> {
         if ((isLogisticContainer(ed) || isRoboport(ed)) && ed.max_logistic_slots !== undefined) {
             return ed.max_logistic_slots
         }
+        if (
+            isLogisticContainer(ed) &&
+            (ed.logistic_mode === 'requester' || ed.logistic_mode === 'buffer')
+        ) {
+            return FD.utilityConstants.max_logistic_filter_count
+        }
+        return 0
+    }
+
+    /**
+     * Count of filter slots to draw.
+     *
+     * The same as `maxFilters` for everything except the two chests that have no
+     * declared limit, where drawing the real one would mean a grid of 1000. Those
+     * get a fixed 30, raised to fit whatever the blueprint arrived holding - a
+     * guess, and the subject of issue #93, which is a question about what the UI
+     * should offer rather than about what the entity can hold. Nothing that
+     * decides what gets *written* should read this; read `maxFilters` instead.
+     */
+    public get filterSlots(): number {
         if (this.name === 'buffer-chest' || this.name === 'requester-chest') {
             return this.logisticChestFilters.reduce(
                 (max, filter) => Math.max(max, filter.index),
-                30 // TODO: find a way to fix this properly
+                30 // TODO: find a way to fix this properly (issue #93)
             )
         }
-        return 0
+        return this.maxFilters
     }
 
     /** List of all filter(s) for splitters, inserters and logistic chests */
@@ -1102,9 +1138,15 @@ export class Entity extends EventEmitter<EntityEvents> {
         const aF = this.acceptedFilters
         if (aF.length > 0 && sourceEntity.acceptedFilters) {
             if (sourceEntity.filters && sourceEntity.filters.length > 0) {
+                /*
+                    Capped by what the target can hold, not by what its dialog
+                    draws. This read `filterSlots`, so a requester or buffer
+                    chest silently dropped everything past the 30th filter -
+                    a UI layout constant deciding how much data survived a copy.
+                */
                 this.filters = sourceEntity.filters
                     .filter(f => aF.includes(f.name))
-                    .slice(0, this.filterSlots)
+                    .slice(0, this.maxFilters)
             } else {
                 this.filters = []
             }

--- a/tests/paste-filter-cap.spec.ts
+++ b/tests/paste-filter-cap.spec.ts
@@ -1,0 +1,210 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprint as encode, packVersion as version } from './helpers/encode-blueprint'
+
+/*
+    How many filters a paste-settings carries onto a logistic chest (issue #93).
+
+    `Entity.pasteSettings` sliced the incoming list at `Entity.filterSlots`,
+    which is how many slots the *dialog draws* - and for requester and buffer
+    chests that is a hardcoded 30 with a `// TODO: find a way to fix this
+    properly` against it. A UI layout constant was deciding how much data
+    survived a copy: a chest holding 35 requests pasted onto another arrived
+    with 30, silently.
+
+    The cap that belongs there is the game's, and it is not 30. Asked of the
+    real binary rather than assumed, because #93 is about a guessed number and
+    replacing it with another guess would not be an improvement -
+    `tools/oracle/probe-filter-count-cap.mjs`, captured in
+    `tools/oracle/fixtures/filter-count-cap.json`:
+
+      - `max_logistic_filter_count` is 1000, and it is enforced **per section**,
+        not per entity. Two sections of 1000 on one chest import cleanly.
+      - Exceeding it is not survivable. A single section of 1001 filters makes
+        `import_stack` return -1 and **the whole blueprint string is refused** -
+        the same failure shape as the index-0 section in #91, not a truncated
+        chest. That is why the write path still holds a cap at all rather than
+        passing everything through.
+
+    The corpus cannot test any of this: measured over wormeyman-tests/, 4639
+    chests carry `request_filters` and the largest section-0 filter list in all
+    578 blueprints is **5**. Nothing there comes within 6x of the old cap, let
+    alone the real one, so both cases here are synthetic.
+
+    Runs against the dev server like the rest of tests/ - see CLAUDE.md.
+*/
+
+const CANVAS = '#editor'
+
+type Page = import('@playwright/test').Page
+type Filter = { index: number; name: string; count?: number }
+
+/*
+    Distinct base-game item names. Distinct matters for the 35 case: the game
+    keeps one filter per item name within a section (the last by index), so a
+    list that repeated an item would be measuring the editor's model against a
+    number the game would collapse anyway. The 1000 case cycles them, which is
+    fine - nothing there asserts what Factorio would keep, only what the editor
+    refuses to write past.
+*/
+const ITEMS = [
+    'iron-plate',
+    'copper-plate',
+    'steel-plate',
+    'iron-gear-wheel',
+    'copper-cable',
+    'electronic-circuit',
+    'advanced-circuit',
+    'processing-unit',
+    'coal',
+    'stone',
+    'iron-ore',
+    'copper-ore',
+    'stone-brick',
+    'concrete',
+    'pipe',
+    'pipe-to-ground',
+    'transport-belt',
+    'fast-transport-belt',
+    'express-transport-belt',
+    'underground-belt',
+    'splitter',
+    'inserter',
+    'fast-inserter',
+    'long-handed-inserter',
+    'bulk-inserter',
+    'burner-inserter',
+    'small-electric-pole',
+    'medium-electric-pole',
+    'big-electric-pole',
+    'substation',
+    'assembling-machine-1',
+    'assembling-machine-2',
+    'assembling-machine-3',
+    'electric-furnace',
+    'steel-furnace',
+    'stone-furnace',
+    'radar',
+    'accumulator',
+    'solar-panel',
+    'battery',
+]
+
+/** `n` filters in the full shape Factorio writes, numbered from 1. */
+const filtersOfLength = (n: number): Filter[] =>
+    Array.from({ length: n }, (_, i) => ({
+        index: i + 1,
+        name: ITEMS[i % ITEMS.length],
+        quality: 'normal',
+        comparator: '=',
+        count: 1,
+    }))
+
+/**
+ * Two requester chests side by side: entity 1 holds `count` filters, entity 2
+ * holds none - the field absent rather than empty, which is what a freshly
+ * placed chest looks like.
+ */
+const twoChests = (count: number): string =>
+    encode({
+        item: 'blueprint',
+        version: version(2, 0, 55),
+        entities: [
+            {
+                entity_number: 1,
+                name: 'requester-chest',
+                position: { x: 0.5, y: 0.5 },
+                request_filters: {
+                    sections: [{ index: 1, filters: filtersOfLength(count) }],
+                },
+            },
+            { entity_number: 2, name: 'requester-chest', position: { x: 2.5, y: 0.5 } },
+        ],
+    })
+
+async function openEditorWith(page: Page, source: string): Promise<void> {
+    await page.goto('/')
+    await page.waitForFunction(() => window.__fbe_test !== undefined, { timeout: 60_000 })
+    await page.locator(CANVAS).waitFor()
+    await page.evaluate(async (src: string) => {
+        const t = window.__fbe_test
+        await t.loadBp(await t.getBlueprintOrBookFromSource(src))
+    }, source)
+}
+
+async function screenOf(page: Page, entityNumber: number): Promise<{ x: number; y: number }> {
+    const at = await page.evaluate(
+        (n: number) => window.__fbe_test.entityScreenPosition(n),
+        entityNumber
+    )
+    if (!at) throw new Error(`no entity ${entityNumber} in the loaded blueprint`)
+    return at
+}
+
+const filtersOf = (page: Page, entityNumber: number): Promise<Filter[] | undefined> =>
+    page.evaluate((n: number) => window.__fbe_test.entityFilters(n), entityNumber)
+
+/** Copies settings off one entity onto another with real input, as #64's spec does. */
+async function pasteSettings(page: Page, from: number, to: number): Promise<void> {
+    const source = await screenOf(page, from)
+    const target = await screenOf(page, to)
+
+    await page.mouse.move(source.x, source.y)
+    await page.keyboard.down('Shift')
+    await page.mouse.down({ button: 'right' })
+    await page.mouse.up({ button: 'right' })
+
+    await page.mouse.move(target.x, target.y)
+    await page.mouse.down()
+    await page.mouse.up()
+    await page.keyboard.up('Shift')
+}
+
+test('a paste carries every filter the source had, not the 30 the dialog draws', async ({
+    page,
+}) => {
+    /*
+        35 is chosen to sit just past the old cap: enough that the truncation is
+        unambiguous, few enough that every filter is a distinct item and so
+        would survive in the game as well as in the model.
+    */
+    const errors: string[] = []
+    page.on('pageerror', e => errors.push(String(e)))
+
+    await openEditorWith(page, twoChests(35))
+    expect(await filtersOf(page, 1)).toHaveLength(35)
+    expect(await filtersOf(page, 2)).toEqual([])
+
+    await pasteSettings(page, 1, 2)
+
+    /*
+        The error check comes first for the reason #64's spec gives: an empty
+        target is equally what a shift-click that missed would leave, so a
+        filter assertion alone cannot tell a broken paste from a gesture that
+        never landed.
+    */
+    expect(errors).toEqual([])
+
+    const pasted = await filtersOf(page, 2)
+    expect(pasted).toHaveLength(35)
+    // and they are the source's, in order, rather than 35 of something
+    expect(pasted?.map(f => f.name)).toEqual(filtersOfLength(35).map(f => f.name))
+    expect(pasted?.map(f => f.index)).toEqual(filtersOfLength(35).map(f => f.index))
+})
+
+test('a paste stops at the per-section cap Factorio enforces', async ({ page }) => {
+    /*
+        1005 in, 1000 out. The cap is real and the consequence of breaking it is
+        the whole exported string being refused on import, so this is the one
+        place the editor should still be dropping data on the floor.
+    */
+    const errors: string[] = []
+    page.on('pageerror', e => errors.push(String(e)))
+
+    await openEditorWith(page, twoChests(1005))
+    expect(await filtersOf(page, 1)).toHaveLength(1005)
+
+    await pasteSettings(page, 1, 2)
+
+    expect(errors).toEqual([])
+    expect(await filtersOf(page, 2)).toHaveLength(1000)
+})

--- a/tools/oracle/fixtures/filter-count-cap.json
+++ b/tools/oracle/fixtures/filter-count-cap.json
@@ -1,0 +1,89 @@
+{
+    "question": "Is utility_constants.max_logistic_filter_count (1000) a cap per entity or per section, and what happens when a blueprint exceeds it?",
+    "issue": 93,
+    "answer": "Per SECTION. One section holding 1001 filters refuses the entire blueprint string - import_stack returns -1 and no entities arrive, the same failure shape as the index-0 finding in #91. Two sections of 1000 each (2000 filters on one chest) import cleanly, so there is no per-entity total.",
+    "secondFinding": "Within a section the game keeps one filter per item name, the LAST one by index. The same item at indices 1, 2 and 3 comes back as a single filter whose index is 3. The cap is checked against the declared list length before that collapse: 1000 filters cycling 50 distinct items imports and returns 50.",
+    "whyItMatters": "Entity.pasteSettings slices the incoming filter list at Entity.filterSlots, which for requester and buffer chests is a hardcoded 30. The cap that belongs there is the game's real one, and the consequence of exceeding it is not a truncated chest but an unimportable blueprint string, so the write path should hold the line at 1000 per section.",
+    "provenance": {
+        "capturedFrom": "2.1.12 (build 87038, mac-arm64, steam)",
+        "capturedOn": "2026-07-27",
+        "method": "tools/oracle/probe-filter-count-cap.mjs - headless import_stack + get_blueprint_entities",
+        "blueprintVersionStamp": "2.0.73",
+        "constantConfirmedInFactorioData": "max_logistic_filter_count = 1000 at tags 2.0.45, 2.0.73 and 2.1.12 (core/prototypes/utility-constants.lua). Note logistic_slots_per_row = 10 is present at 2.0.73 but absent at 2.0.45.",
+        "caveat": "The only Factorio on this machine is 2.1.12; this editor targets 2.0.45-2.0.73. The behaviour is assumed stable across that range but was not measured on a 2.0.x binary. factorio.com/download/archive/ has 2.0.73 if it ever needs settling."
+    },
+    "cases": [
+        {
+            "subject": "requester-chest request_filters, 1 section, 3 distinct items",
+            "role": "control - establishes the shape imports at all",
+            "declaredFilters": 3,
+            "importCode": 0,
+            "entities": 1,
+            "returnedSectionFilterCounts": [3],
+            "returnedHighestIndex": [3]
+        },
+        {
+            "subject": "requester-chest request_filters, 1 section, same item at indices 1, 2, 3",
+            "role": "control - detects whether cycling a short item list measures a cap or a dedupe",
+            "declaredFilters": 3,
+            "importCode": 0,
+            "entities": 1,
+            "returnedSectionFilterCounts": [1],
+            "returnedHighestIndex": [3]
+        },
+        {
+            "subject": "requester-chest request_filters, 1 section",
+            "role": "what the editor draws today",
+            "declaredFilters": 30,
+            "importCode": 0,
+            "entities": 1,
+            "returnedSectionFilterCounts": [30],
+            "returnedHighestIndex": [30]
+        },
+        {
+            "subject": "requester-chest request_filters, 1 section",
+            "declaredFilters": 999,
+            "importCode": 0,
+            "entities": 1,
+            "returnedSectionFilterCounts": [50],
+            "returnedHighestIndex": [999],
+            "note": "50 returned because the probe cycles 50 distinct item names; the collapse is the dedupe above, not the cap"
+        },
+        {
+            "subject": "requester-chest request_filters, 1 section",
+            "role": "exactly max_logistic_filter_count",
+            "declaredFilters": 1000,
+            "importCode": 0,
+            "entities": 1,
+            "returnedSectionFilterCounts": [50],
+            "returnedHighestIndex": [1000]
+        },
+        {
+            "subject": "requester-chest request_filters, 1 section",
+            "role": "one over the cap",
+            "declaredFilters": 1001,
+            "importCode": -1,
+            "entities": 0,
+            "returnedSectionFilterCounts": [],
+            "returnedHighestIndex": []
+        },
+        {
+            "subject": "requester-chest request_filters, 2 sections of 600",
+            "role": "1200 filters on one entity - over 1000 in total, under it per section",
+            "declaredFilters": 1200,
+            "importCode": 0,
+            "entities": 1,
+            "returnedSectionFilterCounts": [50, 50],
+            "returnedHighestIndex": [600, 600]
+        },
+        {
+            "subject": "requester-chest request_filters, 2 sections of 1000",
+            "role": "2000 filters on one entity, each section at the cap",
+            "declaredFilters": 2000,
+            "importCode": 0,
+            "entities": 1,
+            "returnedSectionFilterCounts": [50, 50],
+            "returnedHighestIndex": [1000, 1000]
+        }
+    ]
+}

--- a/tools/oracle/probe-filter-count-cap.mjs
+++ b/tools/oracle/probe-filter-count-cap.mjs
@@ -1,0 +1,224 @@
+/*
+    Is `utility_constants.max_logistic_filter_count` (1000) a cap per entity or
+    per section? The name does not say, and the editor models section 0 only, so
+    the two readings give different answers for what `pasteSettings` may carry.
+
+    Asked because #93 is about the editor guessing 30 filter slots for requester
+    and buffer chests with nothing behind the number. Replacing one guess with
+    another would not be an improvement.
+
+    Two controls come first. A three-filter chest establishes the shape imports
+    cleanly at all, and a chest holding the SAME item at three indices says
+    whether cycling a short item list to reach 1000 is even measuring what it
+    claims to - if the game collapses duplicates, every large case below is
+    reporting dedupe rather than a cap.
+
+    Usage: node tools/oracle/probe-filter-count-cap.mjs
+*/
+import { deflateSync } from 'node:zlib'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const BIN =
+    process.env.FACTORIO_BIN ??
+    `${process.env.HOME}/Library/Application Support/Steam/steamapps/common/Factorio/factorio.app/Contents/MacOS/factorio`
+
+const MOD = 'bp_filter_cap'
+const DUMP = 'filter-cap-dump.json'
+const version = (a, b, c, d = 0) => a * 2 ** 48 + b * 2 ** 32 + c * 2 ** 16 + d
+const encode = blueprint =>
+    `0${deflateSync(Buffer.from(JSON.stringify({ blueprint }))).toString('base64')}`
+
+/*
+    Base-game items only. The mod directory is isolated and depends on `base`
+    alone, so a Space Age name would fail for the wrong reason - it would look
+    like a rejected filter count rather than an unknown item.
+*/
+const ITEMS = [
+    'iron-plate',
+    'copper-plate',
+    'steel-plate',
+    'iron-gear-wheel',
+    'copper-cable',
+    'electronic-circuit',
+    'advanced-circuit',
+    'processing-unit',
+    'coal',
+    'stone',
+    'iron-ore',
+    'copper-ore',
+    'stone-brick',
+    'concrete',
+    'pipe',
+    'pipe-to-ground',
+    'transport-belt',
+    'fast-transport-belt',
+    'express-transport-belt',
+    'underground-belt',
+    'splitter',
+    'inserter',
+    'fast-inserter',
+    'long-handed-inserter',
+    'bulk-inserter',
+    'burner-inserter',
+    'small-electric-pole',
+    'medium-electric-pole',
+    'big-electric-pole',
+    'substation',
+    'assembling-machine-1',
+    'assembling-machine-2',
+    'assembling-machine-3',
+    'electric-furnace',
+    'steel-furnace',
+    'stone-furnace',
+    'radar',
+    'accumulator',
+    'solar-panel',
+    'battery',
+    'plastic-bar',
+    'sulfur',
+    'explosives',
+    'rocket-fuel',
+    'low-density-structure',
+    'engine-unit',
+    'electric-engine-unit',
+    'firearm-magazine',
+    'piercing-rounds-magazine',
+    'grenade',
+]
+
+const filter = (index, name) => ({ index, name, quality: 'normal', comparator: '=', count: 1 })
+/** n filters numbered from 1, cycling ITEMS. */
+const filters = n => Array.from({ length: n }, (_, i) => filter(i + 1, ITEMS[i % ITEMS.length]))
+
+/** A requester chest carrying the given sections, numbered from 1 (see #91). */
+const chest = sections => ({
+    item: 'blueprint',
+    version: version(2, 0, 73),
+    icons: [{ index: 1, signal: { type: 'item', name: 'requester-chest' } }],
+    entities: [
+        {
+            entity_number: 1,
+            name: 'requester-chest',
+            position: { x: 0.5, y: 0.5 },
+            request_filters: {
+                sections: sections.map((f, i) => ({ index: i + 1, filters: f })),
+            },
+        },
+    ],
+})
+
+const CASES = {
+    'control: 3 distinct items, 1 section': chest([filters(3)]),
+    'control: same item at 3 indices, 1 section': chest([
+        [filter(1, 'iron-plate'), filter(2, 'iron-plate'), filter(3, 'iron-plate')],
+    ]),
+    '30 filters, 1 section (what the editor draws today)': chest([filters(30)]),
+    '999 filters, 1 section': chest([filters(999)]),
+    '1000 filters, 1 section (max_logistic_filter_count)': chest([filters(1000)]),
+    '1001 filters, 1 section': chest([filters(1001)]),
+    '2 sections x 600 = 1200 filters': chest([filters(600), filters(600)]),
+    '2 sections x 1000 = 2000 filters': chest([filters(1000), filters(1000)]),
+}
+
+const work = mkdtempSync(join(tmpdir(), 'fbe-oracle-'))
+const writeData = join(work, 'write-data')
+const modDir = join(work, 'mods')
+const modPath = join(modDir, `${MOD}_0.0.1`)
+mkdirSync(writeData, { recursive: true })
+mkdirSync(modPath, { recursive: true })
+
+writeFileSync(
+    join(modPath, 'info.json'),
+    JSON.stringify({
+        name: MOD,
+        version: '0.0.1',
+        title: 'Logistic filter count cap',
+        author: 'oracle',
+        factorio_version: '2.1',
+        dependencies: ['base'],
+    })
+)
+
+const luaCases = Object.entries(CASES)
+    .map(([label, bp]) => `  {label = [==[${label}]==], bp = [==[${encode(bp)}]==]},`)
+    .join('\n')
+
+writeFileSync(
+    join(modPath, 'control.lua'),
+    `script.on_init(function()
+  local cases = {
+${luaCases}
+  }
+  local inv = game.create_inventory(1)
+  local out = {}
+  for _, c in ipairs(cases) do
+    inv[1].set_stack{name = "blueprint"}
+    local code = inv[1].import_stack(c.bp)
+    local ents = inv[1].get_blueprint_entities()
+    local counts = {}
+    local names = {}
+    if ents and ents[1] and ents[1].request_filters and ents[1].request_filters.sections then
+      for i, s in ipairs(ents[1].request_filters.sections) do
+        counts[i] = s.filters and #s.filters or 0
+        -- highest index actually present, to catch a silent renumber
+        local hi = 0
+        if s.filters then
+          for _, f in pairs(s.filters) do if f.index and f.index > hi then hi = f.index end end
+        end
+        names[i] = hi
+      end
+    end
+    out[#out + 1] = {
+      label = c.label,
+      import_code = code,
+      entity_count = ents and #ents or 0,
+      section_filter_counts = counts,
+      section_highest_index = names,
+    }
+  end
+  helpers.write_file("${DUMP}", helpers.table_to_json(out))
+  error("DUMPED-OK")
+end)
+`
+)
+
+writeFileSync(
+    join(work, 'config.ini'),
+    `[path]\nread-data=__PATH__executable__/../data\nwrite-data=${writeData}\n[general]\n[other]\n`
+)
+
+const res = spawnSync(
+    BIN,
+    [
+        '--create',
+        join(work, 'p.zip'),
+        '--mod-directory',
+        modDir,
+        '--config',
+        join(work, 'config.ini'),
+    ],
+    { encoding: 'utf8' }
+)
+
+const dumpPath = join(writeData, 'script-output', DUMP)
+if (!existsSync(dumpPath)) {
+    console.error(
+        'No dump. Factorio tail:\n' + ((res.stdout ?? '') + (res.stderr ?? '')).slice(-3000)
+    )
+    process.exit(1)
+}
+
+const rows = JSON.parse(readFileSync(dumpPath, 'utf8'))
+for (const r of rows) {
+    const counts = Object.values(r.section_filter_counts ?? {})
+    const hi = Object.values(r.section_highest_index ?? {})
+    console.log(
+        `code=${String(r.import_code).padStart(2)}  entities=${r.entity_count}  ` +
+            `sections=[${counts.join(', ')}]  highestIndex=[${hi.join(', ')}]   ${r.label}`
+    )
+}
+writeFileSync(join(work, 'rows.json'), JSON.stringify(rows, null, 2))
+console.log(`\nraw: ${join(work, 'rows.json')}`)


### PR DESCRIPTION
From #93, but **not** the fixed-vs-grow UI decision - that stays open. This is the data half, which needed no decision once the real number was known.

## The defect

`Entity.pasteSettings` sliced the incoming filter list at `Entity.filterSlots` - how many slots the *dialog draws*, which for requester and buffer chests is a hardcoded `30` carrying a `// TODO: find a way to fix this properly`. A UI layout constant was deciding how much data survived a copy: a chest holding 35 requests, pasted onto another, arrived with 30 and said nothing.

Worse, the cap moved with the target. `filterSlots` is `max(30, highest index the target already holds)`, so the same paste onto an empty chest kept 30, and onto a chest that happened to hold a request at index 40 kept 35.

This is a clean truncation of the tail, not a #100-style slide - each `IFilter` carries its own `index` and the setter writes `index: f.index`, so survivors keep their slots.

## The number came from the game

`max_logistic_filter_count` is 1000 in `data.json` and in `factorio-data` at 2.0.45, 2.0.73 and 2.1.12. What the constant's name does not say is whether it is per entity or per section - and the editor models section 0 only, so the two readings differ. Asked rather than assumed (`tools/oracle/probe-filter-count-cap.mjs`, captured in `tools/oracle/fixtures/filter-count-cap.json`):

| Case | Result |
| --- | --- |
| 1 section x 1000 filters | imports |
| 1 section x **1001** | `import_stack` returns **-1**, no entities - the whole string refused |
| 2 sections x 600 (1200 total) | imports |
| 2 sections x 1000 (2000 total) | imports |

**Per section.** And exceeding it is not survivable: the entire blueprint string is refused, the same failure shape as the index-0 section in #91 - not a truncated chest. That is why the write path still caps at all rather than passing everything through.

Two controls ran first, and the second earned its place: a chest holding the **same item at three indices** comes back as **one** filter (the last by index). The game deduplicates by item name within a section, so both large cases were reporting dedupe, not a cap - without that control I would have read `sections=[50]` as a limit of 50.

## The change

`maxFilters` answers what an entity can hold, every branch read from data - `filter_count`, `max_logistic_slots`, and for the two chests that declare neither, `logistic_mode` plus the game's own constant. `filterSlots` keeps its 30 for those two chests and now delegates to `maxFilters` for everything else, so the guess lives in exactly one branch and #93 is a question about that branch alone. `pasteSettings` reads `maxFilters`.

## Coverage

`tests/paste-filter-cap.spec.ts`, driving the real shift+RMB / shift+LMB gesture. The corpus cannot supply either case: across all 578 blueprints, 4,639 chests carry `request_filters` and **the largest section-0 filter list is 5**.

| Mutation | Result |
| --- | --- |
| slice at `filterSlots` again (the old bug) | 2 failed |
| remove the cap entirely | 1 failed (the 1000 case), 1 passed - exactly the one that should notice |

Worth being straight about reachability: nothing in your corpus comes within 6x of the old 30, so this was **latent**, not biting today. It becomes reachable with any real megabase requester.

## Verification

- `vp check .` — exit 0, 0 errors, 0 warnings
- `npm run type-check:gate` — exit 0, 0 at baseline 0
- `vp test` — 127 unit tests
- `npx playwright test` — two consecutive full runs, **102 passed** both times, on the suite stabilised by #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KCMVZGxh3G8hekxFugth5