### PR TITLE
measure: what a rail actually occupies, and why #133 item 1 cannot be written as stated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,7 @@ Common patterns for `draw_*` functions:
 - **`EnergySource` is a discriminated union on `type`, but `getEnergySource` can also answer `undefined`,** and `undefined` has no `type` for the check to narrow through. `if (es.type === 'heat')` therefore narrows nothing and `.connections` / `.pipe_covers` stay unreadable - the guard has to be `if (es && es.type === 'heat')`.
 - **The same layer key is not uniformly present across a family of entities.** Ground rails carry all five picture layers for every non-empty direction; elevated rails have no `ties`, `rail-ramp` has no `backplates` or `metals`, and `heating-tower` is a reactor with no `lower_layer_picture`. So `draw_rail` can use `need()` and `draw_elevated_rail` has to filter - probe `data.json` per entity rather than per type.
 - **Rail placement rules do not group the way the prototype names do.** The same warning one level up: `isAreaAvailable` sorts rails into straight, half-diagonal and curved, and for the question "may a signal sit on this rail's own tiles" that grouping is **wrong in both directions**. Measured across every orientation of every type (`tools/oracle/fixtures/rail-placement.json`): `straight-rail`, `half-diagonal-rail` and `legacy-curved-rail` have no legal signal position overlapping their tiles, while `curved-rail-a` has one per orientation, `curved-rail-b` two or three, and `legacy-straight-rail` one at each of its four **diagonal** orientations and none at its cardinals. So a legacy straight rail behaves like a curved one here and a legacy curved rail like a straight one. Gates split by orientation rather than by prototype: a `straight-rail` takes one only at directions 0 and 4, a `legacy-straight-rail` at all six of its orientations, a `half-diagonal-rail` at none. Ask the oracle per prototype and per direction; do not generalise from one of either.
+- **"Which tiles does this entity occupy" is not a property of the entity.** Collision is continuous and tiles are not, so the answer depends on the size of the box being asked about - measured, a `small-electric-pole` fits on cells a `wooden-chest` is refused on and a `transport-belt` is refused on cells the chest is not, over 28 and 24 of 38 rail orientations. That is why `PositionGrid`'s rectangle cannot simply be replaced by a per-rail cell set, and it generalises past rails: any future "occupancy shape" work has to name the reference size it is calibrated for. See `tools/oracle/fixtures/rail-occupancy.json`
 - **Rail direction normalisation is per prototype, and the modulus is load-bearing in both directions.** How many orientations the game keeps is not uniform: `straight-rail` and `half-diagonal-rail` fold mod 8 down to four, the three curved types keep all eight, and `legacy-straight-rail` keeps **six** - it folds 8 to 0 and 12 to 4 while leaving 10 and 14 distinct from 2 and 6. The four elevated types fold exactly as their ground namesakes do. So a blanket `direction % 8` conflates two legacy orientations the game separates, and dropping it entirely conflates nothing but stops catching a straight rail rotated to direction 8 over one at 0 - which is reachable, since `getPossibleRotations` gives every rail `[0,2,4,6,8,10,12,14]` while the game stores only four of them. Measured over all sixteen directions of all ten prototypes in `tools/oracle/fixtures/rail-on-rail.json`. And the discriminator for whether two rails may share tiles is **not** the prototype name: two _cardinal_ 2x2 rails fill their shared tiles completely whichever prototypes they are, so `legacy-straight-rail` at 0 may not go on `straight-rail` at 0, while the same pair at a _diagonal_ orientation is accepted
 - **The elevated rails are a collision layer, not a geometry, and the list of what they collide with is short and specific.** All four carry `collision_mask = {layers={elevated_rail=true}}` and nothing else, so they pass over every ordinary ground entity - which is why a placement rule keyed on tiles alone refused the one thing an elevated rail is for. What they _do_ collide with is everything else carrying that layer: `rail-ramp`, and about a dozen tall buildings. That list is keyed by **name and not by type** - `oil-refinery` carries it and no other assembling machine does, `big-electric-pole` does and no other pole does - so a type key refuses far more than the game. `rail-support` deliberately does **not** carry it, since a support holds a rail up and must overlap one. Measured in `tools/oracle/fixtures/elevated-rail-collision.json`, and note `data.json` does **not** export `collision_mask`, so the editor's copy of this list is hardcoded in `PositionGrid.ts` and has to be re-derived from the fixture rather than read at runtime.
 
@@ -233,6 +234,28 @@ not just the answer**.
   all sixteen turned it into 8 against 0.
 - Entities **snap**, so a requested position is not a measured one: 16 raw
   acceptances around a straight rail are 4 real signal positions.
+
+And what a rail actually occupies (issue #133 item 1,
+`tools/oracle/fixtures/rail-occupancy.json`), which **inverts that item's
+premise and is the reason not to start writing it**. Occupancy was measured
+operationally - a cell is blocked if the game refuses a 1x1 centred on it while
+the rail stands - against four different 1x1 references, and they do not agree:
+a `small-electric-pole` (0.3x0.3 box) fits on cells a `wooden-chest` (0.7x0.7)
+is refused on, a `transport-belt` (0.8x0.8) is refused on cells the chest is
+not, and a `gate` - **smaller** than the chest - is legal on all four cells of a
+cardinal straight rail, which no size argument explains and which is the
+rail-gate rule. So "which tiles does this rail occupy" has no single answer, and
+one occupancy shape per rail cannot be correct however carefully it is chosen.
+`rail-signal` cannot be measured this way at all and is excluded by its own
+control, being refused on empty ground everywhere. Two further findings: the
+editor's rectangle is wrong in **both** directions and **under**-reporting
+dominates - 34 of 38 orientations block a cell it does not key against 28 that
+key an empty one, a diagonal `straight-rail` really blocking 8 cells where it
+keys 4 and a `half-diagonal-rail` 12 where it keys 4 - and the game publishes
+`tile_width`/`tile_height` that the exporter emits for only 3 of 155 entities,
+which disagree with the computed rectangle for every curved type
+(`curved-rail-a` 2x4 against 2x6, `curved-rail-b` 2x2 against 2x5,
+`legacy-curved-rail` 4x8 against 4x4).
 
 And which rail may be laid across which (issue #133 item 5,
 `tools/oracle/fixtures/rail-on-rail.json`), the first measurement those nine

