### PR TITLE
chore(deps): npm update, pako 3.0.1, and caret the inherited exact pins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ vp run test:e2e -- --list
 
 # Bundle size analysis (from packages/website/) - opens treemap in browser
 # Note: bare `npm`/`npx` must resolve to vp's managed npm (~/.vite-plus/bin on
-# PATH); the root devEngines pins npm `^11`, which system npm may not satisfy.
+# PATH); the root devEngines pins npm `^12`, which system npm may not satisfy.
 cd packages/website && npm run build:analyze
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4644,6 +4644,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/pako": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-3.0.1.tgz",
+            "integrity": "sha512-GupotUUI0mlhugKjUs4bjOwLt3nrehy9Ys2dxC0GtgVef5cnKggkDMmf2bq2poCCuVXopWPmqsc9VDT2iJUy+w==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "(MIT AND Zlib)"
+        },
         "node_modules/parse-svg-path": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.2.0.tgz",
@@ -5831,7 +5847,7 @@
                 "buffer": "6.0.3",
                 "delaunator": "5.1.0",
                 "eventemitter3": "^5.0.4",
-                "pako": "3.0.0",
+                "pako": "3.0.1",
                 "pathfinding": "0.4.18",
                 "pixi.js": "^8.19.0",
                 "utility-types": "3.11.0"
@@ -5842,22 +5858,6 @@
                 "typed-factorio": "^3.36.0",
                 "vite-plus": "0.2.6"
             }
-        },
-        "packages/editor/node_modules/pako": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-3.0.0.tgz",
-            "integrity": "sha512-TGPtlCI1pSUSbkOIxOUUHNrBa0muz4mAp32cYUF3RoSa5c73jiQTKOKo22gaa4DxLggQrda/DAdax5QkcHPvYA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/puzrin"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/nodeca"
-                }
-            ],
-            "license": "(MIT AND Zlib)"
         },
         "packages/website": {
             "name": "@fbe/website",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5844,13 +5844,13 @@
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.20.0",
-                "buffer": "6.0.3",
-                "delaunator": "5.1.0",
+                "buffer": "^6.0.3",
+                "delaunator": "^5.1.0",
                 "eventemitter3": "^5.0.4",
-                "pako": "3.0.1",
-                "pathfinding": "0.4.18",
+                "pako": "^3.0.1",
+                "pathfinding": "^0.4.18",
                 "pixi.js": "^8.19.0",
-                "utility-types": "3.11.0"
+                "utility-types": "^3.11.0"
             },
             "devDependencies": {
                 "@types/delaunator": "5.0.3",
@@ -5864,8 +5864,8 @@
             "version": "1.0.0",
             "dependencies": {
                 "@fbe/editor": "*",
-                "dat.gui": "0.7.9",
-                "file-saver": "2.0.5",
+                "dat.gui": "^0.7.9",
+                "file-saver": "^2.0.5",
                 "pixi.js": "^8.19.0"
             },
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
             ],
             "devDependencies": {
                 "@playwright/test": "^1.62.0",
-                "@types/node": "^26.1.1",
+                "@types/node": "^26.1.2",
                 "typed-factorio": "^3.36.0",
                 "typescript": "^7.0.2",
                 "vite-plus": "0.2.6"
@@ -185,9 +185,9 @@
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.11.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-            "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -2238,9 +2238,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "26.1.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-            "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+            "version": "26.1.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+            "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3348,27 +3348,40 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+                "node": ">=8"
             }
         },
         "node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=12"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -3549,19 +3562,6 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/chokidar/node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/cliui": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -3575,6 +3575,24 @@
             },
             "engines": {
                 "node": ">=20"
+            }
+        },
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/convert-source-map": {
@@ -3684,9 +3702,9 @@
             "license": "MIT"
         },
         "node_modules/earcut": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
-            "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+            "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -3901,6 +3919,19 @@
                 "js-binary-schema-parser": "^2.0.3"
             }
         },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/heap": {
             "version": "0.2.5",
             "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.5.tgz",
