### PR TITLE
chore: point the type-check ratchet at a strict project so #77 can start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,16 @@ jobs:
       # Kept alongside `vp check` rather than folded into it. The two answer
       # different questions: vp check asks "does this type-check under the flags
       # that are on", the gate asks "has the count gone above the committed
-      # baseline". The baseline is 0 today, so this is currently redundant - it
-      # earns its place at the next flag flip, where the count starts non-zero
-      # and ratchets down (issue #77). Note that migration cannot use the
-      # ratchet while typeCheck is on, since vp check tolerates nothing.
+      # baseline". This is the flag flip that finally makes the difference pay -
+      # the baseline is 24 and ratcheting down (issue #77).
+      #
+      # The two can only both be true at once because they read *different
+      # projects*. The gate reads packages/editor/tsconfig.strict.json, which
+      # turns on the flag being migrated to; vp check reads the ordinary
+      # tsconfig.json and stays at 0 throughout. Turning the flag on in the root
+      # config instead would fail this job's `vp check` step above on the first
+      # commit and keep failing until the last, whatever the baseline said,
+      # since vp check exits non-zero before the gate ever runs.
       - name: Type-check gate
         if: ${{ !cancelled() }}
         run: npm run type-check:gate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,13 +57,21 @@ vp check
 vp check --fix
 
 # CI type-check gate: fails only if the error count exceeds the committed
-# baseline in scripts/type-check-baseline.json, now 0. Kept alongside `vp check`
-# because the two answer different questions - vp check asks whether the code
-# type-checks under the flags that are on, the gate asks whether the count has
-# risen above a committed baseline. Redundant while the baseline is 0; it earns
-# its place at the next flag flip (issue #77), where the count starts non-zero.
-# Note that migration cannot use the ratchet while typeCheck is on, since
-# vp check tolerates nothing. Covers packages/editor only.
+# baseline in scripts/type-check-baseline.json. Kept alongside `vp check` because
+# the two answer different questions - vp check asks whether the code type-checks
+# under the flags that are on, the gate asks whether the count has risen above a
+# committed baseline. It was redundant while the baseline was 0; issue #77 is the
+# flip that makes it pay, and the baseline is 24 and counting down.
+#
+# The two coexist only because they read *different projects*. The gate reads
+# packages/editor/tsconfig.strict.json, which turns on the one flag being
+# migrated to (`strictPropertyInitialization`) and which nothing compiles with;
+# `vp check` reads packages/editor/tsconfig.json and stays at 0. This is the
+# correction to what this note used to say - that a migration "cannot use the
+# ratchet while typeCheck is on". It cannot use the ratchet against the *same*
+# project vp check reads, because vp check tolerates nothing and exits non-zero
+# before the gate runs. Against a second project it can, and that is the shape
+# any future flag flip should copy. Covers packages/editor only.
 npm run type-check:gate
 
 # Unit tests (editor + gate) - gate tests now run under vp test

--- a/packages/editor/tsconfig.strict.json
+++ b/packages/editor/tsconfig.strict.json
@@ -1,0 +1,28 @@
+{
+    // Temporary scaffolding for issue #77, the last flag before `strict: true`.
+    //
+    // It exists because the two CI checks disagree about what a migration in
+    // progress looks like. `vp check .` runs with `lint.options.typeCheck` on and
+    // tolerates nothing, so turning `strictPropertyInitialization` on in the root
+    // tsconfig would fail CI on the first commit and stay failing until the last
+    // one - whatever `scripts/type-check-baseline.json` said, since the gate runs
+    // after `vp check` has already exited non-zero. The issue's own plan (flip the
+    // flag, raise the baseline to 24, ratchet down) does not survive that.
+    //
+    // Pointing the ratchet at this project instead splits the two questions apart.
+    // `vp check` keeps asking "does this compile under the flags that are on",
+    // and stays green throughout; the gate asks "has the count under the flag we
+    // are migrating *to* gone down", and can start non-zero. That is the case
+    // CLAUDE.md says the gate was kept for.
+    //
+    // Nothing builds with this project and no editor source file is owned by it -
+    // `vp check` resolves each file to `tsconfig.json` in this directory. It is
+    // read by `scripts/type-check-gate.mjs` and by nothing else.
+    //
+    // It should be deleted, with the flag moved into the root `strict: true`, once
+    // the baseline reaches 0. See scripts/type-check-baseline.json.
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "strictPropertyInitialization": true
+    }
+}

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
-    "project": "packages/editor/tsconfig.json",
-    "maxErrors": 0
+    "project": "packages/editor/tsconfig.strict.json",
+    "maxErrors": 24
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,15 @@
         // definitely assigned", concentrated in UI/controls (TextInput 5,
         // Checkbox 3, Slider 2, Button, Slot) and the paint containers; the
         // exception is Filters.m_Filters, which is also read before assignment.
