### PR TITLE
fix: name the root package so npm stops stamping the directory into the lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "factorio-blueprint-editor",
             "workspaces": [
                 "packages/editor",
                 "packages/website",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "factorio-blueprint-editor",
     "private": true,
     "workspaces": [
         "packages/editor",


### PR DESCRIPTION
Closes #122.

The root `package.json` had no `name`, so npm falls back to the checkout's directory basename when writing the lockfile's top-level `name`. Every worktree-based install rewrote that field, since `.claude/worktrees/<name>` never matches the repo name.

Two added lines.

## Measured

**Before** - worktree named `name-drift-red`, `npm install --package-lock-only`:

```diff
-    "name": "factorio-blueprint-editor",
+    "name": "name-drift-red",
```

**After** - same command, worktree named `some-other-branch-name`: name held, `git status` empty. Repeated with `vp install`, the command `CONTRIBUTING.md` tells contributors to run: also clean.

## One thing the issue got wrong

#122 says the only diff is the added `package.json` field. It is not - adding the name makes npm write it into the lockfile's `packages[""]` entry as well, so the first green run still left a modified `package-lock.json`:

```diff
     "packages": {
         "": {
+            "name": "factorio-blueprint-editor",
             "workspaces": [
```

That line mirrors `package.json` rather than the directory - the main checkout and a differently-named worktree produced the identical blob `96ed41a9` - so it is committed here. Leaving it out would have swapped one spurious first-install diff for another.

## Notes

- `private: true` was already set, so naming the root does not make it publishable.
- The three workspace packages all declare their own `name`; the root was the only one that did not.
- Not a `vp` bug - bare `npm` reproduces it identically, as #122 established.
- `vp check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9srdYxLBokg8ReiHjFf8E