@@ -4053,6 +4084,12 @@
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "license": "MIT"
         },
         "node_modules/kleur": {
@@ -4359,9 +4396,9 @@
             }
         },
         "node_modules/miniflare": {
-            "version": "4.20260722.0",
-            "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260722.0.tgz",
-            "integrity": "sha512-LW6ABMhCx/yIEFBLC/DO4yAhdm2T/G7jp7pr5T2kj895+CCIaHZqpMXdW9O6YE48LcYcCJChwWc8aEs1vpbTXw==",
+            "version": "4.20260722.1",
+            "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260722.1.tgz",
+            "integrity": "sha512-FJIg4omaCb2wwSyOeRosEdmVRi3JzGAOOH3pa3twmmtvWECl6BVZMIDwJbjByLKRyU+mrfk0M/n3oSiojFZvSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4595,9 +4632,9 @@
             }
         },
         "node_modules/p-map": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-            "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+            "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4606,22 +4643,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/pako": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-3.0.0.tgz",
-            "integrity": "sha512-TGPtlCI1pSUSbkOIxOUUHNrBa0muz4mAp32cYUF3RoSa5c73jiQTKOKo22gaa4DxLggQrda/DAdax5QkcHPvYA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/puzrin"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/nodeca"
-                }
-            ],
-            "license": "(MIT AND Zlib)"
         },
         "node_modules/parse-svg-path": {
             "version": "0.2.0",
@@ -4659,9 +4680,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4740,9 +4761,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.23",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+            "version": "8.5.24",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+            "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
             "dev": true,
             "funding": [
                 {
@@ -4794,29 +4815,6 @@
             },
             "engines": {
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
-        "node_modules/pretty-format/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/pretty-format/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/react-is": {
@@ -5026,18 +5024,17 @@
             "license": "MIT"
         },
         "node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -5057,6 +5054,19 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/strip-ansi/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
         "node_modules/supports-color": {
@@ -5126,9 +5136,9 @@
             }
         },
         "node_modules/tinyrainbow": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+            "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5565,9 +5575,9 @@
             }
         },
         "node_modules/wrangler": {
-            "version": "4.114.0",
-            "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.114.0.tgz",
-            "integrity": "sha512-M65P25t5UHA1TIJfgZXDcj+YzVobgKdRguM2QPz0xnxLFuOcuE3ErgllDht0iaho7MS4o0g/Bb4YK2+GT+bibg==",
+            "version": "4.115.0",
+            "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.115.0.tgz",
+            "integrity": "sha512-+upG2VW66M1sjb43yzgUZ6Ss8iYpJ6+7F3U4GF8TY5EYd+08sYdS54d24AEwCnhuef3J9KlSPusqiqR9WYy1UA==",
             "dev": true,
             "license": "MIT OR Apache-2.0",
             "dependencies": {
@@ -5575,7 +5585,7 @@
                 "@cloudflare/unenv-preset": "2.16.1",
                 "blake3-wasm": "2.1.5",
                 "esbuild": "0.28.1",
-                "miniflare": "4.20260722.0",
+                "miniflare": "4.20260722.1",
                 "path-to-regexp": "6.3.0",
                 "unenv": "2.0.0-rc.24",
                 "workerd": "1.20260722.1"
@@ -5633,6 +5643,37 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/ws": {
             "version": "8.21.1",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
@@ -5683,16 +5724,16 @@
             }
         },
         "node_modules/yargs": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+            "version": "18.1.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+            "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cliui": "^9.0.1",
                 "escalade": "^3.1.1",
                 "get-caller-file": "^2.0.5",
-                "string-width": "^7.2.0",
+                "string-width": "^8.2.1",
                 "y18n": "^5.0.5",
                 "yargs-parser": "^22.0.0"
             },
@@ -5786,43 +5827,37 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "ajv": "^8.18.0",
+                "ajv": "^8.20.0",
                 "buffer": "6.0.3",
                 "delaunator": "5.1.0",
                 "eventemitter3": "^5.0.4",
                 "pako": "3.0.0",
                 "pathfinding": "0.4.18",
-                "pixi.js": "^8.17.1",
+                "pixi.js": "^8.19.0",
                 "utility-types": "3.11.0"
             },
             "devDependencies": {
                 "@types/delaunator": "5.0.3",
                 "@types/pathfinding": "0.1.0",
-                "typed-factorio": "^3.35.0",
+                "typed-factorio": "^3.36.0",
                 "vite-plus": "0.2.6"
             }
         },
