### PR TITLE
docs: correct the setup instructions and repoint the fork's links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,18 @@
 
 First of all, thanks for your interest in helping out! 😃
 
+**About this fork.** This is `wormeyman/factorio-blueprint-editor`, a fork of
+[`teoxoy/factorio-blueprint-editor`](https://github.com/teoxoy/factorio-blueprint-editor)
+adding Factorio 2.0 and Space Age support. Two things follow from that and are
+easy to get wrong:
+
+- The default branch is `wormeyman-space-age-support`, not `master`. Branch from
+  it and target it with your pull request. CI only runs on that branch.
+- Issues and pull requests go to the fork. Upstream links in the README point at
+  Teoxoy's repo and deployment.
+
+The fork is deployed at <https://fbe.factorygamefan.com>.
+
 ## Submitting an Issue
 
 Before you submit an issue, please search the issue tracker, maybe an issue for
@@ -13,7 +25,7 @@ allows us to quickly confirm a bug (or point out a coding problem) as well as co
 that we are fixing the right problem.
 
 You can file new issues by selecting from our
-[new issue templates](https://github.com/Teoxoy/factorio-blueprint-editor/issues/new/choose)
+[new issue templates](https://github.com/wormeyman/factorio-blueprint-editor/issues/new/choose)
 and filling out the issue template.
 
 ## Submitting a Pull Request
@@ -21,35 +33,123 @@ and filling out the issue template.
 ### Prerequisites
 
 - [git](https://git-scm.com/)
-- [node](https://nodejs.org/en/)
-- [vscode](https://code.visualstudio.com/)
-- [rust](https://rust-lang.org)
+- [node](https://nodejs.org/en/). The root `package.json` declares
+  `devEngines.packageManager: npm ^11` with `onFail: download`, so an npm new
+  enough to read that field will fetch a matching one; an older npm ignores it
+  and runs anyway, which is the version to watch out for.
+- [Vite+](https://vite.plus) - the `vp` CLI this repo builds, lints, formats and
+  tests with. The version is pinned, and CI installs the same one via
+  `.github/actions/setup-vp`:
+
+    ```shell
+    VP_VERSION=0.2.6 VP_NODE_MANAGER=yes curl -fsSL https://vite.plus | bash
+    ```
+
+    Then put `~/.vite-plus/bin` on your PATH, ahead of any system npm. Two
+    things need it there: `npm run localpreview` spawns `vp` directly, and
+    `VP_NODE_MANAGER=yes` puts vp's managed node and npm on that path, which is
+    what the scripts calling bare `npm`/`npx` expect to resolve to.
+
+- [rust](https://rust-lang.org) - **only** if you want to regenerate the sprite
+  data. The generated data is committed to the repo, so you do not need rust,
+  a Factorio install, or a factorio.com account to work on the editor itself.
+  See [Regenerating the sprite data](#regenerating-the-sprite-data-optional).
+- [vscode](https://code.visualstudio.com/) - optional, but the repo ships
+  workspace settings for it.
 
 ### Note
 
-This project uses `eslint` and `prettier` to lint and format code. I would
-recommend thatyou use `vscode` for this project because the repo already contains
-the extension settings for autofixing linting errors and formatting code on save.
-So, make sure to **download the recommended workspace extensions** in vscode
-after cloning the repo.
+This project lints with `oxlint` and formats with `oxfmt`, both driven by `vp`
+and configured in the root `vite.config.ts`. It no longer uses `eslint` or
+`prettier`, so extensions for those will fight the repo's formatting.
+
+If you use `vscode`, **download the recommended workspace extensions** after
+cloning the repo. `.vscode/extensions.json` asks for `oxc.oxc-vscode` (the
+formatter and linter), plus `rust-lang.rust-analyzer` and `sumneko.lua` for the
+exporter. The committed workspace settings already format and autofix on save
+once that first one is installed.
 
 ## Steps
 
 1. Fork the repo
 1. Clone your fork
 1. Download the recommended workspace extensions in vscode
-1. Create a new git branch (`git checkout -b my-fix-branch master`)
-1. Create a new file at the path `packages/exporter/.env` and configure the
-   exporter (see options below)
-1. Run `npm i --legacy-peer-deps`
-1. Run `npm run start:website` and `npm run start:exporter`
-1. Open the link in a browser or use the vscode debugger
+1. Create a new git branch
+   (`git checkout -b my-fix-branch wormeyman-space-age-support`)
+1. Run `vp install`
+1. Run `npm run localpreview` from the repo root
+1. Open <http://localhost:8080> in a browser
 1. Make changes
+1. Run `vp check --fix` and `vp test` - this is what CI checks
 1. Commit your changes using a descriptive commit message
 1. Push your branch to GitHub `git push origin my-fix-branch`
 1. Start a pull request from GitHub
 
-### Exporter setup options
+That's it! 🎉 Thank you for your contribution! 😃
+
+### Running the editor locally
+
+The editor needs two servers, and `npm run localpreview` starts both from the
+repo root and ties their lifetimes together, so one Ctrl-C stops the pair:
+
+| Port | Server                                         |
+| ---- | ---------------------------------------------- |
+| 8080 | Vite, serving the website (`packages/website`) |
+| 8081 | a static file server, serving the sprite data  |
+
+Both are required. In dev, Vite proxies `/data` to `127.0.0.1:8081` rather than
+serving the sprite output itself, and that proxy target is hardcoded - so the
+sprite server's port is not negotiable and only Vite's can move:
+
+```shell
+npm run localpreview -- --port 8090
+```
+
+The script checks both ports before spawning anything and refuses to start if
+either is taken. That check is as much the point of the script as the
+convenience is: started by hand, Vite without `--strictPort` quietly falls back
+to 8081 and then proxies `/data` to itself, which presents as the sprite server
+failing rather than as a port clash.
+
+### Checks
+
+| Command                   | What it does                                                                      |
+| ------------------------- | --------------------------------------------------------------------------------- |
+| `vp check`                | format + lint + type check, every package. This is the one to run before pushing. |
+| `vp check --fix`          | the same, applying the format and lint fixes it can                               |
+| `vp test`                 | unit tests (the editor's, plus the repo scripts')                                 |
+| `npm run type-check:gate` | fails if the type error count rises above the committed baseline                  |
+| `npx playwright test`     | browser tests - needs `npm run localpreview` running first                        |
+
+Two things about the Playwright suite. Run `npx playwright install` after any
+`@playwright/test` bump, or every spec fails on a missing browser executable.
+And several specs load a local blueprint corpus from `wormeyman-tests/`, which
+is gitignored and not distributed - without it those specs fail on an explicit
+"found no blueprints" assertion, which is not something you broke.
+
+If you moved Vite off 8080, point the specs at it rather than editing
+`playwright.config.ts`:
+
+```shell
+FBE_BASE_URL=http://localhost:8090 npx playwright test
+```
+
+## Regenerating the sprite data (optional)
+
+`packages/exporter` is a rust program that extracts entity definitions and
+sprites from a Factorio installation into `packages/exporter/data/output/`. That
+output is committed, so you only need this if you are updating the data for a
+new game version.
+
+Create `packages/exporter/.env`, configure it with one of the two options below,
+then run:
+
+```shell
+npm run start:exporter
+```
+
+Note that the sprite compression step invokes `./basisu`, and the only binary
+committed for it is macOS ARM64, so that step will not run as-is on Linux.
 
 ### Option A: Local Factorio installation (recommended - includes Space Age support)
 
@@ -68,14 +168,12 @@ FACTORIO_DIR=/path/to/your/factorio/installation
 
 When `FACTORIO_DIR` is set, `FACTORIO_USERNAME` and `FACTORIO_TOKEN` are not needed.
 
-#### Option B: Download base game data (no DLC support)
+### Option B: Download base game data (no DLC support)
 
 Add your `FACTORIO_USERNAME` and `FACTORIO_TOKEN` to `packages/exporter/.env`
 (you can get those [here](https://factorio.com/profile)).
 The exporter will download the base game data automatically.
 This option only supports base game items.
-
-That's it! 🎉 Thank you for your contribution! 😃
 
 ## Working on your first Pull Request?
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Factorio Blueprint Editor logo](./.github/logo.svg)
 
-[![Website](https://img.shields.io/website-up-down-brightgreen-red/https/fbe.teoxoy.com.svg?style=flat-square)](https://fbe.teoxoy.com)
+[![Website](https://img.shields.io/website-up-down-brightgreen-red/https/fbe.factorygamefan.com.svg?style=flat-square)](https://fbe.factorygamefan.com)
 [![Discord](https://img.shields.io/discord/540738973413408809.svg?style=flat-square&color=7289da&logo=discord&logoColor=white)](https://discord.gg/c5eXyBU)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blue.svg?style=flat-square)](./CONTRIBUTING.md)
 &nbsp;&nbsp;_Badges are clickable!_
@@ -10,15 +10,24 @@
 A feature-rich [Factorio](https://www.factorio.com) Blueprint Editor.
 You can now edit your blueprints in the browser!
 
+**About this fork.** This is `wormeyman/factorio-blueprint-editor`, a fork of
+[`teoxoy/factorio-blueprint-editor`](https://github.com/teoxoy/factorio-blueprint-editor)
+adding Factorio 2.0 and Space Age support. It is deployed at
+<https://fbe.factorygamefan.com>, and the links below point there. Upstream's
+own deployment is at <https://fbe.teoxoy.com>, and the Discord badge above is
+upstream's community server. The default branch here is
+`wormeyman-space-age-support`, not `master`.
+
 ![Preview](./.github/preview.png)
 
-Sample blueprint: <https://fbe.teoxoy.com/?source=https://pastebin.com/uc4n81GP>
+Sample blueprint: <https://fbe.factorygamefan.com/?source=https://pastebin.com/uc4n81GP>
 
-Example blueprint book: <https://fbe.teoxoy.com/?source=https://pastebin.com/Xp9u7NaA&index=1>
+Example blueprint book: <https://fbe.factorygamefan.com/?source=https://pastebin.com/Xp9u7NaA&index=1>
 
 ## Features
 
 - rendering and editing blueprints
+- Factorio 2.0 and Space Age entities, tiles and signals
 - history (undo/redo)
 - copy and delete selections
 - import blueprints and books from multiple sources
@@ -28,12 +37,16 @@ Example blueprint book: <https://fbe.teoxoy.com/?source=https://pastebin.com/Xp9
 - oil outpost generator
 - customizable keybinds
 - "creative" entities
+- read-only viewer on mobile, with pan and pinch-to-zoom
 
 ## Contributing
 
 Check out [this readme](./CONTRIBUTING.md) if you are interested in contributing.
 
 ## Credits
+
+Thanks to [Teoxoy](https://github.com/teoxoy) for building the editor this fork
+is based on.
 
 Thanks to all contributors!
 

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -84,7 +84,7 @@ const loadingScreen = {
 }
 
 console.log(
-    '\n%cLooking for the source?\nhttps://github.com/Teoxoy/factorio-blueprint-editor\n',
+    '\n%cLooking for the source?\nhttps://github.com/wormeyman/factorio-blueprint-editor/tree/wormeyman-space-age-support\n',
     'color: #1f79aa; font-weight: bold'
 )
 


### PR DESCRIPTION
`CONTRIBUTING.md` described a toolchain and a run-it-locally flow the repo no longer has. A new contributor following it would not have got the editor running. Each correction below was checked against the repo rather than against memory.

## CONTRIBUTING

| Doc said | Reality |
| --- | --- |
| `npm run start:website` + `npm run start:exporter` to run locally | `npm run localpreview` (Vite 8080, sprite data 8081, one Ctrl-C stops both). `start:exporter` is the rust data *generator*, not a server - following the old steps gave you a website with nothing serving `/data` |
| `npm i --legacy-peer-deps` | `vp install`. A dry-run install resolves clean, so the flag is dead; CI runs `vp install --frozen-lockfile` |
| Uses `eslint` and `prettier` | Neither config exists anywhere in the repo. It is `oxlint` + `oxfmt` via `vp`; `.vscode/extensions.json` asks for `oxc.oxc-vscode`. The old advice pointed contributors at extensions that would fight the repo's formatting |
| `git checkout -b my-fix-branch master` | `wormeyman-space-age-support` - the fork's default branch, and the only one `ci.yml` triggers on |
| Issue link → Teoxoy's tracker | The fork's, which has issues enabled and its own templates |
| `.env` / `FACTORIO_DIR` / `FACTORIO_TOKEN` as a **required** setup step | `packages/exporter/data/output` is committed - 8779 files, explicitly un-ignored in `.gitignore`. No rust, no Factorio install and no factorio.com account are needed to work on the editor. Moved to an optional "regenerating the sprite data" section, which is also where the rust prerequisite now lives |

Added: `vp` as the prerequisite it now is, with the pinned installer CI uses; a table of the check commands (`vp check`, `vp test`, `type-check:gate`, playwright); the `--port` / `FBE_BASE_URL` escape hatch; and a note that several Playwright specs read a corpus from `wormeyman-tests/`, which is gitignored and not distributed - without it they fail an explicit `expect(files.length).toBeGreaterThan(0)`, which reads like a regression the contributor caused.

## README and the console banner

Both pointed at upstream's deployment and repo while this fork serves `fbe.factorygamefan.com`. The website badge, both sample blueprint links and the console banner now point at the fork. Features gained the two things this fork is actually for - Space Age content and the mobile read-only viewer.

The banner in `packages/website/src/index.ts` takes the branch-qualified URL that `index.html`'s own Github button already used, since those two were disagreeing with each other.

Upstream's deployment, Discord server and authorship all stay - credited as upstream's rather than silently reused.

## Verification

- `vp check` passes: 181 files formatted, 0 lint or type errors
- `vp test`: 128/128
- `npm run type-check:gate`: 0 errors, at baseline 0
- The console banner was read out of a real headless Chromium against this branch's dev server, not just off the diff. It prints the fork URL, and no console line mentions Teoxoy
- Both pastebin samples resolve (37,949 and 217,005 bytes, valid `0eNr…` strings), and the fork's own `/corsproxy` returns the same bytes with `access-control-allow-origin: *` - so the relinked samples genuinely load, rather than pointing at a live host that would fail to fetch
- `fbe.factorygamefan.com` returns 200; the legacy `workers.dev` host 301s to it, matching `packages/worker/src/index.ts`
- Every import source listed under Features still exists in `bpString.ts:249-282`, and `?source=`/`?index=` are both still read in `packages/website/src/index.ts`

Docs plus one string literal. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg1SSTQsPz93qtybNGXR7w