### PR TITLE
refactor: initialise the UI control fields strict mode found unset

### DIFF
--- a/packages/editor/src/UI/controls/Checkbox.ts
+++ b/packages/editor/src/UI/controls/Checkbox.ts
@@ -26,7 +26,21 @@ export class Checkbox extends Container {
         super()
 
         this.eventMode = 'static'
-        this.checked = checked
+
+        /*
+            Drawn here rather than by assigning `this.checked`, which is what this
+            used to do. That setter is guarded by `if (this.m_Checked !== checked)`
+            and only ran at all because `m_Checked` started undefined, so
+            `undefined !== false` was true. Initialising the field without also
+            moving the drawing out would have made `new Checkbox(false)` - the
+            default, and what every caller uses - take the early return and never
+            build either graphic, leaving `m_Hover.visible` in the pointerover
+            handler below to throw on undefined.
+        */
+        this.m_Checked = checked
+        this.m_Checkbox = Checkbox.drawGraphic(checked, false, true)
+        this.m_Hover = Checkbox.drawGraphic(checked, true, false)
+        this.addChild(this.m_Checkbox, this.m_Hover)
 
         // Draw text
         if (text !== undefined) {
@@ -104,15 +118,15 @@ export class Checkbox extends Container {
         if (this.m_Checked !== checked) {
             this.m_Checked = checked
 
-            if (this.m_Checkbox !== undefined) {
-                this.removeChild(this.m_Checkbox)
-            }
+            // Both guards this replaces (`if (this.m_Checkbox !== undefined)`)
+            // covered exactly one case: the first call, made by the constructor
+            // before either graphic existed. The constructor draws them itself
+            // now, so there is no longer a call that finds them absent.
+            this.removeChild(this.m_Checkbox)
             this.m_Checkbox = Checkbox.drawGraphic(this.m_Checked, false, true)
             this.addChild(this.m_Checkbox)
 
-            if (this.m_Hover !== undefined) {
-                this.removeChild(this.m_Hover)
-            }
+            this.removeChild(this.m_Hover)
             this.m_Hover = Checkbox.drawGraphic(this.m_Checked, true, false)
             this.addChild(this.m_Hover)
         }

--- a/packages/editor/src/UI/controls/Slider.ts
+++ b/packages/editor/src/UI/controls/Slider.ts
@@ -15,11 +15,16 @@ export class Slider extends Container {
     /** Container to hold slider value graphic */
     private readonly m_SliderValue: Container
 
-    /** Is the button being dragged */
-    private m_Dragging: boolean
-
-    /** Field to hold reference drag point */
-    private m_Dragpoint: number
+    /**
+     * Where in the button the drag was grabbed, and whether a drag is happening
+     * at all - undefined means no drag in progress.
+     *
+     * These were two fields, `m_Dragging: boolean` alongside `m_Dragpoint:
+     * number`, always written together and only ever meaningful together. The
+     * boolean recorded nothing except that the number had been set, so the two
+     * could disagree in principle and the number had no honest initial value.
+     */
+    private m_Dragpoint: number | undefined
 
     /** Value of Slider */
     private p_Value: number
@@ -33,7 +38,6 @@ export class Slider extends Container {
         super()
 
         this.eventMode = 'static'
-        this.m_Dragging = false
         const factor = 2
 
         // Draw slide bar
@@ -93,7 +97,7 @@ export class Slider extends Container {
             buttonHover.visible = true
         })
         this.m_SliderButton.on('pointerout', () => {
-            if (!this.m_Dragging) {
+            if (this.m_Dragpoint === undefined) {
                 buttonHover.visible = false
             }
         })
@@ -102,7 +106,19 @@ export class Slider extends Container {
         this.m_SliderButton.on('pointerup', this.onButtonDragEnd, this)
         this.m_SliderButton.on('pointerupoutside', this.onButtonDragEnd, this)
         this.addChild(this.m_SliderButton)
-        this.value = value
+
+        /*
+            Assigned directly rather than through `this.value = value`, which is
+            what this used to do. That setter is guarded by
+            `if (this.p_Value !== value)` and only did anything here because
+            `p_Value` started undefined; initialising the field without also
+            moving this out would make `new Slider(1)` - the default - skip
+            updateButtonPosition() and leave the button drawn at the far left
+            whatever its value. The `emit('changed')` the setter also does is
+            not reproduced, since nothing can be listening mid-constructor.
+        */
+        this.p_Value = value
+        this.updateButtonPosition()
     }
 
     /** Slider value */
@@ -113,7 +129,7 @@ export class Slider extends Container {
         if (this.p_Value !== value) {
             this.p_Value = value
             this.emit('changed')
-            if (!this.m_Dragging) {
+            if (this.m_Dragpoint === undefined) {
                 this.updateButtonPosition()
             }
         }
@@ -167,8 +183,7 @@ export class Slider extends Container {
 
     /** Drag start event responder */
     private readonly onButtonDragStart = (event: FederatedPointerEvent): void => {
-        if (!this.m_Dragging) {
-            this.m_Dragging = true
+        if (this.m_Dragpoint === undefined) {
             // `this`, not m_SliderButton.parent: the constructor addChild's the
             // button to this Slider and nothing reparents it, so they are the
             // same container - and this one cannot be null.
@@ -180,7 +195,7 @@ export class Slider extends Container {
 
     /** Drag move event callback  */
     private readonly onButtonDragMove = (event: FederatedPointerEvent): void => {
-        if (this.m_Dragging) {
+        if (this.m_Dragpoint !== undefined) {
             const position = this.worldTransform.applyInverse(event.global)
 
             let x = position.x - this.m_Dragpoint
@@ -213,8 +228,8 @@ export class Slider extends Container {
 
     /** Drag end event callback */
     private readonly onButtonDragEnd = (): void => {
-        if (this.m_Dragging) {
-            this.m_Dragging = false
+        if (this.m_Dragpoint !== undefined) {
+            this.m_Dragpoint = undefined
             this.m_SliderButton.getChildAt<ContainerChild>(1).visible = false
         }
     }

--- a/packages/editor/src/UI/controls/Slot.ts
+++ b/packages/editor/src/UI/controls/Slot.ts
@@ -6,7 +6,22 @@ import { Button } from './Button'
  * Base Slot
  */
 export class Slot<Data, Content extends Container = Container> extends Button<Data, Content> {
-    public name: string
+    /*
+        The item name the slot's icon was last drawn for, absent until it has
+        drawn one. A cache key rather than a label: `Filters.m_UpdateSlots`
+        compares it against the filter's name to decide whether to rebuild the
+        icon, and on a slot that has never drawn anything the comparison has to
+        answer "different", which is what the undefined is for.
+
+        It was called `name`, which collided with pixi's own `Container.name` -
+        deprecated since v8, implemented as an accessor pair that proxies to
+        `label` and logs a deprecation warning on every read and write. The
+        declaration here shadowed it with an own field, so the warning never
+        fired and the collision was invisible; it also meant this could not be
+        typed honestly, since an override has to stay assignable to the `string`
+        the base declares. Renaming answers both.
+    */
+    public iconName: string | undefined
 
     // Override Rollover Color of Button
     public get hover(): number {

--- a/packages/editor/src/UI/controls/TextInput.ts
+++ b/packages/editor/src/UI/controls/TextInput.ts
@@ -76,19 +76,23 @@ class OriginalTextInput extends Container {
     private _previous: Partial<PreviousData>
     private _dom_added: boolean
     private _dom_visible: boolean
-    private _dom_input: HTMLInputElement | HTMLTextAreaElement
+    private readonly _dom_input: HTMLInputElement | HTMLTextAreaElement
     private _selection: number[]
     private _restrict_value: string
-    private _restrict_regex: RegExp
+    // Absent until a caller sets `restrict`; the read in _onInputInput is already
+    // written as a truthiness guard, which is what said so before the type did.
+    private _restrict_regex: RegExp | undefined
     private _disabled: boolean
-    private _max_length: number
+    // Absent until a caller sets `maxLength`. There is no honest default: 0 would
+    // mean "no characters allowed" rather than "no limit".
+    private _max_length: number | undefined
     private _multiline: boolean
     private _renderer: Renderer
     // Both are unset until the first render, and both are read through an
     // `if (!...)` guard that predates this - see _renderInternal.
     private _canvas_bounds: IRect | undefined
     private _box: Container | undefined
-    public state: State
+    public state: State = 'DEFAULT'
 
     public constructor(options: Options) {
         super()
@@ -116,7 +120,8 @@ class OriginalTextInput extends Container {
         this._placeholder = ''
         this._selection = [0, 0]
         this._restrict_value = ''
-        this._createDOMInput()
+        this._disabled = false
+        this._dom_input = this._createDOMInput()
         this._setState('DEFAULT')
         this._addListeners()
 
@@ -147,7 +152,7 @@ class OriginalTextInput extends Container {
         this._setState(disabled ? 'DISABLED' : 'DEFAULT')
     }
 
-    public get maxLength(): number {
+    public get maxLength(): number | undefined {
         return this._max_length
     }
 
@@ -156,7 +161,7 @@ class OriginalTextInput extends Container {
         this._dom_input.setAttribute('maxlength', `${length}`)
     }
 
-    public get restrict(): RegExp {
+    public get restrict(): RegExp | undefined {
         return this._restrict_regex
     }
 
@@ -217,18 +222,29 @@ class OriginalTextInput extends Container {
 
     // SETUP
 
-    private _createDOMInput(): void {
+    /*
+        Returns the element rather than assigning `this._dom_input` itself, which
+        is what it used to do. TypeScript's definite-assignment analysis reads the
+        constructor body only and does not follow calls out of it, so a field
+        assigned in here reads as never assigned at all.
+    */
+    private _createDOMInput(): HTMLInputElement | HTMLTextAreaElement {
+        let input: HTMLInputElement | HTMLTextAreaElement
         if (this._multiline) {
-            this._dom_input = document.createElement('textarea')
-            this._dom_input.style.resize = 'none'
+            const textarea = document.createElement('textarea')
+            textarea.style.resize = 'none'
+            input = textarea
         } else {
-            this._dom_input = document.createElement('input')
-            this._dom_input.type = 'text'
+            const text = document.createElement('input')
+            text.type = 'text'
+            input = text
         }
 
         for (const [key, value] of Object.entries(this._input_style)) {
-            this._dom_input.style[key as keyof InputStyles] = value ?? ''
+            input.style[key as keyof InputStyles] = value ?? ''
         }
+
+        return input
     }
 
     private _addListeners(): void {
@@ -255,7 +271,7 @@ class OriginalTextInput extends Container {
     }
 
     private _onInputInput(): void {
-        if (this._restrict_regex) this._applyRestriction()
+        if (this._restrict_regex !== undefined) this._applyRestriction(this._restrict_regex)
 
         this.emit('changed')
     }
@@ -343,8 +359,8 @@ class OriginalTextInput extends Container {
         // this._previous.world_visible = this.worldVisible
     }
 
-    private _applyRestriction(): void {
-        if (this._restrict_regex.test(this.text)) {
+    private _applyRestriction(regex: RegExp): void {
+        if (regex.test(this.text)) {
             this._restrict_value = this.text
         } else {
             this.text = this._restrict_value

--- a/packages/editor/src/UI/editors/components/Filters.ts
+++ b/packages/editor/src/UI/editors/components/Filters.ts
@@ -211,7 +211,11 @@ export class Filters extends Container<Slot<number>> {
                     slot.content = undefined
                 }
             } else {
-                if (slot.content === undefined || slot.name !== slotFilter.name || this.m_Amount) {
+                if (
+                    slot.content === undefined ||
+                    slot.iconName !== slotFilter.name ||
+                    this.m_Amount
+                ) {
                     if (this.m_Amount) {
                         if (slot.content !== undefined) {
                             const text = slot.children[1] as Text
@@ -239,7 +243,7 @@ export class Filters extends Container<Slot<number>> {
                     } else {
                         slot.content = F.CreateIcon(slotFilter.name)
                     }
-                    slot.name = slotFilter.name
+                    slot.iconName = slotFilter.name
                 }
             }
         }

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.strict.json",
-    "maxErrors": 24
+    "maxErrors": 13
 }


### PR DESCRIPTION
Second of five for #77. Ratchets the `strictPropertyInitialization` count **24 -> 13**.

Four of the five `UI/controls/` files. `Button.m_Data` is deliberately left for PR 3 - see the end.

## Two of these were live traps, not annotations

`Checkbox` and `Slider` both have **guarded setters** that their constructors call:

```ts
public set checked(checked: boolean) {
    if (this.m_Checked !== checked) { /* draws both graphics */ }
}
```

That body ran at construction *only* because `m_Checked` started `undefined`, making `undefined !== false` true. The change the flag appears to ask for - give the field an initialiser - is precisely the one that breaks it:

- `new Checkbox(false)`, the default and what every caller uses, would take the early return, never build either graphic, and leave `this.m_Hover.visible` in the `pointerover` handler throwing on undefined.
- `new Slider(1)`, likewise, would skip `updateButtonPosition()` and draw its button at the far left regardless of value.

Both constructors now do the drawing directly, which is what makes the fields initialisable. `Checkbox`'s two `if (this.m_Checkbox !== undefined)` guards went with it - they covered exactly the call that no longer happens.

## `Slot.name` was shadowing a deprecated pixi accessor

`Container.name` has been deprecated in pixi since v8. It is not a field - it is an accessor pair that proxies to `label` and calls `deprecation()` on **every read and write**. `Slot` declared `public name: string`, which shadows it with an own field, so no warning ever fired and the collision was invisible.

It also could not be typed honestly: an override has to stay assignable to the base's `string`, so `string | undefined` is a `TS2416`. Renamed to **`iconName`**, which is what it actually holds - the item name its icon was last drawn for, absent until it has drawn one. Two call sites in `Filters.ts` updated.

## Smaller

- **`Slider`**: `m_Dragging: boolean` and `m_Dragpoint: number` collapsed into one `number | undefined`. The boolean recorded nothing except that the number had been set, so the two could disagree in principle and the number had no honest initial value.
- **`TextInput`** (5): `_dom_input` and `state` were assigned inside methods the constructor calls, and TypeScript's definite-assignment analysis does not follow calls out of the constructor - `_createDOMInput` now returns the element instead of assigning it. `_disabled` genuinely defaults to `false`. `_max_length` and `_restrict_regex` are genuinely absent until a caller sets them; the `if (this._restrict_regex)` guard already written around the latter said so before the type did, and `_applyRestriction` now takes the regex as an argument so that narrowing survives the call.

## Verification

| Check | Result |
| --- | --- |
| `vp check` | 0 errors, 184 files formatted |
| `npm run type-check:gate` | passes at 13, baseline lowered 24 -> 13 |
| `vp test` | 128 passed |
| Playwright | see below |

**The Playwright result is not a clean sweep and is worth reading.** Four full runs on this branch: **127 passed twice**, and two runs each failed **one** unrelated pointer-driven spec - once `toast-click-interception.spec.ts:97`, once `paste-cross-type-settings.spec.ts:249`. Different spec each time, and both pass in isolation. The baseline was run once here for comparison and passed 127.

Neither spec opens a dialog or touches `UI/controls`, and nothing in this diff is on their path, so this reads as the known flakiness of pointer-driven specs under load rather than a regression from these changes. Recording it rather than re-rolling until green.

## Why `Button.m_Data` is not here

Widening it to `Data | undefined` was measured, not assumed: it produces **11 errors** across `Filters`, `Modules`, `WiresPanel` and `InventoryDialog`, every one at a site where the value provably exists, because `slot.data = slotIndex` runs on the line after `new Slot<number>()`. That would buy 11 bogus guards.

The honest fix is the issue's first preference - take the data as a constructor parameter, so the value exists at construction. That touches 6 files and 3 subclass constructors, which is its own change rather than a rider on this one. PR 3 (13 -> 5) will carry it alongside the paint containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9srdYxLBokg8ReiHjFf8E