-        "packages/editor/node_modules/ajv": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "packages/editor/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "license": "MIT"
+        "packages/editor/node_modules/pako": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-3.0.0.tgz",
+            "integrity": "sha512-TGPtlCI1pSUSbkOIxOUUHNrBa0muz4mAp32cYUF3RoSa5c73jiQTKOKo22gaa4DxLggQrda/DAdax5QkcHPvYA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "(MIT AND Zlib)"
         },
         "packages/website": {
             "name": "@fbe/website",
@@ -5831,7 +5866,7 @@
                 "@fbe/editor": "*",
                 "dat.gui": "0.7.9",
                 "file-saver": "2.0.5",
-                "pixi.js": "^8.17.1"
+                "pixi.js": "^8.19.0"
             },
             "devDependencies": {
                 "@types/dat.gui": "0.7.13",
@@ -5846,7 +5881,7 @@
             "version": "0.0.1",
             "devDependencies": {
                 "typescript": "^7.0.2",
-                "wrangler": "^4.75.0"
+                "wrangler": "^4.115.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "devDependencies": {
         "@playwright/test": "^1.62.0",
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "typed-factorio": "^3.36.0",
         "typescript": "^7.0.2",
         "vite-plus": "0.2.6"
@@ -31,7 +31,7 @@
     "devEngines": {
         "packageManager": {
             "name": "npm",
-            "version": "^11",
+            "version": "^12",
             "onFail": "download"
         }
     },

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -20,7 +20,7 @@
         "buffer": "6.0.3",
         "delaunator": "5.1.0",
         "eventemitter3": "^5.0.4",
-        "pako": "3.0.0",
+        "pako": "3.0.1",
         "pathfinding": "0.4.18",
         "pixi.js": "^8.19.0",
         "utility-types": "3.11.0"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -16,19 +16,19 @@
         "test:unit:watch": "vp test"
     },
     "dependencies": {
-        "ajv": "^8.18.0",
+        "ajv": "^8.20.0",
         "buffer": "6.0.3",
         "delaunator": "5.1.0",
         "eventemitter3": "^5.0.4",
         "pako": "3.0.0",
         "pathfinding": "0.4.18",
-        "pixi.js": "^8.17.1",
+        "pixi.js": "^8.19.0",
         "utility-types": "3.11.0"
     },
     "devDependencies": {
         "@types/delaunator": "5.0.3",
         "@types/pathfinding": "0.1.0",
-        "typed-factorio": "^3.35.0",
+        "typed-factorio": "^3.36.0",
         "vite-plus": "0.2.6"
     }
 }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -17,13 +17,13 @@
     },
     "dependencies": {
         "ajv": "^8.20.0",
-        "buffer": "6.0.3",
-        "delaunator": "5.1.0",
+        "buffer": "^6.0.3",
+        "delaunator": "^5.1.0",
         "eventemitter3": "^5.0.4",
-        "pako": "3.0.1",
-        "pathfinding": "0.4.18",
+        "pako": "^3.0.1",
+        "pathfinding": "^0.4.18",
         "pixi.js": "^8.19.0",
-        "utility-types": "3.11.0"
+        "utility-types": "^3.11.0"
     },
     "devDependencies": {
         "@types/delaunator": "5.0.3",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -10,8 +10,8 @@
     },
     "dependencies": {
         "@fbe/editor": "*",
-        "dat.gui": "0.7.9",
-        "file-saver": "2.0.5",
+        "dat.gui": "^0.7.9",
+        "file-saver": "^2.0.5",
         "pixi.js": "^8.19.0"
     },
     "devDependencies": {

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -12,7 +12,7 @@
         "@fbe/editor": "*",
         "dat.gui": "0.7.9",
         "file-saver": "2.0.5",
-        "pixi.js": "^8.17.1"
+        "pixi.js": "^8.19.0"
     },
     "devDependencies": {
         "@types/dat.gui": "0.7.13",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -10,6 +10,6 @@
     },
     "devDependencies": {
         "typescript": "^7.0.2",
-        "wrangler": "^4.75.0"
+        "wrangler": "^4.115.0"
     }
 }


### PR DESCRIPTION
Started as "I ran `npm update --save`, did I break anything?" - the answer is no, but the investigation turned up two things worth fixing.

## What's here

Three commits, each revertable on its own.

**1. `chore(deps): npm update --save`** - the routine refresh.

