### PR TITLE
refactor: give the containers and Button the values they were assumed to have

### DIFF
--- a/packages/editor/src/UI/InventoryDialog.ts
+++ b/packages/editor/src/UI/InventoryDialog.ts
@@ -31,7 +31,14 @@ import { colors, styles } from './style'
     Height : 10 + 16 + 10 + 36 + 8 = 78
 */
 
-type InventoryItems = Container<Button<Container>>
+/*
+    The item buttons carry no data - only `content`, the icon. This used to say
+    `Button<Container>`, which puts the type argument in Button's *Data* slot
+    rather than its Content one, so it claimed every item button held a
+    Container that nothing ever assigned. Data defaults to undefined, which is
+    what these actually have.
+*/
+type InventoryItems = Container<Button<undefined>>
 
 /** Inventory Dialog - Displayed to the user if there is a need to select an item */
 export class InventoryDialog extends Dialog {
@@ -119,7 +126,7 @@ export class InventoryDialog extends Dialog {
                 continue
             }
 
-            const inventoryGroupItems = new Container<Button<Container>>()
+            const inventoryGroupItems: InventoryItems = new Container()
             let itemColIndex = 0
             let itemRowIndex = 0
 
@@ -142,7 +149,7 @@ export class InventoryDialog extends Dialog {
                         itemRowIndex += 1
                     }
 
-                    const button = new Button<Container>(36, 36)
+                    const button = new Button<undefined>(undefined, 36, 36)
                     button.position.set(itemColIndex * 38, itemRowIndex * 38)
                     button.content = F.CreateIcon(item.name)
                     button.on('pointerdown', e => {
@@ -188,11 +195,12 @@ export class InventoryDialog extends Dialog {
                 }
                 this.m_ContentHeights.set(inventoryGroupItems, contentH)
 
-                const button = new Button<Container<Button<Container>>>(68, 68, 3)
+                // The group buttons do hold data - which items to reveal - and
+                // `m_InventoryGroups` has always been declared as holding these.
+                const button = new Button<InventoryItems>(inventoryGroupItems, 68, 68, 3)
                 button.active = groupIndex === 0
                 button.position.set(groupIndex * 70, 0)
                 button.content = F.CreateIcon(group.name, group.name === 'creative' ? 32 : 64)
-                button.data = inventoryGroupItems
                 button.on('pointerdown', e => {
                     e.stopPropagation()
                     if (e.button === 0) {

--- a/packages/editor/src/UI/QuickbarPanel.ts
+++ b/packages/editor/src/UI/QuickbarPanel.ts
@@ -90,7 +90,7 @@ export class QuickbarPanel extends Panel {
     public generateSlots(itemNames?: (string | undefined)[]): void {
         for (let r = 0; r < this.rows; r++) {
             for (let i = 0; i < 10; i++) {
-                const quickbarSlot = new QuickbarSlot()
+                const quickbarSlot = new QuickbarSlot(undefined)
                 quickbarSlot.position.set((36 + 2) * i + (i > 4 ? 38 : 0), 38 * r)
 
                 // Read into a local: the index is a loop `let`, so TypeScript

--- a/packages/editor/src/UI/WiresPanel.ts
+++ b/packages/editor/src/UI/WiresPanel.ts
@@ -14,13 +14,13 @@ import { colors } from './style'
     panel exists. Nothing ever clears one.
 */
 class WireSlot extends Slot<string> {
-    public get wireName(): string {
-        return this.data
+    public constructor(wireName: string) {
+        super(wireName)
+        this.content = F.CreateIcon(wireName)
     }
 
-    public setWireName(wireName: string): void {
-        this.data = wireName
-        this.content = F.CreateIcon(wireName)
+    public get wireName(): string {
+        return this.data
     }
 }
 
@@ -46,8 +46,7 @@ export class WiresPanel extends Panel {
 
     public generateSlots(): void {
         for (const [i, wire] of WiresPanel.Wires.entries()) {
-            const slot = new WireSlot()
-            slot.setWireName(wire)
+            const slot = new WireSlot(wire)
             slot.position.set((36 + 2) * i, 0)
 
             slot.on('pointerdown', e => {

--- a/packages/editor/src/UI/controls/Button.ts
+++ b/packages/editor/src/UI/controls/Button.ts
@@ -18,11 +18,25 @@ export class Button<Data = undefined, Content extends Container = Container> ext
     /** Content of Control, absent when the control is showing nothing */
     private m_Content: Content | undefined
 
-    /** Data of Control */
+    /**
+     * Data of Control.
+     *
+     * Taken as a constructor argument rather than assigned afterwards. Every
+     * caller already knew the value one line later - `slot.data = slotIndex`
+     * directly after `new Slot<number>()` - so the window in which this was
+     * undefined existed only because the constructor did not ask for it.
+     */
     private m_Data: Data
 
-    public constructor(width = 36, height = 36, border = colors.controls.button.border) {
+    public constructor(
+        data: Data,
+        width = 36,
+        height = 36,
+        border = colors.controls.button.border
+    ) {
         super()
+
+        this.m_Data = data
 
         this.eventMode = 'static'
         this.cursor = 'pointer'

--- a/packages/editor/src/UI/controls/Slot.ts
+++ b/packages/editor/src/UI/controls/Slot.ts
@@ -33,7 +33,7 @@ export class Slot<Data, Content extends Container = Container> extends Button<Da
         return true
     }
 
-    public constructor(width = 36, height = 36, border = 1) {
-        super(width, height, border)
+    public constructor(data: Data, width = 36, height = 36, border = 1) {
+        super(data, width, height, border)
     }
 }

--- a/packages/editor/src/UI/editors/components/Filters.ts
+++ b/packages/editor/src/UI/editors/components/Filters.ts
@@ -121,12 +121,11 @@ export class Filters extends Container<Slot<number>> {
 
         // Create slots for entity
         for (let slotIndex = 0; slotIndex < this.m_Filters.length; slotIndex++) {
-            const slot = new Slot<number>()
+            const slot = new Slot<number>(slotIndex)
             slot.position.set(
                 Math.floor((slotIndex % this.m_Columns) * 38),
                 Math.floor(slotIndex / this.m_Columns) * 38
             )
-            slot.data = slotIndex
             slot.on('pointerdown', this.onSlotPointerDown, this)
             this.addChild(slot)
         }

--- a/packages/editor/src/UI/editors/components/Modules.ts
+++ b/packages/editor/src/UI/editors/components/Modules.ts
@@ -29,9 +29,8 @@ export class Modules extends Container<Slot<number>> {
 
         // Create slots for entity
         for (let slotIndex = 0; slotIndex < this.m_Modules.length; slotIndex++) {
-            const slot = new Slot<number>()
+            const slot = new Slot<number>(slotIndex)
             slot.position.set(slotIndex * 38, 0)
-            slot.data = slotIndex
             slot.on('pointerdown', this.onSlotPointerDown)
             // Read into a local first: `slotIndex` is a loop `let`, so
             // TypeScript will not carry a narrowing of `m_Modules[slotIndex]`

--- a/packages/editor/src/UI/editors/components/Recipe.ts
+++ b/packages/editor/src/UI/editors/components/Recipe.ts
@@ -11,7 +11,7 @@ export class Recipe extends Slot<undefined> {
     private readonly m_Entity: Entity
 
     public constructor(entity: Entity) {
-        super()
+        super(undefined)
 
         this.m_Entity = entity
         this.updateContent(this.m_Entity.recipe)

--- a/packages/editor/src/containers/BlueprintContainer.ts
+++ b/packages/editor/src/containers/BlueprintContainer.ts
@@ -143,11 +143,24 @@ export class BlueprintContainer extends Container {
         return this.paintContainer
     }
 
-    private _entityForCopyData: Entity
+    /*
+        The entity a settings copy was taken from, absent until one is taken.
+        `pasteEntitySettings` below already tests it for truthiness and
+        OverlayContainer already tests it for `!== undefined`, so every reader
+        was written for the undefined the declaration denied.
+    */
+    private _entityForCopyData: Entity | undefined
     private copyModeEntities: Entity[] = []
     private deleteModeEntities: Entity[] = []
-    private copyModeUpdateFn: (endX: number, endY: number) => void
-    private deleteModeUpdateFn: (endX: number, endY: number) => void
+    /*
+        Registered on gridData while COPY/DELETE mode is held and removed on the
+        way out, so they exist only for that span. Cleared on exit as well as
+        removed, which the listener alone did not do - each closure captures the
+        drag's start position and its entity list, and held one of each alive
+        until the next drag replaced it.
+    */
+    private copyModeUpdateFn: ((endX: number, endY: number) => void) | undefined
+    private deleteModeUpdateFn: ((endX: number, endY: number) => void) | undefined
     private copySettingsActive = false
 
     // PIXI properties
@@ -525,7 +538,7 @@ export class BlueprintContainer extends Container {
         })
     }
 
-    public get entityForCopyData(): Entity {
+    public get entityForCopyData(): Entity | undefined {
         return this._entityForCopyData
     }
 
@@ -680,7 +693,10 @@ export class BlueprintContainer extends Container {
         if (this.mode !== EditorMode.COPY) return
 
         this.overlayContainer.hideSelectionArea()
-        this.gridData.off('update32', this.copyModeUpdateFn, this)
+        if (this.copyModeUpdateFn !== undefined) {
+            this.gridData.off('update32', this.copyModeUpdateFn, this)
+            this.copyModeUpdateFn = undefined
+        }
 
         this.setMode(EditorMode.NONE)
         this.updateHoverContainer()
@@ -735,7 +751,10 @@ export class BlueprintContainer extends Container {
         if (this.mode !== EditorMode.DELETE) return
 
         this.overlayContainer.hideSelectionArea()
-        this.gridData.off('update32', this.deleteModeUpdateFn, this)
+        if (this.deleteModeUpdateFn !== undefined) {
+            this.gridData.off('update32', this.deleteModeUpdateFn, this)
+            this.deleteModeUpdateFn = undefined
+        }
 
         this.setMode(EditorMode.NONE)
         this.updateHoverContainer()

--- a/packages/editor/src/containers/EntitySprite.ts
+++ b/packages/editor/src/containers/EntitySprite.ts
@@ -63,8 +63,22 @@ export class EntitySprite extends Sprite {
     private static nextID = 0
 
     private id: number
-    private __zIndex: number
-    private zOrder: number
+    /*
+        The render layer, defaulted rather than left unset. `getParts` assigns
+        this per sprite, but its splitter/underground-belt/loader arm only does
+        so for the one sprite that is the main belt:
+
+            if (!foundMainBelt && data.filename.includes('transport-belt')) {
+
+        Every other sprite of those three types fell out with no value at all,
+        and `compareFn` then computed `undefined - undefined`, which is NaN -
+        an incoherent comparator, so their order was whatever the sort happened
+        to do. ENTITY_BASE is what the chain's own `else` gives everything not
+        otherwise special, so it is the value they were meant to have.
+    */
+    private __zIndex: number = LAYER.ENTITY_BASE
+    /** Overwritten by getParts for every sprite it builds; 0 is its first index. */
+    private zOrder = 0
     private readonly entityPos: IPoint
 
     public constructor(

--- a/packages/editor/src/containers/OverlayContainer.ts
+++ b/packages/editor/src/containers/OverlayContainer.ts
@@ -39,7 +39,8 @@ export class OverlayContainer extends Container {
     private readonly undergroundLines = new Container()
     private readonly selectionArea = new Graphics()
     private copyCursorBox: Container | undefined
-    private selectionAreaUpdateFn: (endX: number, endY: number) => void
+    // Absent outside a selection drag, same as `copyCursorBox` above.
+    private selectionAreaUpdateFn: ((endX: number, endY: number) => void) | undefined
 
     public constructor(bpc: BlueprintContainer) {
         super()
@@ -602,6 +603,9 @@ export class OverlayContainer extends Container {
 
     public hideSelectionArea(): void {
         this.selectionArea.clear()
-        this.bpc.gridData.off('update', this.selectionAreaUpdateFn, this)
+        if (this.selectionAreaUpdateFn !== undefined) {
+            this.bpc.gridData.off('update', this.selectionAreaUpdateFn, this)
+            this.selectionAreaUpdateFn = undefined
+        }
     }
 }

--- a/packages/editor/src/containers/PaintContainer.ts
+++ b/packages/editor/src/containers/PaintContainer.ts
@@ -29,7 +29,16 @@ export abstract class PaintContainer extends Container<EntitySprite> {
     protected constructor(bpc: BlueprintContainer, name: string) {
         super()
         this.bpc = bpc
-        this.name = name
+
+        /*
+            The two writes the `name` setter makes, done here instead. The setter
+            destroys the previous icon before drawing the next, and its
+            `this.icon?.destroy()` was optional only to survive this first call,
+            when there was no previous icon. Same calls in the same order.
+        */
+        this._name = name
+        this.icon = F.CreateIcon(this.getItemName())
+        G.UI.addPaintIcon(this.icon)
 
         this._children_tint = F.rgbToColorSource(0.4, 1, 0.4)
 
@@ -67,7 +76,9 @@ export abstract class PaintContainer extends Container<EntitySprite> {
 
     protected set name(name: string) {
         this._name = name
-        this.icon?.destroy()
+        // Not `?.` any more: the constructor draws the first icon, so every call
+        // that reaches here has one to replace.
+        this.icon.destroy()
         this.icon = F.CreateIcon(this.getItemName())
         G.UI.addPaintIcon(this.icon)
     }

--- a/packages/editor/src/containers/PaintWireContainer.ts
+++ b/packages/editor/src/containers/PaintWireContainer.ts
@@ -12,8 +12,8 @@ export class PaintWireContainer extends PaintContainer {
     private color: WireColor
     /** The anchored end of the wire being dragged; the other end follows the cursor. */
     private cp?: IEntityConnectionPoint = undefined
-    /** This is only a reference */
-    private cursorBox: Container
+    /** This is only a reference, and there is none until redraw draws one. */
+    private cursorBox: Container | undefined
 
     public constructor(bpc: BlueprintContainer, name: string) {
         super(bpc, name)

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.strict.json",
-    "maxErrors": 13
+    "maxErrors": 3
 }


### PR DESCRIPTION
Third of five for #77. Ratchets the count **13 -> 3**. Only `Book._active` and `Filters.m_Filters` remain.

## `Button.m_Data` takes the constructor route

Widening it to `Data | undefined` was **measured, not assumed**: 11 errors across `Filters` (7), `Modules` (2), `WiresPanel` and `InventoryDialog`, every one at a site where the value provably exists, because `slot.data = slotIndex` ran on the line *after* `new Slot<number>()`. That buys 11 guards that can never fire.

Asking for the value in the constructor removes the window instead of guarding it:

```diff
- const slot = new Slot<number>()
- slot.data = slotIndex
+ const slot = new Slot<number>(slotIndex)
```

Six call sites. `WireSlot.setWireName` folded into a constructor, its only caller having been the line after the construction.

### Two things that fell out

`new Button<Container>(36, 36)` put its type argument in Button's **Data** slot, not its Content one - `Button<Data = undefined, Content extends Container = Container>`. So every inventory item button claimed to hold a `Container` that nothing ever assigned, and `type InventoryItems = Container<Button<Container>>` encoded the same mistake. Both now say `Button<undefined>`, which is what they are. Only `.content` was ever set on those buttons.

## `EntitySprite.__zIndex` was a live bug

`getParts` assigns it per sprite, but the splitter / underground-belt / loader arm assigns it **conditionally**:

```ts
} else if (entity.type === 'splitter' || ... 'underground-belt' || ... 'loader') {
    if (!foundMainBelt && data.filename.includes('transport-belt')) {
        foundMainBelt = true
        sprite.__zIndex = LAYER.TRANSPORT_BELT
    }
    // no else - every other sprite of these types falls out unset
}
```

`compareFn` then computes `a.__zIndex - b.__zIndex` = `undefined - undefined` = **NaN**. A comparator returning NaN has no defined behaviour, so the draw order of those sprites was whatever the sort happened to do with it.

Defaulting to `LAYER.ENTITY_BASE` - what the chain's own `else` gives everything unremarkable - makes them sort where they were meant to.

**This is a real change to rendering order for those three entity types, and nothing in the suite asserts draw order.** `sprite-data.spec.ts` digests generated sprite *data*, not the sprites' z ordering, so a green suite is not evidence here. Flagging it rather than burying it; worth a look at a splitter and an underground belt in the editor before this is trusted.

## The rest were declarations denying what their readers already knew

| Property | The tell that was already in the code |
| --- | --- |
| `_entityForCopyData` | tested for truthiness one method below, and `!== undefined` in `OverlayContainer` |
| `PaintContainer.icon` | reached through `this.icon?.destroy()` |
| `PaintWireContainer.cursorBox` | reached through `this.cursorBox?.destroy()` |
| `copyModeUpdateFn`, `deleteModeUpdateFn`, `selectionAreaUpdateFn` | registered on entering a drag mode, `off()`d on exit |

`PaintContainer`'s constructor now does the two writes its `name` setter made, the same way `Checkbox` did in PR #126 - the setter's `?.` existed only to survive that first call.

The three drag callbacks are now **cleared** on exit as well as unregistered. `off()` alone did not do that, and each closure captures a drag's start position and its entity list, so one of each stayed alive until the next drag replaced it.

## Verification

| Check | Result |
| --- | --- |
| `vp check` | 0 errors |
| `npm run type-check:gate` | passes at 3, baseline lowered 13 -> 3 |
| `vp test` | 128 passed |
| Playwright | **127 passed**, clean run |

Coverage is real for most of this - `editor-mode-input` drives both paint containers, `chest-editor` opens the inventory dialog and clicks slots, `paste-entity-settings` and `paste-cross-type-settings` exercise the copy-data path. The `__zIndex` change is the exception noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9srdYxLBokg8ReiHjFf8E