-        // See issue #22.
+        // See issues #22 and #77.
+        //
+        // That flag is being migrated now, and deliberately not from here. It is
+        // on in packages/editor/tsconfig.strict.json, which nothing compiles with
+        // and which only scripts/type-check-gate.mjs reads, so the ratchet can
+        // start at 24 and count down while this block keeps every package at 0.
+        // Turning it on here instead would fail `vp check` in CI from the first
+        // commit of the migration to the last. When the baseline reaches 0, this
+        // whole block becomes `"strict": true` and that file is deleted.
         "strict": false,
         "noImplicitThis": true,
         "alwaysStrict": true,


### PR DESCRIPTION
First of five for #77. No runtime code changes - this only makes the migration possible to run in CI.

## Why the plan in the issue does not work

#77 proposes flipping `strict: true` in the root tsconfig, raising the baseline to 24, and ratcheting down. That fails on the first commit: `.github/workflows/ci.yml` runs `vp check .` **before** the gate, `lint.options.typeCheck` is on, and it tolerates nothing. It exits non-zero and the gate never runs. The build would be red from the start of the migration to the end.

`CLAUDE.md` and `ci.yml` both already said this, as "migration cannot use the ratchet while typeCheck is on".

## What this does instead

That statement is true only against the project `vp check` reads. So the gate now reads a different one:

- **`packages/editor/tsconfig.strict.json`** (new) - extends the editor project and turns on `strictPropertyInitialization`. Nothing compiles with it and it owns no source file; `scripts/type-check-gate.mjs` is its only reader.
- **`scripts/type-check-baseline.json`** - repointed at that project, `maxErrors` 0 -> 24.

`vp check` keeps every package at 0 under today's flags. The gate counts 24 down. When it reaches 0, the root block becomes `"strict": true` and the new file is deleted (PR 5).

## Measured

| Check | Result |
| --- | --- |
| `vp check` | 0 errors, 140 files - confirmed the new project is **not** adopted for editor sources |
| `npm run type-check:gate` | passes at 24 against baseline 24 |
| Ratchet can fail | added one uninitialized property to `Book.ts` -> `gate FAILED: 25 errors against baseline 24`, exit 1 |
| `vp test` | 128 passed |
| Playwright | 127 passed |

The mutation check matters more than the passing one: a ratchet that only ever passes would let all four remaining PRs land without enforcing anything.

## Prose changes

Three comments said the opposite of what is now true and are corrected rather than deleted - `ci.yml`, root `tsconfig.json`, and `CLAUDE.md`. Each records that the ratchet works against a *second* project, since that is the part a future flag flip will want to copy.

## Remaining

| PR | Scope | Baseline |
| --- | --- | --- |
| 2 | `UI/controls/` - TextInput 5, Checkbox 3, Slider 2, Button 1, Slot 1 | 24 -> 13 |
| 3 | paint + sprite containers - BlueprintContainer 3, EntitySprite 2, PaintContainer 2, PaintWireContainer 1, OverlayContainer 1 | 13 -> 5 |
| 4 | `Book._active`, `Filters.m_Filters` (the only TS2565) | 5 -> 0 |
| 5 | flip root `strict: true`, delete the temp project, repoint the baseline | closes #77 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9srdYxLBokg8ReiHjFf8E