### PR TITLE
refactor: initialise Book._active and Filters.m_Filters, reaching 0

### DIFF
--- a/packages/editor/src/UI/editors/components/Filters.ts
+++ b/packages/editor/src/UI/editors/components/Filters.ts
@@ -84,7 +84,7 @@ export class Filters extends Container<Slot<number>> {
         what makes this IFilterSlot[] rather than IFilter[]. Entity's setter is
         built for exactly this and strips the nameless entries on the way in.
     */
-    private m_Filters: IFilterSlot[]
+    private m_Filters: IFilterSlot[] = []
 
     /**
      * Slots to a row. Six is what every filter dialog used to draw, and is still
@@ -177,25 +177,33 @@ export class Filters extends Container<Slot<number>> {
             past the grid, and an entry with nowhere to draw is better than one
             the array does not have at all.
         */
+        /*
+            The `if (slots > 0)` this replaces left m_Filters unassigned entirely
+            for an entity with no filter slots, and the constructor reads
+            `this.m_Filters.length` on the next line - so that case threw on
+            undefined rather than drawing an empty grid. Building the array
+            unconditionally answers it: `Array.from({ length: 0 })` is `[]`, both
+            loops below then do nothing, and the constructor's own loop does not
+            run either. Identical for every slots > 0, which is every entity that
+            reaches this dialog today.
+        */
         const slots = Math.max(this.m_SlotCount, this.m_Entity.filterSlots)
-        if (slots > 0) {
-            this.m_Filters = Array.from<IFilterSlot>({ length: slots })
-            const filters = this.m_Entity.filters
-            if (filters !== undefined) {
-                for (const item of filters) {
-                    this.m_Filters[item.index - 1] = {
-                        index: item.index,
-                        name: item.name,
-                        count: item.count,
-                    }
+        this.m_Filters = Array.from<IFilterSlot>({ length: slots })
+        const filters = this.m_Entity.filters
+        if (filters !== undefined) {
+            for (const item of filters) {
+                this.m_Filters[item.index - 1] = {
+                    index: item.index,
+                    name: item.name,
+                    count: item.count,
                 }
             }
-            for (let slotIndex = 0; slotIndex < slots; slotIndex++) {
-                this.m_Filters[slotIndex] =
-                    this.m_Filters[slotIndex] === undefined
-                        ? { index: slotIndex + 1, name: undefined }
-                        : this.m_Filters[slotIndex]
-            }
+        }
+        for (let slotIndex = 0; slotIndex < slots; slotIndex++) {
+            this.m_Filters[slotIndex] =
+                this.m_Filters[slotIndex] === undefined
+                    ? { index: slotIndex + 1, name: undefined }
+                    : this.m_Filters[slotIndex]
         }
     }
 

--- a/packages/editor/src/core/Book.ts
+++ b/packages/editor/src/core/Book.ts
@@ -2,7 +2,13 @@ import { IBlueprint, IBlueprintBook, IBlueprintBookEntry, IIcon } from '../types
 import { Blueprint, getFactorioVersion } from './Blueprint'
 
 class Book {
-    private _active: Blueprint
+    /*
+        The blueprint currently open, absent until selectBlueprint has opened one.
+        A freshly constructed Book has none, which is why saveActiveBlueprint
+        below is written as `if (this._active)` and answers 0 without it - the
+        guard predates the type saying so.
+    */
+    private _active: Blueprint | undefined
     private _activeIndex: number
     private readonly blueprints: IBlueprintBookEntry[]
 

--- a/scripts/type-check-baseline.json
+++ b/scripts/type-check-baseline.json
@@ -1,4 +1,4 @@
 {
     "project": "packages/editor/tsconfig.strict.json",
-    "maxErrors": 3
+    "maxErrors": 0
 }


### PR DESCRIPTION
Fourth of five for #77. Ratchets the count **3 -> 0**. The flag itself flips in PR 5, which also deletes the temporary project the ratchet reads.

## `Book._active`

Absent until `selectBlueprint` opens one. `saveActiveBlueprint` has always known - it is written `if (this._active)` and answers `0` without one. Only the declaration disagreed.

## `Filters.m_Filters` - the one the issue singled out

The only **TS2565** in the set: *used* before assignment, not merely unassigned. The issue predicted this would be "about control flow rather than about an annotation", and it was - there is a real hole behind it.

`m_UpdateFilters` only built the array inside a guard:

```ts
const slots = Math.max(this.m_SlotCount, this.m_Entity.filterSlots)
if (slots > 0) {
    this.m_Filters = Array.from<IFilterSlot>({ length: slots })
    ...
}
```

and the constructor reads `this.m_Filters.length` on the line after calling it. So an entity with **no filter slots** did not draw an empty grid - it threw on undefined.

Building the array unconditionally answers both the type error and the hole: `Array.from({ length: 0 })` is `[]`, both loops inside do nothing, and the constructor's own slot loop does not run either. Identical behaviour for every `slots > 0`, which is every entity that reaches this dialog today.

## Verification

| Check | Result |
| --- | --- |
| `vp check` | 0 errors |
| `npm run type-check:gate` | passes at 0, baseline lowered 3 -> 0 |
| `vp test` | 128 passed |
| Playwright | 127 passed |

`chest-editor.spec.ts` and `chest-filters.spec.ts` both drive the filter grid, including the issue #93 case of a chest arriving with a request at index 45, so the `m_UpdateFilters` change is covered.

## A separate finding from a failed run

One earlier run failed `paste-cross-type-settings.spec.ts:249` on a hover timeout. The trace names a cause that has nothing to do with this change and is worth its own issue:

```css
.dg.main { position: fixed; bottom: 0; left: 0; z-index: 5; }
```

The dat.gui settings pane is a 320px column pinned over the canvas, and the failing page snapshot shows it open. `tests/helpers/toasts.ts` suppresses `.toasts-container` - bottom **right** - and nothing else. This is issue #119 in the other corner, still uncovered, and would explain intermittent failures in pointer specs whose target lands bottom-left. Filed separately rather than smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9srdYxLBokg8ReiHjFf8E