--- a/tools/oracle/README.md
+++ b/tools/oracle/README.md
@@ -43,6 +43,7 @@ This is the part that saves time, and it is not "open a disassembler":
 | `probe-rail-placement.mjs`           | Where a signal and a gate may sit relative to every rail orientation (#95)    |
 | `probe-elevated-rail-collision.mjs`  | What an elevated rail collides with, and what may sit under one (#133)        |
 | `probe-rail-on-rail.mjs`             | Which rail may be laid across which, over 1444 ordered pairs (#133)           |
+| `probe-rail-occupancy.mjs`           | Which tiles a rail really blocks, and whether one answer serves (#133)        |
 
 ```sh
 node tools/oracle/probe-section-index-cases.mjs
@@ -97,6 +98,15 @@ model wants the same treatment.
   not. That control was a restatement of the hypothesis, so it could only ever
   agree or announce the finding, never invalidate the apparatus. It was replaced
   with "the anchor's own position is never accepted", which is about the rig.
+- **A probe entity is part of the question, not a neutral instrument.** "Which
+  tiles does this rail occupy" sounds like a property of the rail. It is not:
+  collision is continuous, so the answer depends on how big the box being asked
+  about is. Measured with four 1x1 references, a `small-electric-pole` (0.3 x
+  0.3) fits on cells a `wooden-chest` (0.7 x 0.7) is refused on, and a
+  `transport-belt` (0.8 x 0.8) is refused on cells the chest is not - 28 and 24
+  of 38 rail orientations respectively. Sweep more than one reference before
+  concluding anything of the form "X occupies Y", and if they disagree, that is
+  the finding.
 - **Check a proposed rule against the rows before writing any code.** The same
   probe carries two transcriptions of the editor's arms, before and after, and
   reports what each would get wrong across every measured row. The first draft

--- a/tools/oracle/fixtures/rail-occupancy.json
+++ b/tools/oracle/fixtures/rail-occupancy.json
@@ -1,0 +1,27464 @@
+{
+    "question": "Which integer tiles does each rail actually block, is the answer the same for everything that might be placed there, and does the editor rectangle contain it?",
+    "issue": 133,
+    "probe": "tools/oracle/probe-rail-occupancy.mjs",
+    "binary": "Version: 2.1.12 (build 87038, mac-arm64, steam)",
+    "versionCaveat": "Captured on 2.1.12. This editor targets 2.0.45 to 2.0.73 and the corpus declares nothing outside that range.",
+    "measurementCaveats": [
+        "Occupancy is operational, not geometric: a cell is blocked if the game refuses a 1x1 entity centred on it while the rail stands, and accepts the same on empty ground. That is the question isAreaAvailable is asked. It is not a claim about how Factorio composes a curve out of collision boxes.",
+        "A cell counts as free if ANY of the sixteen directions is accepted there, since a gate and a signal are directional and legal only at some facings while the grid question is whether the cell can be built on at all.",
+        "editorTiles is computed on this side from data.json, mirroring getEntitySize. Note the exporter emits tile_width/tile_height for only 3 of 155 entities, so the editor computes from collision_box where the game publishes a footprint - the two columns are there to be compared."
+    ],
+    "controls": [
+        {
+            "control": "an empty window is free for wooden-chest",
+            "holds": true,
+            "got": "0 blocked"
+        },
+        {
+            "control": "an empty window is free for gate",
+            "holds": true,
+            "got": "0 blocked"
+        },
+        {
+            "control": "an empty window is free for transport-belt",
+            "holds": true,
+            "got": "0 blocked"
+        },
+        {
+            "control": "an empty window is free for small-electric-pole",
+            "holds": true,
+            "got": "0 blocked"
+        },
+        {
+            "control": "an empty window is free for rail-signal",
+            "holds": false,
+            "got": "121 blocked"
+        },
+        {
+            "control": "a straight-rail at direction 0 blocks exactly its 2x2",
+            "holds": true,
+            "got": "-1,-1 -1,0 0,-1 0,0"
+        },
+        {
+            "control": "a straight-rail at direction 4 blocks exactly its 2x2",
+            "holds": true,
+            "got": "-1,-1 -1,0 0,-1 0,0"
+        },
+        {
+            "control": "wooden-chest collides with rails at all",
+            "holds": true,
+            "got": "blocked somewhere"
+        },
+        {
+            "control": "gate collides with rails at all",
+            "holds": true,
+            "got": "blocked somewhere"
+        },
+        {
+            "control": "transport-belt collides with rails at all",
+            "holds": true,
+            "got": "blocked somewhere"
+        },
+        {
+            "control": "small-electric-pole collides with rails at all",
+            "holds": true,
+            "got": "blocked somewhere"
+        }
+    ],
+    "referenceBoxes": {
+        "wooden-chest": [
+            [-0.35, -0.35],
+            [0.35, 0.35]
+        ],
+        "gate": [
+            [-0.29, -0.29],
+            [0.29, 0.29]
+        ],
+        "transport-belt": [
+            [-0.4, -0.4],
+            [0.4, 0.4]
+        ],
+        "small-electric-pole": [
+            [-0.15, -0.15],
+            [0.15, 0.15]
+        ],
+        "rail-signal": [
+            [-0.2, -0.2],
+            [0.2, 0.2]
+        ]
+    },
+    "referenceAgreement": {
+        "usableReferences": ["wooden-chest", "gate", "transport-belt", "small-electric-pole"],
+        "excludedByTheirOwnControl": ["rail-signal"],
+        "oneShapePerRailIsEnough": false,
+        "disagreements": [
+            {
+                "rail": "straight-rail",
+                "direction": 0,
+                "reference": "gate",
+                "blockedForChestNotFor": ["-1,-1", "-1,0", "0,-1", "0,0"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "straight-rail",
+                "direction": 4,
+                "reference": "gate",
+                "blockedForChestNotFor": ["-1,-1", "-1,0", "0,-1", "0,0"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "half-diagonal-rail",
+                "direction": 0,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-2,-1", "-1,1", "0,-2", "1,0"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "half-diagonal-rail",
+                "direction": 2,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-2,0", "-1,-2", "0,1", "1,-1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "half-diagonal-rail",
+                "direction": 4,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-2,-1", "-1,1", "0,-2", "1,0"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "half-diagonal-rail",
+                "direction": 6,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-2,0", "-1,-2", "0,1", "1,-1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 0,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["-2,-1", "-1,-4"]
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 0,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-2,-2", "0,-2"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 2,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["0,-4", "1,-1"]
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 2,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-1,-2", "1,-2"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 4,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["0,-2", "3,-1"]
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 4,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["1,-2", "1,0"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 6,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["0,1", "3,0"]
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 6,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["1,-1", "1,1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 8,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["0,3", "1,0"]
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 8,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-1,1", "1,1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 10,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["-2,0", "-1,3"]
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 10,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-2,1", "0,1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 12,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["-4,0", "-1,1"]
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 12,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-2,-1", "-2,1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 14,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["-4,-1", "-1,-2"]
+            },
+            {
+                "rail": "curved-rail-a",
+                "direction": 14,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-2,-2", "-2,0"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 0,
+                "reference": "gate",
+                "blockedForChestNotFor": ["-2,0"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 0,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["1,0"]
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 0,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-2,0", "-1,1", "0,-1", "0,2"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 2,
+                "reference": "gate",
+                "blockedForChestNotFor": ["1,0"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 2,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["-2,0"]
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 2,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-1,-1", "-1,2", "0,1", "1,0"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 4,
+                "reference": "gate",
+                "blockedForChestNotFor": ["-1,-2"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 4,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["-1,1"]
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 4,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-3,0", "-2,-1", "-1,-2", "0,0"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 6,
+                "reference": "gate",
+                "blockedForChestNotFor": ["-1,1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 6,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["-1,-2"]
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 6,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-3,-1", "-2,0", "-1,1", "0,-1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 8,
+                "reference": "gate",
+                "blockedForChestNotFor": ["1,-1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 8,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["-2,-1"]
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 8,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-1,-3", "-1,0", "0,-2", "1,-1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 10,
+                "reference": "gate",
+                "blockedForChestNotFor": ["-2,-1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 10,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["1,-1"]
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 10,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-2,-1", "-1,-2", "0,-3", "0,0"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 12,
+                "reference": "gate",
+                "blockedForChestNotFor": ["0,1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 12,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["0,-2"]
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 12,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-1,-1", "0,1", "1,0", "2,-1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 14,
+                "reference": "gate",
+                "blockedForChestNotFor": ["0,-2"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 14,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["0,1"]
+            },
+            {
+                "rail": "curved-rail-b",
+                "direction": 14,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-1,0", "0,-2", "1,-1", "2,0"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "legacy-straight-rail",
+                "direction": 0,
+                "reference": "gate",
+                "blockedForChestNotFor": ["-1,-1", "-1,0", "0,-1", "0,0"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "legacy-straight-rail",
+                "direction": 4,
+                "reference": "gate",
+                "blockedForChestNotFor": ["-1,-1", "-1,0", "0,-1", "0,0"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 0,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["0,-2"]
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 0,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-2,-4", "-2,-1", "-1,-3"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 2,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["-1,-2"]
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 2,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["0,-3", "1,-4", "1,-1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 4,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["1,0"]
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 4,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["0,-2", "2,-1", "3,-2"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 6,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["1,-1"]
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 6,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["0,1", "2,0", "3,1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 8,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["-1,1"]
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 8,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["0,2", "1,0", "1,3"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 10,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["0,1"]
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 10,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-2,0", "-2,3", "-1,2"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 12,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["-2,-1"]
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 12,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-4,1", "-3,0", "-1,1"],
+                "blockedForRefNotForChest": []
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 14,
+                "reference": "transport-belt",
+                "blockedForChestNotFor": [],
+                "blockedForRefNotForChest": ["-2,0"]
+            },
+            {
+                "rail": "legacy-curved-rail",
+                "direction": 14,
+                "reference": "small-electric-pole",
+                "blockedForChestNotFor": ["-4,-2", "-3,-1", "-1,-2"],
+                "blockedForRefNotForChest": []
+            }
+        ]
+    },
+    "footprints": [
+        {
+            "rail": "straight-rail",
+            "direction": 0,
+            "gameTiles": "2x2",
+            "editorTiles": "2x2",
+            "blockedCells": 4,
+            "editorCells": 4,
+            "occupiedButNotKeyed": [],
+            "keyedButEmpty": []
+        },
+        {
+            "rail": "straight-rail",
+            "direction": 2,
+            "gameTiles": "2x2",
+            "editorTiles": "2x2",
+            "blockedCells": 8,
+            "editorCells": 4,
+            "occupiedButNotKeyed": ["-2,0", "-1,1", "0,-2", "1,-1"],
+            "keyedButEmpty": []
+        },
+        {
+            "rail": "straight-rail",
+            "direction": 4,
+            "gameTiles": "2x2",
+            "editorTiles": "2x2",
+            "blockedCells": 4,
+            "editorCells": 4,
+            "occupiedButNotKeyed": [],
+            "keyedButEmpty": []
+        },
+        {
+            "rail": "straight-rail",
+            "direction": 6,
+            "gameTiles": "2x2",
+            "editorTiles": "2x2",
+            "blockedCells": 8,
+            "editorCells": 4,
+            "occupiedButNotKeyed": ["-2,-1", "-1,-2", "0,1", "1,0"],
+            "keyedButEmpty": []
+        },
+        {
+            "rail": "half-diagonal-rail",
+            "direction": 0,
+            "gameTiles": "2x2",
+            "editorTiles": "2x2",
+            "blockedCells": 12,
+            "editorCells": 4,
+            "occupiedButNotKeyed": ["-2,-2", "-2,-1", "-1,-2", "-1,1", "0,-2", "0,1", "1,0", "1,1"],
+            "keyedButEmpty": []
+        },
+        {
+            "rail": "half-diagonal-rail",
+            "direction": 2,
+            "gameTiles": "2x2",
+            "editorTiles": "2x2",
+            "blockedCells": 12,
+            "editorCells": 4,
+            "occupiedButNotKeyed": ["-2,0", "-2,1", "-1,-2", "-1,1", "0,-2", "0,1", "1,-2", "1,-1"],
+            "keyedButEmpty": []
+        },
+        {
+            "rail": "half-diagonal-rail",
+            "direction": 4,
+            "gameTiles": "2x2",
+            "editorTiles": "2x2",
+            "blockedCells": 12,
+            "editorCells": 4,
+            "occupiedButNotKeyed": ["-2,-1", "-2,0", "-2,1", "-1,1", "0,-2", "1,-2", "1,-1", "1,0"],
+            "keyedButEmpty": []
+        },
+        {
+            "rail": "half-diagonal-rail",
+            "direction": 6,
+            "gameTiles": "2x2",
+            "editorTiles": "2x2",
+            "blockedCells": 12,
+            "editorCells": 4,
+            "occupiedButNotKeyed": ["-2,-2", "-2,-1", "-2,0", "-1,-2", "0,1", "1,-1", "1,0", "1,1"],
+            "keyedButEmpty": []
+        },
+        {
+            "rail": "curved-rail-a",
+            "direction": 0,
+            "gameTiles": "2x4",
+            "editorTiles": "2x6",
+            "blockedCells": 11,
+            "editorCells": 12,
+            "occupiedButNotKeyed": ["-2,-3", "-2,-2"],
+            "keyedButEmpty": ["-1,2", "0,-3", "0,2"]
+        },
+        {
+            "rail": "curved-rail-a",
+            "direction": 2,
+            "gameTiles": "2x4",
+            "editorTiles": "2x6",
+            "blockedCells": 11,
+            "editorCells": 12,
+            "occupiedButNotKeyed": ["1,-3", "1,-2"],
+            "keyedButEmpty": ["-1,-3", "-1,2", "0,2"]
+        },
+        {
+            "rail": "curved-rail-a",
+            "direction": 4,
+            "gameTiles": "2x4",
+            "editorTiles": "6x2",
+            "blockedCells": 11,
+            "editorCells": 12,
+            "occupiedButNotKeyed": ["1,-2", "2,-2"],
+            "keyedButEmpty": ["-3,-1", "-3,0", "2,0"]
+        },
+        {
+            "rail": "curved-rail-a",
+            "direction": 6,
+            "gameTiles": "2x4",
+            "editorTiles": "6x2",
+            "blockedCells": 11,
+            "editorCells": 12,
+            "occupiedButNotKeyed": ["1,1", "2,1"],
+            "keyedButEmpty": ["-3,-1", "-3,0", "2,-1"]
+        },
+        {
+            "rail": "curved-rail-a",
+            "direction": 8,
+            "gameTiles": "2x4",
+            "editorTiles": "2x6",
+            "blockedCells": 11,
+            "editorCells": 12,
+            "occupiedButNotKeyed": ["1,1", "1,2"],
+            "keyedButEmpty": ["-1,-3", "-1,2", "0,-3"]
+        },
+        {
+            "rail": "curved-rail-a",
+            "direction": 10,
+            "gameTiles": "2x4",
+            "editorTiles": "2x6",
+            "blockedCells": 11,
+            "editorCells": 12,
+            "occupiedButNotKeyed": ["-2,1", "-2,2"],
+            "keyedButEmpty": ["-1,-3", "0,-3", "0,2"]
+        },
+        {
+            "rail": "curved-rail-a",
+            "direction": 12,
+            "gameTiles": "2x4",
+            "editorTiles": "6x2",
+            "blockedCells": 11,
+            "editorCells": 12,
+            "occupiedButNotKeyed": ["-3,1", "-2,1"],
+            "keyedButEmpty": ["-3,-1", "2,-1", "2,0"]
+        },
+        {
+            "rail": "curved-rail-a",
+            "direction": 14,
+            "gameTiles": "2x4",
+            "editorTiles": "6x2",
+            "blockedCells": 11,
+            "editorCells": 12,
+            "occupiedButNotKeyed": ["-3,-2", "-2,-2"],
+            "keyedButEmpty": ["-3,0", "2,-1", "2,0"]
+        },
+        {
+            "rail": "curved-rail-b",
+            "direction": 0,
+            "gameTiles": "2x2",
+            "editorTiles": "2x5",
+            "blockedCells": 14,
+            "editorCells": 10,
+            "occupiedButNotKeyed": ["-3,-2", "-2,-3", "-2,-2", "-2,-1", "-2,0", "1,1"],
+            "keyedButEmpty": ["-1,2", "0,-2"]
+        },
+        {
+            "rail": "curved-rail-b",
+            "direction": 2,
+            "gameTiles": "2x2",
+            "editorTiles": "2x5",
+            "blockedCells": 14,
+            "editorCells": 10,
+            "occupiedButNotKeyed": ["-2,1", "1,-3", "1,-2", "1,-1", "1,0", "2,-2"],
+            "keyedButEmpty": ["-1,-2", "0,2"]
+        },
+        {
+            "rail": "curved-rail-b",
+            "direction": 4,
+            "gameTiles": "2x2",
+            "editorTiles": "5x2",
+            "blockedCells": 14,
+            "editorCells": 10,
+            "occupiedButNotKeyed": ["-3,0", "-2,1", "-1,-2", "0,-2", "1,-3", "1,-2", "2,-2"],
+            "keyedButEmpty": ["1,0", "2,-1", "2,0"]
+        },
+        {
+            "rail": "curved-rail-b",
+            "direction": 6,
+            "gameTiles": "2x2",
+            "editorTiles": "5x2",
+            "blockedCells": 14,
+            "editorCells": 10,
+            "occupiedButNotKeyed": ["-3,-1", "-2,-2", "-1,1", "0,1", "1,1", "1,2", "2,1"],
+            "keyedButEmpty": ["1,-1", "2,-1", "2,0"]
+        },
+        {
+            "rail": "curved-rail-b",
+            "direction": 8,
+            "gameTiles": "2x2",
+            "editorTiles": "2x5",
+            "blockedCells": 14,
+            "editorCells": 10,
+            "occupiedButNotKeyed": ["-2,-2", "-1,-3", "1,-1", "1,0", "1,1", "1,2", "2,1"],
+            "keyedButEmpty": ["-1,1", "-1,2", "0,2"]
+        },
+        {
+            "rail": "curved-rail-b",
+            "direction": 10,
+            "gameTiles": "2x2",
+            "editorTiles": "2x5",
+            "blockedCells": 14,
+            "editorCells": 10,
+            "occupiedButNotKeyed": ["-3,1", "-2,-1", "-2,0", "-2,1", "-2,2", "0,-3", "1,-2"],
+            "keyedButEmpty": ["-1,2", "0,1", "0,2"]
+        },
+        {
+            "rail": "curved-rail-b",
+            "direction": 12,
+            "gameTiles": "2x2",
+            "editorTiles": "5x2",
+            "blockedCells": 14,
+            "editorCells": 10,
+            "occupiedButNotKeyed": ["-3,1", "-2,1", "-2,2", "-1,1", "0,1", "1,-2"],
+            "keyedButEmpty": ["-2,-1", "2,0"]
+        },
+        {
+            "rail": "curved-rail-b",
+            "direction": 14,
+            "gameTiles": "2x2",
+            "editorTiles": "5x2",
+            "blockedCells": 14,
+            "editorCells": 10,
+            "occupiedButNotKeyed": ["-3,-2", "-2,-3", "-2,-2", "-1,-2", "0,-2", "1,1"],
+            "keyedButEmpty": ["-2,0", "2,-1"]
+        },
+        {
+            "rail": "legacy-straight-rail",
+            "direction": 0,
+            "gameTiles": "2x2",
+            "editorTiles": "2x2",
+            "blockedCells": 4,
+            "editorCells": 4,
+            "occupiedButNotKeyed": [],
+            "keyedButEmpty": []
+        },
+        {
+            "rail": "legacy-straight-rail",
+            "direction": 2,
+            "gameTiles": "2x2",
+            "editorTiles": "2x2",
+            "blockedCells": 5,
+            "editorCells": 4,
+            "occupiedButNotKeyed": ["0,-2", "1,-1"],
+            "keyedButEmpty": ["-1,0"]
+        },
+        {
+            "rail": "legacy-straight-rail",
+            "direction": 4,
+            "gameTiles": "2x2",
+            "editorTiles": "2x2",
+            "blockedCells": 4,
+            "editorCells": 4,
+            "occupiedButNotKeyed": [],
+            "keyedButEmpty": []
+        },
+        {
+            "rail": "legacy-straight-rail",
+            "direction": 6,
+            "gameTiles": "2x2",
+            "editorTiles": "2x2",
+            "blockedCells": 5,
+            "editorCells": 4,
+            "occupiedButNotKeyed": ["0,1", "1,0"],
+            "keyedButEmpty": ["-1,-1"]
+        },
+        {
+            "rail": "legacy-straight-rail",
+            "direction": 10,
+            "gameTiles": "2x2",
+            "editorTiles": "2x2",
+            "blockedCells": 5,
+            "editorCells": 4,
+            "occupiedButNotKeyed": ["-2,0", "-1,1"],
+            "keyedButEmpty": ["0,-1"]
+        },
+        {
+            "rail": "legacy-straight-rail",
+            "direction": 14,
+            "gameTiles": "2x2",
+            "editorTiles": "2x2",
+            "blockedCells": 5,
+            "editorCells": 4,
+            "occupiedButNotKeyed": ["-2,-1", "-1,-2"],
+            "keyedButEmpty": ["0,0"]
+        },
+        {
+            "rail": "legacy-curved-rail",
+            "direction": 0,
+            "gameTiles": "4x8",
+            "editorTiles": "4x4",
+            "blockedCells": 18,
+            "editorCells": 16,
+            "occupiedButNotKeyed": ["-3,-3", "-2,-4", "-2,-3", "-1,-3", "0,2", "0,3", "1,2", "1,3"],
+            "keyedButEmpty": ["-2,0", "-2,1", "-1,1", "0,-2", "1,-2", "1,-1"]
+        },
+        {
+            "rail": "legacy-curved-rail",
+            "direction": 2,
+            "gameTiles": "4x8",
+            "editorTiles": "4x4",
+            "blockedCells": 18,
+            "editorCells": 16,
+            "occupiedButNotKeyed": ["-2,2", "-2,3", "-1,2", "-1,3", "0,-3", "1,-4", "1,-3", "2,-3"],
+            "keyedButEmpty": ["-2,-2", "-2,-1", "-1,-2", "0,1", "1,0", "1,1"]
+        },
+        {
+            "rail": "legacy-curved-rail",
+            "direction": 4,
+            "gameTiles": "4x8",
+            "editorTiles": "4x4",
+            "blockedCells": 18,
+            "editorCells": 16,
+            "occupiedButNotKeyed": ["-4,0", "-4,1", "-3,0", "-3,1", "2,-3", "2,-2", "2,-1", "3,-2"],
+            "keyedButEmpty": ["-2,-2", "-2,-1", "-1,-2", "0,1", "1,0", "1,1"]
+        },
+        {
+            "rail": "legacy-curved-rail",
+            "direction": 6,
+            "gameTiles": "4x8",
+            "editorTiles": "4x4",
+            "blockedCells": 18,
+            "editorCells": 16,
+            "occupiedButNotKeyed": ["-4,-2", "-4,-1", "-3,-2", "-3,-1", "2,0", "2,1", "2,2", "3,1"],
+            "keyedButEmpty": ["-2,0", "-2,1", "-1,1", "0,-2", "1,-2", "1,-1"]
+        },
+        {
+            "rail": "legacy-curved-rail",
+            "direction": 8,
+            "gameTiles": "4x8",
+            "editorTiles": "4x4",
+            "blockedCells": 18,
+            "editorCells": 16,
+            "occupiedButNotKeyed": ["-2,-4", "-2,-3", "-1,-4", "-1,-3", "0,2", "1,2", "1,3", "2,2"],
+            "keyedButEmpty": ["-2,0", "-2,1", "-1,1", "0,-2", "1,-2", "1,-1"]
+        },
+        {
+            "rail": "legacy-curved-rail",
+            "direction": 10,
+            "gameTiles": "4x8",
+            "editorTiles": "4x4",
+            "blockedCells": 18,
+            "editorCells": 16,
+            "occupiedButNotKeyed": ["-3,2", "-2,2", "-2,3", "-1,2", "0,-4", "0,-3", "1,-4", "1,-3"],
+            "keyedButEmpty": ["-2,-2", "-2,-1", "-1,-2", "0,1", "1,0", "1,1"]
+        },
+        {
+            "rail": "legacy-curved-rail",
+            "direction": 12,
+            "gameTiles": "4x8",
+            "editorTiles": "4x4",
+            "blockedCells": 18,
+            "editorCells": 16,
+            "occupiedButNotKeyed": ["-4,1", "-3,0", "-3,1", "-3,2", "2,-2", "2,-1", "3,-2", "3,-1"],
+            "keyedButEmpty": ["-2,-2", "-2,-1", "-1,-2", "0,1", "1,0", "1,1"]
+        },
+        {
+            "rail": "legacy-curved-rail",
+            "direction": 14,
+            "gameTiles": "4x8",
+            "editorTiles": "4x4",
+            "blockedCells": 18,
+            "editorCells": 16,
+            "occupiedButNotKeyed": ["-4,-2", "-3,-3", "-3,-2", "-3,-1", "2,0", "2,1", "3,0", "3,1"],
+            "keyedButEmpty": ["-2,0", "-2,1", "-1,1", "0,-2", "1,-2", "1,-1"]
+        }
+    ],
+    "rails": [
+        {
+            "name": "straight-rail",
+            "direction": 0,
+            "asked_direction": 0,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -0.98828125],
+                [0.69921875, 0.98828125]
+            ],
+            "bounding_box": [
+                [-0.69921875, -0.98828125],
+                [0.69921875, 0.98828125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 117
+                },
+                {
+                    "reference": "gate",
+                    "blocked": {},
+                    "free_count": 121
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 117
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 117
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "straight-rail",
+            "direction": 2,
+            "asked_direction": 2,
+            "position": {
+                "x": -4,
+                "y": -4
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -0.98828125],
+                [0.69921875, 0.98828125]
+            ],
+            "bounding_box": [
+                [-0.69921875, -1.34765625],
+                [0.69921875, 1.34765625]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 113
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 113
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 113
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 113
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "straight-rail",
+            "direction": 4,
+            "asked_direction": 4,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -0.98828125],
+                [0.69921875, 0.98828125]
+            ],
+            "bounding_box": [
+                [-0.69921875, -0.98828125],
+                [0.69921875, 0.98828125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 117
+                },
+                {
+                    "reference": "gate",
+                    "blocked": {},
+                    "free_count": 121
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 117
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 117
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "straight-rail",
+            "direction": 6,
+            "asked_direction": 6,
+            "position": {
+                "x": -4,
+                "y": -4
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -0.98828125],
+                [0.69921875, 0.98828125]
+            ],
+            "bounding_box": [
+                [-0.69921875, -1.34765625],
+                [0.69921875, 1.34765625]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 113
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 113
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 113
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 113
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "half-diagonal-rail",
+            "direction": 0,
+            "asked_direction": 0,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.75, -1.8984375],
+                [0.75, 1.8984375]
+            ],
+            "bounding_box": [
+                [-0.75, -1.8984375],
+                [0.75, 1.8984375]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 109
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 109
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 109
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 113
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "half-diagonal-rail",
+            "direction": 2,
+            "asked_direction": 2,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.75, -1.8984375],
+                [0.75, 1.8984375]
+            ],
+            "bounding_box": [
+                [-0.75, -1.8984375],
+                [0.75, 1.8984375]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 109
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 109
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 109
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 113
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "half-diagonal-rail",
+            "direction": 4,
+            "asked_direction": 4,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.75, -1.8984375],
+                [0.75, 1.8984375]
+            ],
+            "bounding_box": [
+                [-0.75, -1.8984375],
+                [0.75, 1.8984375]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 109
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 109
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 109
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 113
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "half-diagonal-rail",
+            "direction": 6,
+            "asked_direction": 6,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.75, -1.8984375],
+                [0.75, 1.8984375]
+            ],
+            "bounding_box": [
+                [-0.75, -1.8984375],
+                [0.75, 1.8984375]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 109
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 109
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 109
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 113
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-a",
+            "direction": 0,
+            "asked_direction": 0,
+            "position": {
+                "x": -3,
+                "y": -4
+            },
+            "tile_width": 2,
+            "tile_height": 4,
+            "collision_box": [
+                [-0.69921875, -2.515625],
+                [0.69921875, 2.515625]
+            ],
+            "bounding_box": [
+                [-1.046875, -3.04296875],
+                [0.3515625, 1.98828125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 112
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-a",
+            "direction": 2,
+            "asked_direction": 2,
+            "position": {
+                "x": -3,
+                "y": -4
+            },
+            "tile_width": 2,
+            "tile_height": 4,
+            "collision_box": [
+                [-0.69921875, -2.515625],
+                [0.69921875, 2.515625]
+            ],
+            "bounding_box": [
+                [-0.3515625, -3.04296875],
+                [1.046875, 1.98828125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        }
+                    ],
+                    "free_count": 112
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-a",
+            "direction": 4,
+            "asked_direction": 4,
+            "position": {
+                "x": -4,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 4,
+            "collision_box": [
+                [-0.69921875, -2.515625],
+                [0.69921875, 2.515625]
+            ],
+            "bounding_box": [
+                [-0.171875, -2.86328125],
+                [1.2265625, 2.16796875]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 112
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-a",
+            "direction": 6,
+            "asked_direction": 6,
+            "position": {
+                "x": -4,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 4,
+            "collision_box": [
+                [-0.69921875, -2.515625],
+                [0.69921875, 2.515625]
+            ],
+            "bounding_box": [
+                [-0.171875, -2.16796875],
+                [1.2265625, 2.86328125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 112
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-a",
+            "direction": 8,
+            "asked_direction": 8,
+            "position": {
+                "x": -3,
+                "y": -4
+            },
+            "tile_width": 2,
+            "tile_height": 4,
+            "collision_box": [
+                [-0.69921875, -2.515625],
+                [0.69921875, 2.515625]
+            ],
+            "bounding_box": [
+                [-0.3515625, -1.98828125],
+                [1.046875, 3.04296875]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        }
+                    ],
+                    "free_count": 112
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-a",
+            "direction": 10,
+            "asked_direction": 10,
+            "position": {
+                "x": -3,
+                "y": -4
+            },
+            "tile_width": 2,
+            "tile_height": 4,
+            "collision_box": [
+                [-0.69921875, -2.515625],
+                [0.69921875, 2.515625]
+            ],
+            "bounding_box": [
+                [-1.046875, -1.98828125],
+                [0.3515625, 3.04296875]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 112
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-a",
+            "direction": 12,
+            "asked_direction": 12,
+            "position": {
+                "x": -4,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 4,
+            "collision_box": [
+                [-0.69921875, -2.515625],
+                [0.69921875, 2.515625]
+            ],
+            "bounding_box": [
+                [-1.2265625, -2.16796875],
+                [0.171875, 2.86328125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 112
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-a",
+            "direction": 14,
+            "asked_direction": 14,
+            "position": {
+                "x": -4,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 4,
+            "collision_box": [
+                [-0.69921875, -2.515625],
+                [0.69921875, 2.515625]
+            ],
+            "bounding_box": [
+                [-1.2265625, -2.86328125],
+                [0.171875, 2.16796875]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 110
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 112
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-b",
+            "direction": 0,
+            "asked_direction": 0,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -2.4375],
+                [0.69921875, 2.4375]
+            ],
+            "bounding_box": [
+                [-1.14453125, -2.50390625],
+                [0.25390625, 2.37109375]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 107
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 111
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 5
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-b",
+            "direction": 2,
+            "asked_direction": 2,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -2.4375],
+                [0.69921875, 2.4375]
+            ],
+            "bounding_box": [
+                [-0.25390625, -2.50390625],
+                [1.14453125, 2.37109375]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 107
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 111
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 5
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-b",
+            "direction": 4,
+            "asked_direction": 4,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -2.4375],
+                [0.69921875, 2.4375]
+            ],
+            "bounding_box": [
+                [-0.6328125, -2.8828125],
+                [0.765625, 1.9921875]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 107
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 111
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 5
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-b",
+            "direction": 6,
+            "asked_direction": 6,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -2.4375],
+                [0.69921875, 2.4375]
+            ],
+            "bounding_box": [
+                [-0.6328125, -1.9921875],
+                [0.765625, 2.8828125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 107
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 111
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 5
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-b",
+            "direction": 8,
+            "asked_direction": 8,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -2.4375],
+                [0.69921875, 2.4375]
+            ],
+            "bounding_box": [
+                [-0.25390625, -2.37109375],
+                [1.14453125, 2.50390625]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 107
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 111
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 5
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-b",
+            "direction": 10,
+            "asked_direction": 10,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -2.4375],
+                [0.69921875, 2.4375]
+            ],
+            "bounding_box": [
+                [-1.14453125, -2.37109375],
+                [0.25390625, 2.50390625]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 107
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 111
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 5
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-b",
+            "direction": 12,
+            "asked_direction": 12,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -2.4375],
+                [0.69921875, 2.4375]
+            ],
+            "bounding_box": [
+                [-0.765625, -1.9921875],
+                [0.6328125, 2.8828125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 107
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 111
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 5
+                }
+            ]
+        },
+        {
+            "name": "curved-rail-b",
+            "direction": 14,
+            "asked_direction": 14,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -2.4375],
+                [0.69921875, 2.4375]
+            ],
+            "bounding_box": [
+                [-0.765625, -2.8828125],
+                [0.6328125, 1.9921875]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 107
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 108
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 111
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 5
+                }
+            ]
+        },
+        {
+            "name": "legacy-straight-rail",
+            "direction": 0,
+            "asked_direction": 0,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -0.98828125],
+                [0.69921875, 0.98828125]
+            ],
+            "bounding_box": [
+                [-0.69921875, -0.98828125],
+                [0.69921875, 0.98828125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 117
+                },
+                {
+                    "reference": "gate",
+                    "blocked": {},
+                    "free_count": 121
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 117
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 117
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "legacy-straight-rail",
+            "direction": 2,
+            "asked_direction": 2,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -0.98828125],
+                [0.69921875, 0.98828125]
+            ],
+            "bounding_box": [
+                [-0.203125, -1.1484375],
+                [1.1953125, 0.15234375]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 2
+                }
+            ]
+        },
+        {
+            "name": "legacy-straight-rail",
+            "direction": 4,
+            "asked_direction": 4,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -0.98828125],
+                [0.69921875, 0.98828125]
+            ],
+            "bounding_box": [
+                [-0.98828125, -0.69921875],
+                [0.98828125, 0.69921875]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 117
+                },
+                {
+                    "reference": "gate",
+                    "blocked": {},
+                    "free_count": 121
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 117
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 117
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ]
+        },
+        {
+            "name": "legacy-straight-rail",
+            "direction": 6,
+            "asked_direction": 6,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -0.98828125],
+                [0.69921875, 0.98828125]
+            ],
+            "bounding_box": [
+                [-0.203125, -0.15625],
+                [1.1953125, 1.14453125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 2
+                }
+            ]
+        },
+        {
+            "name": "legacy-straight-rail",
+            "direction": 10,
+            "asked_direction": 10,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -0.98828125],
+                [0.69921875, 0.98828125]
+            ],
+            "bounding_box": [
+                [-1.1953125, -0.15625],
+                [0.203125, 1.14453125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 2
+                }
+            ]
+        },
+        {
+            "name": "legacy-straight-rail",
+            "direction": 14,
+            "asked_direction": 14,
+            "position": {
+                "x": -3,
+                "y": -3
+            },
+            "tile_width": 2,
+            "tile_height": 2,
+            "collision_box": [
+                [-0.69921875, -0.98828125],
+                [0.69921875, 0.98828125]
+            ],
+            "bounding_box": [
+                [-1.1953125, -1.1484375],
+                [0.203125, 0.15234375]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 116
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 2
+                }
+            ]
+        },
+        {
+            "name": "legacy-curved-rail",
+            "direction": 0,
+            "asked_direction": 0,
+            "position": {
+                "x": -4,
+                "y": -4
+            },
+            "tile_width": 4,
+            "tile_height": 8,
+            "collision_box": [
+                [-0.75, -0.546875],
+                [0.75, 1.59765625]
+            ],
+            "bounding_box": [
+                [0.24609375, 1.73828125],
+                [1.74609375, 3.8828125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        }
+                    ],
+                    "free_count": 102
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ],
+            "secondary_bounding_box": [
+                [-1.0390625, -3.3984375],
+                [0.3203125, 2]
+            ]
+        },
+        {
+            "name": "legacy-curved-rail",
+            "direction": 2,
+            "asked_direction": 2,
+            "position": {
+                "x": -4,
+                "y": -4
+            },
+            "tile_width": 4,
+            "tile_height": 8,
+            "collision_box": [
+                [-0.75, -0.546875],
+                [0.75, 1.59765625]
+            ],
+            "bounding_box": [
+                [-1.74609375, 1.73828125],
+                [-0.24609375, 3.8828125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        }
+                    ],
+                    "free_count": 102
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ],
+            "secondary_bounding_box": [
+                [-0.3203125, -3.3984375],
+                [1.0390625, 2]
+            ]
+        },
+        {
+            "name": "legacy-curved-rail",
+            "direction": 4,
+            "asked_direction": 4,
+            "position": {
+                "x": -4,
+                "y": -4
+            },
+            "tile_width": 4,
+            "tile_height": 8,
+            "collision_box": [
+                [-0.75, -0.546875],
+                [0.75, 1.59765625]
+            ],
+            "bounding_box": [
+                [-3.8828125, 0.24609375],
+                [-1.73828125, 1.74609375]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 102
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ],
+            "secondary_bounding_box": [
+                [0.01953125, -3.05859375],
+                [1.37890625, 2.33984375]
+            ]
+        },
+        {
+            "name": "legacy-curved-rail",
+            "direction": 6,
+            "asked_direction": 6,
+            "position": {
+                "x": -4,
+                "y": -4
+            },
+            "tile_width": 4,
+            "tile_height": 8,
+            "collision_box": [
+                [-0.75, -0.546875],
+                [0.75, 1.59765625]
+            ],
+            "bounding_box": [
+                [-3.8828125, -1.74609375],
+                [-1.73828125, -0.24609375]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 102
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ],
+            "secondary_bounding_box": [
+                [0.01953125, -2.33984375],
+                [1.37890625, 3.05859375]
+            ]
+        },
+        {
+            "name": "legacy-curved-rail",
+            "direction": 8,
+            "asked_direction": 8,
+            "position": {
+                "x": -4,
+                "y": -4
+            },
+            "tile_width": 4,
+            "tile_height": 8,
+            "collision_box": [
+                [-0.75, -0.546875],
+                [0.75, 1.59765625]
+            ],
+            "bounding_box": [
+                [-1.74609375, -3.8828125],
+                [-0.24609375, -1.73828125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        }
+                    ],
+                    "free_count": 102
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ],
+            "secondary_bounding_box": [
+                [-0.3203125, -2],
+                [1.0390625, 3.3984375]
+            ]
+        },
+        {
+            "name": "legacy-curved-rail",
+            "direction": 10,
+            "asked_direction": 10,
+            "position": {
+                "x": -4,
+                "y": -4
+            },
+            "tile_width": 4,
+            "tile_height": 8,
+            "collision_box": [
+                [-0.75, -0.546875],
+                [0.75, 1.59765625]
+            ],
+            "bounding_box": [
+                [0.24609375, -3.8828125],
+                [1.74609375, -1.73828125]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 102
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ],
+            "secondary_bounding_box": [
+                [-1.0390625, -2],
+                [0.3203125, 3.3984375]
+            ]
+        },
+        {
+            "name": "legacy-curved-rail",
+            "direction": 12,
+            "asked_direction": 12,
+            "position": {
+                "x": -4,
+                "y": -4
+            },
+            "tile_width": 4,
+            "tile_height": 8,
+            "collision_box": [
+                [-0.75, -0.546875],
+                [0.75, 1.59765625]
+            ],
+            "bounding_box": [
+                [1.73828125, -1.74609375],
+                [3.8828125, -0.24609375]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 102
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": -1
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -3
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": -1
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 2
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ],
+            "secondary_bounding_box": [
+                [-1.37890625, -2.33984375],
+                [-0.01953125, 3.05859375]
+            ]
+        },
+        {
+            "name": "legacy-curved-rail",
+            "direction": 14,
+            "asked_direction": 14,
+            "position": {
+                "x": -4,
+                "y": -4
+            },
+            "tile_width": 4,
+            "tile_height": 8,
+            "collision_box": [
+                [-0.75, -0.546875],
+                [0.75, 1.59765625]
+            ],
+            "bounding_box": [
+                [1.73828125, 0.24609375],
+                [3.8828125, 1.74609375]
+            ],
+            "references": [
+                {
+                    "reference": "wooden-chest",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "gate",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 103
+                },
+                {
+                    "reference": "transport-belt",
+                    "blocked": [
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 102
+                },
+                {
+                    "reference": "small-electric-pole",
+                    "blocked": [
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        }
+                    ],
+                    "free_count": 106
+                },
+                {
+                    "reference": "rail-signal",
+                    "blocked": [
+                        {
+                            "x": -5,
+                            "y": -5
+                        },
+                        {
+                            "x": -5,
+                            "y": -4
+                        },
+                        {
+                            "x": -5,
+                            "y": -3
+                        },
+                        {
+                            "x": -5,
+                            "y": -2
+                        },
+                        {
+                            "x": -5,
+                            "y": -1
+                        },
+                        {
+                            "x": -5,
+                            "y": 0
+                        },
+                        {
+                            "x": -5,
+                            "y": 1
+                        },
+                        {
+                            "x": -5,
+                            "y": 2
+                        },
+                        {
+                            "x": -5,
+                            "y": 3
+                        },
+                        {
+                            "x": -5,
+                            "y": 4
+                        },
+                        {
+                            "x": -5,
+                            "y": 5
+                        },
+                        {
+                            "x": -4,
+                            "y": -5
+                        },
+                        {
+                            "x": -4,
+                            "y": -4
+                        },
+                        {
+                            "x": -4,
+                            "y": -3
+                        },
+                        {
+                            "x": -4,
+                            "y": -2
+                        },
+                        {
+                            "x": -4,
+                            "y": 0
+                        },
+                        {
+                            "x": -4,
+                            "y": 1
+                        },
+                        {
+                            "x": -4,
+                            "y": 2
+                        },
+                        {
+                            "x": -4,
+                            "y": 3
+                        },
+                        {
+                            "x": -4,
+                            "y": 4
+                        },
+                        {
+                            "x": -4,
+                            "y": 5
+                        },
+                        {
+                            "x": -3,
+                            "y": -5
+                        },
+                        {
+                            "x": -3,
+                            "y": -4
+                        },
+                        {
+                            "x": -3,
+                            "y": -3
+                        },
+                        {
+                            "x": -3,
+                            "y": -2
+                        },
+                        {
+                            "x": -3,
+                            "y": -1
+                        },
+                        {
+                            "x": -3,
+                            "y": 0
+                        },
+                        {
+                            "x": -3,
+                            "y": 1
+                        },
+                        {
+                            "x": -3,
+                            "y": 2
+                        },
+                        {
+                            "x": -3,
+                            "y": 3
+                        },
+                        {
+                            "x": -3,
+                            "y": 4
+                        },
+                        {
+                            "x": -3,
+                            "y": 5
+                        },
+                        {
+                            "x": -2,
+                            "y": -5
+                        },
+                        {
+                            "x": -2,
+                            "y": -4
+                        },
+                        {
+                            "x": -2,
+                            "y": -2
+                        },
+                        {
+                            "x": -2,
+                            "y": -1
+                        },
+                        {
+                            "x": -2,
+                            "y": 0
+                        },
+                        {
+                            "x": -2,
+                            "y": 1
+                        },
+                        {
+                            "x": -2,
+                            "y": 2
+                        },
+                        {
+                            "x": -2,
+                            "y": 3
+                        },
+                        {
+                            "x": -2,
+                            "y": 4
+                        },
+                        {
+                            "x": -2,
+                            "y": 5
+                        },
+                        {
+                            "x": -1,
+                            "y": -5
+                        },
+                        {
+                            "x": -1,
+                            "y": -4
+                        },
+                        {
+                            "x": -1,
+                            "y": -3
+                        },
+                        {
+                            "x": -1,
+                            "y": -2
+                        },
+                        {
+                            "x": -1,
+                            "y": -1
+                        },
+                        {
+                            "x": -1,
+                            "y": 0
+                        },
+                        {
+                            "x": -1,
+                            "y": 1
+                        },
+                        {
+                            "x": -1,
+                            "y": 2
+                        },
+                        {
+                            "x": -1,
+                            "y": 3
+                        },
+                        {
+                            "x": -1,
+                            "y": 4
+                        },
+                        {
+                            "x": -1,
+                            "y": 5
+                        },
+                        {
+                            "x": 0,
+                            "y": -5
+                        },
+                        {
+                            "x": 0,
+                            "y": -4
+                        },
+                        {
+                            "x": 0,
+                            "y": -3
+                        },
+                        {
+                            "x": 0,
+                            "y": -2
+                        },
+                        {
+                            "x": 0,
+                            "y": -1
+                        },
+                        {
+                            "x": 0,
+                            "y": 0
+                        },
+                        {
+                            "x": 0,
+                            "y": 1
+                        },
+                        {
+                            "x": 0,
+                            "y": 2
+                        },
+                        {
+                            "x": 0,
+                            "y": 3
+                        },
+                        {
+                            "x": 0,
+                            "y": 4
+                        },
+                        {
+                            "x": 0,
+                            "y": 5
+                        },
+                        {
+                            "x": 1,
+                            "y": -5
+                        },
+                        {
+                            "x": 1,
+                            "y": -4
+                        },
+                        {
+                            "x": 1,
+                            "y": -3
+                        },
+                        {
+                            "x": 1,
+                            "y": -2
+                        },
+                        {
+                            "x": 1,
+                            "y": -1
+                        },
+                        {
+                            "x": 1,
+                            "y": 0
+                        },
+                        {
+                            "x": 1,
+                            "y": 1
+                        },
+                        {
+                            "x": 1,
+                            "y": 2
+                        },
+                        {
+                            "x": 1,
+                            "y": 3
+                        },
+                        {
+                            "x": 1,
+                            "y": 4
+                        },
+                        {
+                            "x": 1,
+                            "y": 5
+                        },
+                        {
+                            "x": 2,
+                            "y": -5
+                        },
+                        {
+                            "x": 2,
+                            "y": -4
+                        },
+                        {
+                            "x": 2,
+                            "y": -3
+                        },
+                        {
+                            "x": 2,
+                            "y": -2
+                        },
+                        {
+                            "x": 2,
+                            "y": -1
+                        },
+                        {
+                            "x": 2,
+                            "y": 0
+                        },
+                        {
+                            "x": 2,
+                            "y": 1
+                        },
+                        {
+                            "x": 2,
+                            "y": 2
+                        },
+                        {
+                            "x": 2,
+                            "y": 3
+                        },
+                        {
+                            "x": 2,
+                            "y": 4
+                        },
+                        {
+                            "x": 2,
+                            "y": 5
+                        },
+                        {
+                            "x": 3,
+                            "y": -5
+                        },
+                        {
+                            "x": 3,
+                            "y": -4
+                        },
+                        {
+                            "x": 3,
+                            "y": -3
+                        },
+                        {
+                            "x": 3,
+                            "y": -2
+                        },
+                        {
+                            "x": 3,
+                            "y": 0
+                        },
+                        {
+                            "x": 3,
+                            "y": 1
+                        },
+                        {
+                            "x": 3,
+                            "y": 3
+                        },
+                        {
+                            "x": 3,
+                            "y": 4
+                        },
+                        {
+                            "x": 3,
+                            "y": 5
+                        },
+                        {
+                            "x": 4,
+                            "y": -5
+                        },
+                        {
+                            "x": 4,
+                            "y": -4
+                        },
+                        {
+                            "x": 4,
+                            "y": -3
+                        },
+                        {
+                            "x": 4,
+                            "y": -2
+                        },
+                        {
+                            "x": 4,
+                            "y": -1
+                        },
+                        {
+                            "x": 4,
+                            "y": 0
+                        },
+                        {
+                            "x": 4,
+                            "y": 1
+                        },
+                        {
+                            "x": 4,
+                            "y": 2
+                        },
+                        {
+                            "x": 4,
+                            "y": 3
+                        },
+                        {
+                            "x": 4,
+                            "y": 4
+                        },
+                        {
+                            "x": 4,
+                            "y": 5
+                        },
+                        {
+                            "x": 5,
+                            "y": -5
+                        },
+                        {
+                            "x": 5,
+                            "y": -4
+                        },
+                        {
+                            "x": 5,
+                            "y": -3
+                        },
+                        {
+                            "x": 5,
+                            "y": -2
+                        },
+                        {
+                            "x": 5,
+                            "y": -1
+                        },
+                        {
+                            "x": 5,
+                            "y": 0
+                        },
+                        {
+                            "x": 5,
+                            "y": 1
+                        },
+                        {
+                            "x": 5,
+                            "y": 2
+                        },
+                        {
+                            "x": 5,
+                            "y": 3
+                        },
+                        {
+                            "x": 5,
+                            "y": 4
+                        },
+                        {
+                            "x": 5,
+                            "y": 5
+                        }
+                    ],
+                    "free_count": 4
+                }
+            ],
+            "secondary_bounding_box": [
+                [-1.37890625, -3.05859375],
+                [-0.01953125, 2.33984375]
+            ]
+        }
+    ]
+}

--- a/tools/oracle/probe-rail-occupancy.mjs
+++ b/tools/oracle/probe-rail-occupancy.mjs
@@ -1,0 +1,498 @@
+/*
+    Issue #133, item 1 - the structural one. `PositionGrid` keys integer tiles
+    and gives a rail the rectangle `getEntitySize` computes from its bounding
+    box. The issue says that over-reports, a curved rail being a curve inside a
+    mostly empty rectangle, and asks for per-rail occupancy shapes instead.
+
+    Before writing that, two things have to be true, and neither has been
+    measured:
+
+      1. **The rectangle itself has to be right.** The editor computes it from
+         `collision_box`, which for a curved rail is an axis-aligned *bounding*
+         box. The game publishes its own `tile_width`/`tile_height`, and the
+         exporter emits those for only 3 of 155 entities, so the editor is
+         computing what it could be reading. This records both side by side.
+
+      2. **One shape per rail has to be enough.** The editor stores occupancy
+         once, per entity, without knowing what will later be asked about it. So
+         a single set of cells can only work if "is this cell blocked" has one
+         answer regardless of what is being placed. Gates and signals are known
+         to interact with rails specially, so this sweeps a chest, a gate and a
+         signal over the same cells and compares. **If they disagree, item 1 as
+         written is not implementable** - occupancy would have to be per pair,
+         which is a truth table and not a shape, and the issue needs rewriting
+         rather than working.
+
+    Occupancy is defined operationally, the way the grid would use it: a cell is
+    occupied if the game refuses a 1x1 entity centred on it while the rail
+    stands and accepts the same on empty ground. That is the same question
+    `isAreaAvailable` is asked, rather than a claim about collision boxes, and it
+    needs no guess about how Factorio composes a curve out of boxes.
+
+    Controls:
+
+      1. **Empty ground.** Every cell in the window must be free for every
+         reference entity with no rail present. A cell that is blocked anyway
+         means terrain or a leftover entity is confounding the sweep, and the
+         rail's own answer is unreadable.
+      2. **A known answer.** A cardinal `straight-rail` fills its 2x2 completely
+         - it is the one rail whose footprint nobody disputes - so the chest
+         sweep must come back with exactly those 4 cells. If the calibration
+         case is wrong, nothing else in the run is worth reading.
+      3. **The reference entity has to collide with rails at all.** A chest on
+         the rail's own centre must be refused. Otherwise a sweep of all-free
+         cells would read as "the rail occupies nothing".
+
+    Usage: node tools/oracle/probe-rail-occupancy.mjs
+           node tools/oracle/probe-rail-occupancy.mjs --write-fixture && vp check --fix
+*/
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const BIN =
+    process.env.FACTORIO_BIN ??
+    `${process.env.HOME}/Library/Application Support/Steam/steamapps/common/Factorio/factorio.app/Contents/MacOS/factorio`
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO = join(HERE, '..', '..')
+const FIXTURE = join(HERE, 'fixtures', 'rail-occupancy.json')
+const WRITE_FIXTURE = process.argv.includes('--write-fixture')
+
+const MOD = 'bp_rail_occupancy'
+const DUMP = 'rail-occupancy-dump.json'
+
+const RAILS = [
+    'straight-rail',
+    'half-diagonal-rail',
+    'curved-rail-a',
+    'curved-rail-b',
+    'legacy-straight-rail',
+    'legacy-curved-rail',
+]
+
+/**
+ * 1x1 probes. The chest is the ordinary case, the belt and the pole are there so
+ * that a chest-versus-gate split cannot be mistaken for a chest-versus-everything
+ * one, and the gate is the known special case.
+ *
+ * `rail-signal` is swept and then **excluded by its own control**, deliberately
+ * rather than by being left out: it is refused on every cell of empty ground,
+ * since a signal needs an adjacent rail to exist at all - #95 measured 0 of 2704
+ * - so it cannot distinguish "this cell is occupied" from "there is no rail
+ * next to this cell". Keeping it in the run records why no occupancy shape can
+ * ever answer for signals, which is what items 2 and 3 of #133 are for.
+ */
+const REFERENCES = ['wooden-chest', 'gate', 'transport-belt', 'small-electric-pole', 'rail-signal']
+
+const work = mkdtempSync(join(tmpdir(), 'fbe-oracle-'))
+const writeData = join(work, 'write-data')
+const modDir = join(work, 'mods')
+const modPath = join(modDir, `${MOD}_0.0.1`)
+mkdirSync(writeData, { recursive: true })
+mkdirSync(modPath, { recursive: true })
+
+writeFileSync(
+    join(modPath, 'info.json'),
+    JSON.stringify({
+        name: MOD,
+        version: '0.0.1',
+        title: 'Which tiles a rail actually occupies',
+        author: 'oracle',
+        factorio_version: '2.1',
+        dependencies: ['base'],
+    })
+)
+
+writeFileSync(
+    join(modPath, 'control.lua'),
+    `
+local out = {rails = {}, empty_ground = {}, errors = {}}
+
+local ALL_DIRS = {}
+for d = 0, 15 do ALL_DIRS[#ALL_DIRS + 1] = d end
+
+local RAILS = {${RAILS.map(r => `"${r}"`).join(', ')}}
+local REFERENCES = {${REFERENCES.map(r => `"${r}"`).join(', ')}}
+local WINDOW = 5
+
+local function clearArea(surface, cx, cy, r)
+  for _, e in pairs(surface.find_entities_filtered{area = {{cx - r, cy - r}, {cx + r, cy + r}}}) do
+    if e.valid and e.type ~= "character" then e.destroy() end
+  end
+end
+
+local function canPlace(surface, force, name, pos, dir)
+  local res = false
+  pcall(function()
+    res = surface.can_place_entity{
+      name = name, position = pos, direction = dir, force = force,
+      build_check_type = defines.build_check_type.manual,
+    }
+  end)
+  return res
+end
+
+local function findSpot(surface, force, name, dir, cx, cy, r)
+  for dx = -r, r do
+    for dy = -r, r do
+      local pos = {cx + dx, cy + dy}
+      if canPlace(surface, force, name, pos, dir) then return pos end
+    end
+  end
+  return nil
+end
+
+-- Which cells in the window refuse this 1x1, over every direction it can face.
+-- A gate and a signal are directional and legal only at some facings, so a cell
+-- counts as free if ANY direction is accepted there - the grid's question is
+-- whether the cell can be built on at all, not whether one facing works.
+local function occupancy(surface, force, refName, origin, window)
+  local blocked, free = {}, {}
+  for tx = -window, window do
+    for ty = -window, window do
+      local pos = {origin[1] + tx + 0.5, origin[2] + ty + 0.5}
+      local ok = false
+      for _, d in ipairs(ALL_DIRS) do
+        if canPlace(surface, force, refName, pos, d) then ok = true break end
+      end
+      if ok then
+        free[#free + 1] = {x = tx, y = ty}
+      else
+        blocked[#blocked + 1] = {x = tx, y = ty}
+      end
+    end
+  end
+  return {blocked = blocked, free_count = #free}
+end
+
+script.on_init(function()
+  local surface = game.surfaces[1]
+  local force = game.forces.player
+
+  surface.request_to_generate_chunks({0, 0}, 8)
+  surface.force_generate_chunk_requests()
+  local tiles = {}
+  for x = -40, 40 do
+    for y = -40, 40 do tiles[#tiles + 1] = {name = "grass-1", position = {x, y}} end
+  end
+  surface.set_tiles(tiles)
+  clearArea(surface, 0, 0, 40)
+
+  -- Control 1: the same window with nothing in it. Every cell must be free for
+  -- every reference, or the sweeps below are measuring the ground.
+  for _, ref in ipairs(REFERENCES) do
+    local res = occupancy(surface, force, ref, {0, 0}, WINDOW)
+    out.empty_ground[#out.empty_ground + 1] = {
+      reference = ref, blocked = res.blocked, free_count = res.free_count,
+    }
+  end
+
+  for _, name in ipairs(RAILS) do
+    local seen = {}
+    for _, d in ipairs(ALL_DIRS) do
+      clearArea(surface, 0, 0, 20)
+      local spot = findSpot(surface, force, name, d, 0, 0, 4)
+      if spot then
+        local created = surface.create_entity{
+          name = name, position = spot, direction = d, force = force,
+        }
+        if created and not seen[created.direction] then
+          seen[created.direction] = true
+          local p = prototypes.entity[name]
+          local row = {
+            name = name,
+            direction = created.direction,
+            asked_direction = d,
+            position = {x = created.position.x, y = created.position.y},
+            -- What the game itself says the footprint is, against what the
+            -- editor computes from collision_box on the other side.
+            tile_width = p.tile_width,
+            tile_height = p.tile_height,
+            collision_box = {
+              {p.collision_box.left_top.x, p.collision_box.left_top.y},
+              {p.collision_box.right_bottom.x, p.collision_box.right_bottom.y},
+            },
+            bounding_box = {
+              {created.bounding_box.left_top.x - created.position.x,
+               created.bounding_box.left_top.y - created.position.y},
+              {created.bounding_box.right_bottom.x - created.position.x,
+               created.bounding_box.right_bottom.y - created.position.y},
+            },
+            references = {},
+          }
+          pcall(function()
+            local sb = created.secondary_bounding_box
+            if sb then
+              row.secondary_bounding_box = {
+                {sb.left_top.x - created.position.x, sb.left_top.y - created.position.y},
+                {sb.right_bottom.x - created.position.x, sb.right_bottom.y - created.position.y},
+              }
+            end
+          end)
+
+          for _, ref in ipairs(REFERENCES) do
+            local res = occupancy(surface, force, ref, {created.position.x, created.position.y}, WINDOW)
+            row.references[#row.references + 1] = {
+              reference = ref, blocked = res.blocked, free_count = res.free_count,
+            }
+          end
+          out.rails[#out.rails + 1] = row
+        end
+        if created and created.valid then created.destroy() end
+      end
+    end
+  end
+
+  helpers.write_file("${DUMP}", helpers.table_to_json(out))
+  error("DUMPED-OK")
+end)
+`
+)
+
+writeFileSync(
+    join(work, 'config.ini'),
+    `[path]\nread-data=__PATH__executable__/../data\nwrite-data=${writeData}\n[general]\n[other]\n`
+)
+
+const version = spawnSync(BIN, ['--version'], { encoding: 'utf8' }).stdout ?? ''
+const binaryLine = version.split('\n')[0].trim()
+
+console.log(`running ${binaryLine}...`)
+const res = spawnSync(
+    BIN,
+    [
+        '--create',
+        join(work, 'p.zip'),
+        '--mod-directory',
+        modDir,
+        '--config',
+        join(work, 'config.ini'),
+    ],
+    { encoding: 'utf8' }
+)
+
+const dumpPath = join(writeData, 'script-output', DUMP)
+if (!existsSync(dumpPath)) {
+    console.error(
+        'No dump. Factorio tail:\n' + ((res.stdout ?? '') + (res.stderr ?? '')).slice(-4000)
+    )
+    process.exit(1)
+}
+
+const d = JSON.parse(readFileSync(dumpPath, 'utf8'))
+const vals = o => Object.values(o ?? {})
+
+/* The editor's own rectangle, from the same data.json it loads. */
+const FD = JSON.parse(
+    readFileSync(join(REPO, 'packages', 'exporter', 'data', 'output', 'data.json'), 'utf8')
+).entities
+
+const entitySize = (name, dir = 0) => {
+    const e = FD[name]
+    const bb = e.collision_box
+    const w = e.tile_width || Math.ceil(Math.abs(bb[0][0]) + Math.abs(bb[1][0]))
+    const h = e.tile_height || Math.ceil(Math.abs(bb[0][1]) + Math.abs(bb[1][1]))
+    if (w === h) return { x: w, y: h }
+    const dd =
+        e.type === 'curved-rail-a' || e.type === 'curved-rail-b'
+            ? Math.floor((dir % 8) / 4) * 4
+            : (Math.round(dir / 4) * 4) % 16
+    return dd === 4 || dd === 12 ? { x: h, y: w } : { x: w, y: h }
+}
+
+/** The cells PositionGrid would key, relative to the entity's position. */
+const editorCells = (name, dir, px, py) => {
+    const s = entitySize(name, dir)
+    const x0 = Math.round(px - s.x / 2)
+    const y0 = Math.round(py - s.y / 2)
+    const cells = new Set()
+    for (let x = x0; x < x0 + s.x; x++) {
+        for (let y = y0; y < y0 + s.y; y++) cells.add(`${x - Math.floor(px)},${y - Math.floor(py)}`)
+    }
+    return { cells, size: s }
+}
+
+const key = c => `${c.x},${c.y}`
+
+/** Cells sort by x then y, so a listed set reads as a shape rather than as text */
+const cellOrder = (a, b) => {
+    const [ax, ay] = a.split(',').map(Number)
+    const [bx, by] = b.split(',').map(Number)
+    return ax - bx || ay - by
+}
+
+console.log(`\n=== binary: ${binaryLine}`)
+
+/* ------------------------------------------------------------------ controls */
+const controls = []
+const usable = []
+console.log('\n=== control 1: an empty window is free for every reference ===')
+for (const e of vals(d.empty_ground)) {
+    const n = vals(e.blocked).length
+    if (n === 0) usable.push(e.reference)
+    console.log(
+        `  ${n === 0 ? 'ok  ' : 'VOID'} ${e.reference.padEnd(20)} ${n} blocked cells${n === 0 ? '' : ' - cannot tell occupancy from adjacency, excluded below'}`
+    )
+    controls.push({
+        control: `an empty window is free for ${e.reference}`,
+        holds: n === 0,
+        got: `${n} blocked`,
+    })
+}
+
+const rows = vals(d.rails)
+const chestBlocked = row => {
+    const r = vals(row.references).find(x => x.reference === 'wooden-chest')
+    return new Set(vals(r?.blocked).map(key))
+}
+
+console.log('\n=== control 2: a cardinal straight-rail fills exactly its 2x2 ===')
+for (const row of rows.filter(r => r.name === 'straight-rail' && r.direction % 4 === 0)) {
+    const blocked = chestBlocked(row)
+    const expected = new Set(['-1,-1', '-1,0', '0,-1', '0,0'])
+    const ok = blocked.size === expected.size && [...expected].every(c => blocked.has(c))
+    console.log(
+        `  ${ok ? 'ok  ' : 'FAIL'} dir ${row.direction}: ${blocked.size} cells [${[...blocked].sort(cellOrder).join(' ')}]`
+    )
+    controls.push({
+        control: `a straight-rail at direction ${row.direction} blocks exactly its 2x2`,
+        holds: ok,
+        got: [...blocked].sort(cellOrder).join(' '),
+    })
+}
+
+console.log('\n=== control 3: the references collide with rails at all ===')
+for (const ref of usable) {
+    const anyBlocked = rows.some(row => {
+        const r = vals(row.references).find(x => x.reference === ref)
+        return vals(r?.blocked).length > 0
+    })
+    console.log(`  ${anyBlocked ? 'ok  ' : 'FAIL'} ${ref} is blocked by at least one rail`)
+    controls.push({
+        control: `${ref} collides with rails at all`,
+        holds: anyBlocked,
+        got: anyBlocked ? 'blocked somewhere' : 'never blocked',
+    })
+}
+
+/* --------------------------------------------------- do the references agree? */
+console.log('\n=== does one occupancy set serve every reference? ===')
+const disagreements = []
+for (const row of rows) {
+    const sets = {}
+    for (const r of vals(row.references)) sets[r.reference] = new Set(vals(r.blocked).map(key))
+    const base = sets['wooden-chest']
+    for (const ref of usable) {
+        if (ref === 'wooden-chest') continue
+        const s = sets[ref]
+        const onlyChest = [...base].filter(c => !s.has(c))
+        const onlyRef = [...s].filter(c => !base.has(c))
+        if (onlyChest.length || onlyRef.length) {
+            disagreements.push({
+                rail: row.name,
+                direction: row.direction,
+                reference: ref,
+                blockedForChestNotFor: onlyChest.sort(cellOrder),
+                blockedForRefNotForChest: onlyRef.sort(cellOrder),
+            })
+        }
+    }
+}
+const byRef = {}
+for (const x of disagreements) byRef[x.reference] = (byRef[x.reference] ?? 0) + 1
+console.log(
+    `  ${disagreements.length === 0 ? 'one shape per rail is enough' : 'NO - occupancy depends on what is being placed'}`
+)
+for (const [ref, n] of Object.entries(byRef)) {
+    console.log(`    ${ref}: differs from the chest on ${n} of ${rows.length} orientations`)
+}
+for (const x of disagreements.slice(0, 6)) {
+    console.log(
+        `      ${x.rail} dir ${x.direction} vs ${x.reference}: chest-only [${x.blockedForChestNotFor.join(' ')}] ${x.reference}-only [${x.blockedForRefNotForChest.join(' ')}]`
+    )
+}
+
+/* --------------------------------------------- the rectangle, game vs editor */
+console.log(
+    '\n=== footprint: what the game says, what the editor computes, what is actually blocked ==='
+)
+const footprints = []
+for (const row of rows) {
+    const blocked = chestBlocked(row)
+    const { cells, size } = editorCells(row.name, row.direction, row.position.x, row.position.y)
+    const missed = [...blocked].filter(c => !cells.has(c))
+    const spare = [...cells].filter(c => !blocked.has(c))
+    footprints.push({
+        rail: row.name,
+        direction: row.direction,
+        gameTiles: `${row.tile_width}x${row.tile_height}`,
+        editorTiles: `${size.x}x${size.y}`,
+        blockedCells: blocked.size,
+        editorCells: cells.size,
+        occupiedButNotKeyed: missed.sort(cellOrder),
+        keyedButEmpty: spare.sort(cellOrder),
+    })
+}
+const seenRail = new Set()
+for (const f of footprints) {
+    const first = !seenRail.has(f.rail)
+    seenRail.add(f.rail)
+    if (!first && f.occupiedButNotKeyed.length === 0) continue
+    console.log(
+        `  ${f.rail.padEnd(22)} dir ${String(f.direction).padStart(2)}  game ${f.gameTiles.padEnd(5)} editor ${f.editorTiles.padEnd(5)}  really blocked ${String(f.blockedCells).padStart(2)}  keyed ${String(f.editorCells).padStart(2)}  MISSED ${f.occupiedButNotKeyed.length}  spare ${f.keyedButEmpty.length}`
+    )
+}
+
+const totalMissed = footprints.filter(f => f.occupiedButNotKeyed.length > 0).length
+console.log(
+    `\n  ${totalMissed} of ${footprints.length} orientations block a cell the editor's rectangle does not key`
+)
+
+const raw = join(work, 'rail-occupancy.json')
+writeFileSync(raw, JSON.stringify(d, null, 2))
+console.log(`\nraw: ${raw}`)
+
+if (WRITE_FIXTURE) {
+    writeFileSync(
+        FIXTURE,
+        JSON.stringify(
+            {
+                question:
+                    'Which integer tiles does each rail actually block, is the answer the same for everything that might be placed there, and does the editor rectangle contain it?',
+                issue: 133,
+                probe: 'tools/oracle/probe-rail-occupancy.mjs',
+                binary: binaryLine,
+                versionCaveat:
+                    'Captured on 2.1.12. This editor targets 2.0.45 to 2.0.73 and the corpus declares nothing outside that range.',
+                measurementCaveats: [
+                    'Occupancy is operational, not geometric: a cell is blocked if the game refuses a 1x1 entity centred on it while the rail stands, and accepts the same on empty ground. That is the question isAreaAvailable is asked. It is not a claim about how Factorio composes a curve out of collision boxes.',
+                    'A cell counts as free if ANY of the sixteen directions is accepted there, since a gate and a signal are directional and legal only at some facings while the grid question is whether the cell can be built on at all.',
+                    'editorTiles is computed on this side from data.json, mirroring getEntitySize. Note the exporter emits tile_width/tile_height for only 3 of 155 entities, so the editor computes from collision_box where the game publishes a footprint - the two columns are there to be compared.',
+                ],
+                controls,
+                // The sizes are most of the explanation: a rail's collision is
+                // continuous, so which tiles it makes unbuildable depends on how
+                // big the box being placed is. The gate is the exception that
+                // size does not explain - it is smaller than the chest and yet
+                // legal on all four cells of a cardinal straight rail, which is
+                // the rail-gate rule rather than geometry.
+                referenceBoxes: Object.fromEntries(REFERENCES.map(r => [r, FD[r]?.collision_box])),
+                referenceAgreement: {
+                    usableReferences: usable,
+                    excludedByTheirOwnControl: REFERENCES.filter(r => !usable.includes(r)),
+                    oneShapePerRailIsEnough: disagreements.length === 0,
+                    disagreements,
+                },
+                footprints,
+                rails: rows,
+            },
+            null,
+            4
+        ) + '\n'
+    )
+    console.log(`\nwrote ${FIXTURE}`)
+    console.log('now run: vp check --fix')
+}


### PR DESCRIPTION
Measurement only - no behaviour change. #133 item 1 asks for per-rail occupancy shapes replacing the `getEntitySize` rectangle; this measures the ground first, and the answer **inverts the premise**.

New probe `tools/oracle/probe-rail-occupancy.mjs`, fixture `tools/oracle/fixtures/rail-occupancy.json`. Occupancy is defined the way the grid would use it - a cell is blocked if the game refuses a 1x1 entity centred on it while the rail stands, and accepts the same on empty ground - swept over every orientation of every rail type against four 1x1 references.

## One occupancy shape per rail cannot be correct

The references disagree, for two unrelated reasons.

**Collision is continuous and tiles are not,** so the answer depends on the size of the box being asked about:

| reference | box | disagrees with the chest on |
| --- | --- | --- |
| `small-electric-pole` | 0.3 x 0.3 | 28 of 38 orientations |
| `transport-belt` | 0.8 x 0.8 | 24 of 38 |
| `gate` | 0.58 x 0.58 | 12 of 38 |

The pole fits on cells the chest is refused on; the belt is refused on cells the chest is not.

**And the gate is not explained by size at all** - it is *smaller* than the chest, yet legal on all four cells of a cardinal straight rail. That is the rail-gate rule, a per-pair special case that no shape can absorb.

So a per-rail cell set would have to pick one reference size, be wrong for everything else, and still carry the per-pair rules on top.

`rail-signal` is swept and then **excluded by its own control**, deliberately rather than left out: it is refused on all 121 empty-ground cells, since a signal needs an adjacent rail to exist, so it cannot tell occupancy from adjacency. That is recorded because it is precisely why no shape will ever answer for signals - #133 items 2 and 3 exist for that.

## The rectangle is wrong in both directions, and under-reporting dominates

**34 of 38** orientations block a cell the editor's rectangle does not key; **28 of 38** key a cell that is empty.

| rail | really blocked | editor keys | missed | spare |
| --- | --- | --- | --- | --- |
| `straight-rail` cardinal | 4 | 4 | 0 | 0 |
| `straight-rail` diagonal | 8 | 4 | 4 | 0 |
| `half-diagonal-rail` | 12 | 4 | 8 | 0 |
| `curved-rail-a` | 11 | 12 | 2 | 3 |
| `curved-rail-b` | 14 | 10 | 6-7 | 2-3 |
| `legacy-curved-rail` | 18 | 16 | 8 | 6 |

#133 emphasises over-reporting ("a gate at the far end of a curved rail's rectangle reads as blocked"). That happens, but it is the smaller half. Correcting the footprint would make the editor **stricter**, which is the opposite of what item 1 was filed to achieve - it is listed there under "measured refusals the game accepts".

## The game already publishes a footprint the exporter drops

`tile_width`/`tile_height` are emitted for only **3 of 155** entities, so `getEntitySize` computes from `collision_box` what it could be reading. They disagree for every curved type:

| rail | game | editor computes |
| --- | --- | --- |
| `curved-rail-a` | 2x4 | 2x6 |
| `curved-rail-b` | 2x2 | 2x5 |
| `legacy-curved-rail` | 4x8 | 4x4 |

Note the last one: the editor's rectangle is **smaller** than the game's own footprint, which #133's table does not anticipate.

## Controls

All hold. Empty ground free for all four usable references; a cardinal `straight-rail` blocks exactly its 2x2 (the calibration case with a known answer); each reference is blocked by at least one rail. The fifth reference was voided by control 1 and is reported as such.

## What this means for #133

Item 1 as written - "per-rail occupancy shapes in PositionGrid, replacing the getEntitySize rectangle for rail types only" - is not implementable correctly. I have not rewritten the issue; that is a call for @wormeyman with these numbers in hand.

Refs #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9upL43cci5R9QspAwHanb