| | |
|---|---|
| `pixi.js` | `^8.17.1` → `^8.19.0` |
| `ajv` | `^8.18.0` → `^8.20.0` |
| `wrangler` | `^4.75.0` → `^4.115.0` |
| `typed-factorio` | `^3.35.0` → `^3.36.0` (editor; root was already 3.36) |
| `@types/node` | `^26.1.1` → `^26.1.2` |

typed-factorio stays on v3 - v4 is still held by the Factorio 2.1 data mismatch.

Two things npm did on its own:

- It rewrote `"@fbe/editor": "*"` to `"^1.0.0"` in `packages/website`. **Reverted.** That wildcard has been `*` in every commit of the file's history, and the pin is version-coupled - bump the editor to 2.0.0 and npm stops linking the local workspace and goes looking for `@fbe/editor` on the registry, where it doesn't exist.
- It moved `devEngines` npm from `^11` to `^12` to match the npm it ran under. **Kept** - `onFail` is `download`, and CI installs through `vp install` with vp's own node manager. `CLAUDE.md`'s note about the `^11` pin is updated to match.

**2. `chore(deps): pako 3.0.0 -> 3.0.1`** - I diffed both tarballs rather than trusting the version number. Same 20 files, zero deps, +2.4 KB, exactly two changes:

```js
status = deflate$1(strm, _flush_mode);
if (status === -2) break;              // added in 3.0.1
```

`-2` is `Z_STREAM_ERROR`; without the guard a failed deflate falls through and keeps looping. This is on our blueprint encode path (`bpString.ts:213`). Everything else is the `.d.ts` widening `Uint8Array` → `Uint8Array<ArrayBuffer>` (TypeScript 5.7+ generic `Uint8Array`, not a pako API change) - which is the one thing that could have broken us under `strict: true`, and doesn't.

**3. `chore(deps): caret the seven inherited exact pins`** - `buffer`, `delaunator`, `pako`, `pathfinding`, `utility-types`, `dat.gui`, `file-saver`. **No installed version moves.**

`git log -L` traces those pins to upstream `4c935c97` (the PIXI v8 upgrade), which bulk-converted carets to exact pins in one sweep - and left `eventemitter3` on `^5.0.4` in the same commit, which is the tell that it was a sweep, not a judgement. Since `package-lock.json` is committed and CI runs `vp install --frozen-lockfile` (`ci.yml:38`, `:86`), the range doesn't decide what anyone installs; the lockfile does. So the pin added no reproducibility and only hid updates - which is how pako sat on 3.0.0 for three weeks while that fix shipped.

Caret rather than tilde because tilde still needs every minor chased by hand. Caret refuses majors, which is the boundary that matters here: pako 2→3 removed the default export and renamed `{ to: 'string' }` → `{ toText: true }`, needing the code changes in 575429b9.

## Verification

| Check | Result |
|---|---|
| `vp check` | 0 warnings/lint/type errors, 157 files |
| `vp test` | 143 passed |
| `npm run type-check:gate` | 0 errors at baseline 0 |
| `vp build` (website) | clean |
| `wrangler deploy --dry-run` | clean, `ASSETS` bound |
| `npx playwright test` | **160/160 passed** |

The one that matters for pako is `blueprint-round-trip.spec.ts` - it walks all 578 blueprints through decode → model → serialize and **hashes the serialized output**, and serializing ends in `pako.deflate`, so a compression change moves that hash. It didn't. `vp check` and the unit tests can't see any of this, since `bpString.ts` needs FD loaded.

For commit 3 the two worth naming are `dat.gui` (covered by `settings-pane-click-interception.spec.ts`) and `pathfinding` (covered by `generators.test.ts`, which pins oil-outpost layouts against a committed fixture).

## One trap worth recording

**A long-lived Vite dev server does not pick up a dependency change.** The server running during this work had pre-bundled deps from four days earlier and was still serving pixi 8.17.1, so my first full Playwright run measured the *old* version and would have been a false green. A fresh server logs `Re-optimizing dependencies because lockfile has changed` - without that line the run isn't testing what you think it is. Every result above is from a fresh server that logged it.

Related: `npm outdated` reads `Wanted` vs `Current`, not `Latest`. When those two match, the *range* is holding the dep, not npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DraE4QQurBXt4787h6Kop2