### PR TITLE
#142: measure the game's published footprints, and find the premise refuted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,8 @@ keys 4 and a `half-diagonal-rail` 12 where it keys 4 - and the game publishes
 `tile_width`/`tile_height` that the exporter emits for only 3 of 155 entities,
 which disagree with the computed rectangle for every curved type
 (`curved-rail-a` 2x4 against 2x6, `curved-rail-b` 2x2 against 2x5,
-`legacy-curved-rail` 4x8 against 4x4).
+`legacy-curved-rail` 4x8 against 4x4) - **and that last observation is a trap,
+which #142 walked into and then measured its way back out of**; see below.
 
 And which rail may be laid across which (issue #133 item 5,
 `tools/oracle/fixtures/rail-on-rail.json`), the first measurement those nine
@@ -349,6 +350,55 @@ tiles, a finished line is legal to 20, and a blueprint is the second - the corpu
 spaces supports at exactly 20, so measuring only the walk would have produced a
 rule refusing every real elevated bridge.
 
+And what footprint the game publishes for every entity (issue #142,
+`tools/oracle/fixtures/entity-tile-size.json`), which **refutes the change it
+was capturing evidence for** - the second measurement here to end in "do not
+implement", and the first taken on a **2.0.x** binary rather than on 2.1.12. The
+issue was "make the editor's footprints agree with the game's own
+`tile_width`/`tile_height`". They already agree for 146 of 155 entities. The 9
+that differ are the six curved rail types, their two `dummy-` variants and
+`rail-ramp`, and for **8 of those 9 the published rectangle does not contain the
+entity's own collision box** - `curved-rail-b` is 2x2 against a box 4.88 tiles
+tall, `rail-ramp` 2x16 against a box 3.6 wide. The reason is in the runtime
+docs, one line that settles the whole issue: `tile_width` "is used to decide, if
+the center should be in the center of the tile (odd tile size dimension) or on
+the tile border (even tile size dimension)". It is a **centring parity, not a
+size**, and it coincides with the enclosing rectangle for the 146 only because
+most entities are boxes. **A field whose name reads like a size is not therefore
+a size** - and this one is already read as one, at `factorioData.ts:598`, where
+it is load-bearing and correct for exactly two entities (`offshore-pump`
+declares 1x1 where the fallback computes 2x2, `train-stop` 2x2 where the
+fallback computes 1x1).
+
+Transcribing the proposed rule into the analysis and checking it against
+`rail-occupancy.json` **before writing any code** - the #133 item 5 lesson,
+which has now paid twice - says adopting the numbers makes agreement with
+measured occupancy worse in **both** directions across all 38 measured
+orientations: occupied-but-not-keyed 180 -> 188, keyed-but-empty 96 -> 152.
+`curved-rail-a` improves by 2 cells of 11, and that is the whole of the upside;
+`curved-rail-b` drops from 10 keyed cells to 4 against 14 really blocked, and
+`legacy-curved-rail` doubles to 32 keyed against 18. Since the footprint is also
+what `getEntityAtPosition` reads, the price is half of `rail-ramp` becoming
+unclickable. The real fix for the curved rails is still per-rail measured cell
+sets, which is #133 item 1 and was costed and abandoned as #138.
+
+Three method notes, all in the probe README:
+
+- **A mod's `factorio_version` must match the binary**, and every probe before
+  this one hardcodes `2.1` - correct only because 2.1.12 was the only Factorio
+  on the machine. A mismatch is silent: the mod is skipped, no dump appears, and
+  the failure names nothing. `probe-entity-tile-size.mjs` derives it from
+  `factorio --version`, which is the whole of what it takes to make the targeted
+  2.0.x range measurable. Copy that, not the string.
+- **Read what the docs say a field decides, not what its name suggests.** This
+  probe's own instrument control - the three entities that declare `tile_width`
+  at the data stage must read back the same number at runtime - passed
+  perfectly, because the field is being read correctly. It was the right control
+  and it could not have caught this. What caught it was one sentence of prose.
+- **The version cross-check found something again**, and again it did not
+  matter: four entities move footprint between 2.0.77 and 2.1.12 (`tree-plant`
+  and the three demolisher corpses), none of them among the 155.
+
 ## Cloudflare Deployment
 
 The editor is deployed to Cloudflare Workers at https://fbe.factorygamefan.com (custom
@@ -391,7 +441,7 @@ Automated tests that load blueprint `.txt` files from `wormeyman-tests/` against
 - `tests/rail-placement-rules.spec.ts` - What `isAreaAvailable` answers for a signal or a gate dropped on a rail (issue #95). The corpus cannot reach any of it: `isAreaAvailable` is only called from the paint containers, so every answer needs hand placement, and the 578 real exports were all legal when the game wrote them. What the tests are really shaped around is that **the positive cases carry as much weight as the negative ones** - a fix that simply refused every signal on every rail passes the "refused" test and fails the "still allowed" one, and mutation-checking found that both directions matter, since six separate mutations each fail exactly one test. Two expectations are ones reading the code would get backwards, both measured: a `legacy-curved-rail` refuses a signal on its tiles where `curved-rail-a` accepts one, and a `legacy-straight-rail` accepts one at its diagonal orientations where `straight-rail` never does. The last test pins the arms that stay **permissive on purpose** so that narrowing them is a decision rather than a side effect of tidying the rule next door. Two more tests cover **rail on rail** (#133 item 5), and they are a matched pair rather than two independent tests - the tempting fix, "allow whenever the prototypes differ", passes the first and fails the second, because two _cardinal_ 2x2 rails fill their shared tiles whichever prototypes they are while the same pair at a _diagonal_ orientation does not. Mutation-checked five ways; the two that catch the tempting mistakes are name-only matching and dropping the direction normalisation, and each kills exactly the guard test. One expectation in the guard test is a refusal the game would allow - an identical curved rail at an identical direction, the 24 rows left for #133 item 1 - pinned so that closing it is a decision
 - `tests/elevated-rail-placement.spec.ts` - What `isAreaAvailable` answers around the four `elevated-*` types (issue #133 item 4), which it never named, so they fell to `default:` and read as ordinary obstructions in both directions. Worth knowing why this is reachable at all, since the obvious route is not: **no item places an elevated rail** - nothing in `data.json` has one as its `place_result` and the rail planner gives `straight-rail` - so the inventory cannot reach it and pipetting one hands back a ground rail. It is reached through `PaintBlueprintEntityContainer`, which asks about every entity of a **pasted** selection, and from the other side by hand-placing anything under an elevated rail a loaded blueprint brought with it. The refusals carry as much weight as the acceptances: a fix that ignored elevated rails entirely passes the first test and fails the next two. Two of the tests are shaped by mistakes that would otherwise look right - the collider list is keyed by **name**, so it pins a `big-electric-pole` refused beside a `medium-electric-pole` accepted, and `canCollide` is asked about the **ground** entity of the pair, so reading the placed one instead is caught only by the paste direction. The last test involves no elevated rail at all: the filter only ever removes, and a mistake that removed too much would quietly turn the whole function into "always true"
 - `tests/rail-signal-snapping.spec.ts` - That `PaintEntityContainer` actually calls the snapping (issue #133 item 2). The arithmetic is unit tested in `packages/editor/src/core/railSignalSnapping.test.ts`, which is pure and FD-free; what needs a browser is the wiring, and there is no other way to see it - a paint container's position and facing are invisible until the entity is placed, by which point a wrong snap and a missed click look identical, which is what the `paintContainerState` hook is for. Reached by pipette (`Q`) over an existing signal, the same route `editor-mode-input.spec.ts` documents. Three things this spec was shaped by, each of which cost a run. Every expectation is an **offset from the rail**, never an absolute position, because loading re-centres a blueprint - use the `entityPosition` hook rather than the coordinates you encoded. The zoom is **derived** from two entities a known distance apart rather than hardcoded, since the editor picks it from the blueprint's bounds. And the last test - the control, a signal far enough out to be left under the cursor - moves **sideways six tiles** for two separate reasons: diagonally it leaves the canvas, where the paint container is _hidden_ rather than moved and reports its last snapped position; and six is chosen to sit inside the rail search window and outside the snap distance, so the rail is found and then rejected on distance. Aim further and the window rejects it first, which passes for the wrong reason - that is exactly what happened while the window was a hardcoded 9, and it left a mutation removing the real distance limit invisible to the whole suite
-- `tests/rail-footprints.spec.ts` - Which tiles the position grid hands each rail, and so which tiles **select** it (issue #142). Written deliberately _before_ the change it guards, because the footprint is not only a placement rule: `getEntityAtPosition` reads the same cells, so a `legacy-curved-rail` going 4x4 -> 4x8 doubles the area that selects it and a `curved-rail-a` going 2x6 -> 2x4 shrinks it, and **nothing else in the suite can see either** - every other spec hovers an entity's _centre_, which selects it whatever its size, so a footprint change would land green with users simply finding rails harder or easier to click. Mutation-checked with the real future change (forcing `curved-rail-a` to the game's 2x4), which moves 12 cells to 8 and leaves `elevated-curved-rail-a` alone. Two non-rails are in the fixture as controls, so a change that hit everything rather than rails says so. A fixed point, not a refreshable snapshot - and note it needs no pointer, no rendering and no viewport, reading the grid straight off a decoded blueprint the way `position-grid.spec.ts` does, which makes it the one piece of placement coverage that cannot go intermittent
+- `tests/rail-footprints.spec.ts` - Which tiles the position grid hands each rail, and so which tiles **select** it (issue #142). Written deliberately _before_ the change it was to guard - **and that change is not coming**, because measuring it refuted it (see the #142 paragraph under Asking the real game). So it is now a fixed point guarding footprints that are staying put, which is the more useful thing for it to be. It matters because the footprint is not only a placement rule: `getEntityAtPosition` reads the same cells, so a `legacy-curved-rail` going 4x4 -> 4x8 doubles the area that selects it and a `curved-rail-a` going 2x6 -> 2x4 shrinks it, and **nothing else in the suite can see either** - every other spec hovers an entity's _centre_, which selects it whatever its size, so a footprint change would land green with users simply finding rails harder or easier to click. Mutation-checked with what was then the expected future change (forcing `curved-rail-a` to the game's 2x4), which moves 12 cells to 8 and leaves `elevated-curved-rail-a` alone. Two non-rails are in the fixture as controls, so a change that hit everything rather than rails says so. A fixed point, not a refreshable snapshot - and note it needs no pointer, no rendering and no viewport, reading the grid straight off a decoded blueprint the way `position-grid.spec.ts` does, which makes it the one piece of placement coverage that cannot go intermittent
 - `tests/viewport-transform-freshness.spec.ts` - That a screen position read straight after a load is the real one (issue #144), which is the root cause of a flake that had made pointer specs fail intermittently for months. `Viewport.centerViewPort` computed the new scale and position and set a **dirty flag**, leaving the matrix itself to be rebuilt by `update()` on the render ticker - so `getTransform()` answered the matrix from _before_ the blueprint was centred until a frame ran, and `toScreen`, which is what every spec aims its pointer with, reads it. Measured, an entity reported **(-80, -16)**: off the canvas. Specs normally survive only because a `page.evaluate` round-trip is long enough for a frame to land in the gap; when one is not, the pointer goes somewhere the entity is not, the hover never arrives and the spec dies on a 10s timeout naming nothing. **The bug was intermittent and this test is not** - it reads inside the same `evaluate` as the load, with no yield, so the frame cannot have run, and it failed 25 of 25 before the fix. The third test is the one to understand before touching `Viewport`: the tempting over-correction is to clear the dirty flag in `getTransform` as well as rebuild, which passes the other two and every pointer spec in the suite, because `update()`'s return value is what writes the container's position and scale - clearing the flag on a _read_ hands back a fresh transform and skips the draw, so the model is centred and the pixels are not, and `toScreen`/`toWorld` stay perfectly self-consistent while the blueprint is drawn somewhere else. Only a screenshot or the `viewportRenderedInSync` hook can see it
 - `tests/sprite-generation.spec.ts` - Two halves. One builds a synthetic blueprint holding every entity in `data.json` at the four cardinal directions (`tests/helpers/all-entities-blueprint.ts`); the other loads the real bases, which is where the neighbour-dependent branches (pipe junctions, belt corners, undergrounds) and modules get exercised. Both assert against a pinned list of entity types that fail today
 - `tests/entity-accessors.spec.ts` - Tallies what every `Entity` accessor returns (a value, an empty list, or nothing) across all 578 blueprints in `wormeyman-tests/`, so a getter that starts returning `[]` where it returned `undefined` shows up. Fixed point, not a refreshable snapshot

--- a/tests/rail-footprints.spec.ts
+++ b/tests/rail-footprints.spec.ts
@@ -14,14 +14,26 @@ import { encodeBlueprint as encode, packVersion as version } from './helpers/enc
     exporter is not dropping it - so every rail footprint here is the computed
     fallback. The game's own numbers disagree for every curved type
     (`curved-rail-a` 2x4 against 2x6, `curved-rail-b` 2x2 against 2x5,
-    `legacy-curved-rail` 4x8 against 4x4), which is what #142 is about.
+    `legacy-curved-rail` 4x8 against 4x4), which is what #142 was about.
 
-    This exists to be the **before** picture, and it is deliberately written
-    before that change rather than alongside it. The footprint is not only a
-    placement rule: `getEntityAtPosition` reads the same cells, so it decides
-    what a click selects. A `legacy-curved-rail` going 4x4 -> 4x8 doubles the
-    area that selects it and `curved-rail-a` going 2x6 -> 2x4 shrinks it, and
-    nothing in the suite could see either - every other spec hovers an entity's
+    **The change this was the "before" picture for is not coming, and the
+    numbers above are why it looked like it should.** #142 was measured in full
+    (`tools/oracle/fixtures/entity-tile-size.json`, the first capture here taken
+    on a 2.0.x binary) and the premise did not survive: `tile_width` is a
+    **centring parity**, not a footprint - the runtime docs say it decides
+    whether an entity's centre sits at a tile centre or a tile border - and for
+    8 of the 9 entities where it disagrees with the editor, the published
+    rectangle does not contain the entity's own collision box. Checked against
+    `fixtures/rail-occupancy.json` before any code was written, adopting it
+    makes agreement with measured occupancy worse in both directions over all 38
+    orientations: occupied-but-not-keyed 180 -> 188, keyed-but-empty 96 -> 152.
+
+    So this is now a fixed point guarding footprints that are staying put, which
+    is the more useful thing for it to be. The footprint is not only a placement
+    rule: `getEntityAtPosition` reads the same cells, so it decides what a click
+    selects. A `legacy-curved-rail` going 4x4 -> 4x8 would double the area that
+    selects it and `curved-rail-a` going 2x6 -> 2x4 would shrink it, and nothing
+    else in the suite could see either - every other spec hovers an entity's
     **centre**, which selects it whatever its size. So a change to footprints
     would land with the suite green and the only symptom would be users finding
     rails harder or easier to click.

--- a/tools/oracle/README.md
+++ b/tools/oracle/README.md
@@ -46,6 +46,7 @@ This is the part that saves time, and it is not "open a disassembler":
 | `probe-rail-occupancy.mjs`           | Which tiles a rail really blocks, and whether one answer serves (#133)        |
 | `probe-rail-signal-spots.mjs`        | Every legal signal position, and whether the #95 window clipped them (#133)   |
 | `probe-elevated-rail-support.mjs`    | What holds an elevated rail up, and whether a tile grid can express it (#141) |
+| `probe-entity-tile-size.mjs`         | What `tile_width`/`tile_height` the game publishes for every entity (#142)    |
 
 One script here is not a probe and asks the game nothing:
 
@@ -87,8 +88,25 @@ model wants the same treatment.
 
 - **`helpers.write_file` / `helpers.table_to_json`**, not `game.*`. They moved in
   2.1 and the old names are gone.
-- **`factorio_version` must be `"2.1"`** in the mod's `info.json` for a 2.1.x
-  game, or the mod is silently skipped and no dump appears.
+- **`factorio_version` in the mod's `info.json` must match the binary's
+  major.minor**, or the mod is silently skipped and no dump appears - the run
+  ends on "No dump" and nothing in Factorio's output names the cause. Every
+  probe up to #141 hardcodes `"2.1"`, which is correct only because the only
+  Factorio on this machine was the 2.1.12 Steam install. `probe-entity-tile-size.mjs`
+  **derives** it from `factorio --version` instead, which is what makes running
+  against a 2.0.x binary - the range this editor actually targets - a matter of
+  setting `FACTORIO_BIN` and nothing else. Copy that, not the hardcoded string.
+- **`tile_width`/`tile_height` are a centring parity, not a footprint.** The
+  runtime docs say so in as many words: "is used to decide, if the center should
+  be in the center of the tile (odd tile size dimension) or on the tile border
+  (even tile size dimension)". For 146 of the 155 entities this editor knows
+  that coincides with the enclosing rectangle, which is exactly why reading it
+  as a footprint looks right. For the other 9 - every curved rail and
+  `rail-ramp` - the published rectangle does **not contain the entity's own
+  collision box**: `curved-rail-b` is 2x2 against a box 4.88 tiles tall, and
+  `rail-ramp` is 2x16 against a box 3.6 tiles wide. Measured in
+  `fixtures/entity-tile-size.json`. A field whose name reads like a size is not
+  therefore a size; check what the docs say it decides.
 - **Embed the blueprint string in a Lua long bracket** (`[==[ ... ]==]`) so its
   base64 survives verbatim.
 - **`error("DUMPED-OK")` makes Factorio exit non-zero.** That is success. Key off
@@ -220,6 +238,30 @@ with only the rails between them changing, answers refused / accepted / refused
 and everything beyond that has to be reached through rails that already exist.
 So the editor's question, "may this rail go here", cannot be answered from the
 tiles under it or from any neighbourhood of them.
+
+And what footprint the game publishes for every entity (issue #142,
+`fixtures/entity-tile-size.json`), which **refutes the change it was capturing
+evidence for** and is the second measurement here to end in "do not implement".
+The issue was "make the editor's footprints agree with the game's own
+`tile_width`/`tile_height`". They already agree for 146 of 155 entities. The 9
+that differ are the six curved rail types, their two `dummy-` variants and
+`rail-ramp` - and for 8 of those 9 the game's rectangle does not contain the
+entity's collision box, because `tile_width` is a centring parity rather than a
+size (see the gotcha above). Transcribing the proposed rule and checking it
+against `fixtures/rail-occupancy.json` before writing any code - the #133 item 5
+lesson - says adopting the numbers makes agreement with measured occupancy worse
+in **both** directions across the 38 measured orientations: occupied-but-not-keyed
+180 -> 188, keyed-but-empty 96 -> 152. `curved-rail-a` improves by 2 cells of 11;
+`curved-rail-b` drops from 10 keyed cells to 4 against 14 really blocked, and
+`legacy-curved-rail` doubles to 32 keyed against 18. Since the footprint is also
+what `getEntityAtPosition` reads, that is half of `rail-ramp` becoming
+unclickable in exchange for agreeing with a number that does not mean what the
+issue assumed.
+
+This is also the first capture here taken on a **2.0.x** binary rather than on
+2.1.12, and the cross-check paid for itself again: four entities move footprint
+between 2.0.77 and 2.1.12 (`tree-plant` and the three demolisher corpses), none
+of them among the 155 the editor knows.
 
 ## Fixture policy
 

--- a/tools/oracle/fixtures/entity-tile-size.json
+++ b/tools/oracle/fixtures/entity-tile-size.json
@@ -1,0 +1,1253 @@
+{
+    "question": "What tile_width/tile_height does the game publish for every entity, and where does that disagree with the rectangle getEntitySize computes from the collision box?",
+    "issue": 142,
+    "probe": "tools/oracle/probe-entity-tile-size.mjs",
+    "binary": "Version: 2.0.77 (build 84539, mac-arm64, full)",
+    "mods": {
+        "base": "2.0.77",
+        "elevated-rails": "2.0.77",
+        "quality": "2.0.77",
+        "space-age": "2.0.77",
+        "bp_entity_tile_size": "0.0.1"
+    },
+    "versionNote": "Captured on a binary in the 2.0.x range this editor targets (2.0.45 to 2.0.73), unlike every earlier fixture here, which came from 2.1.12. The mod declares factorio_version derived from the binary; hardcoding 2.1 makes a 2.0.x run produce no dump and no message saying why.",
+    "measurementCaveats": [
+        "tile_width/tile_height are runtime properties of LuaEntityPrototype, derived by the engine from the collision box. They are not available at the data stage, which is why data.json carries them for only 3 of 155 entities - those three declare them - and why the exporter is not dropping anything.",
+        "editorTiles is computed on this side from packages/exporter/data/output/data.json, mirroring getEntitySize at direction 0, because the question is what the editor computes rather than what the game collides with. The width/height swap getEntitySize applies at directions 4 and 12 is orthogonal and is not captured here.",
+        "This is the published footprint, not occupancy. #133 item 1 measured that a rail blocks cells no rectangle of any size describes, and that the answer depends on the size of the box asking. A correct rectangle is still a rectangle.",
+        "The fixture lists only the 155 entities data.json knows. The game table is larger; the full sweep is summarised in counts and kept in the raw dump."
+    ],
+    "controls": {
+        "note": "Each of these can fail while the hypothesis holds.",
+        "entitiesSwept": 1016,
+        "withAFootprint": 1016,
+        "withoutOne": 0,
+        "distinctFootprints": 40,
+        "declaredAtTheDataStageAgreesWithRuntime": [
+            {
+                "name": "asteroid-collector",
+                "dataStage": "3x3",
+                "runtime": "3x3",
+                "agrees": true
+            },
+            {
+                "name": "offshore-pump",
+                "dataStage": "1x1",
+                "runtime": "1x1",
+                "agrees": true
+            },
+            {
+                "name": "train-stop",
+                "dataStage": "2x2",
+                "runtime": "2x2",
+                "agrees": true
+            }
+        ],
+        "dataJsonEntitiesMissingFromTheGameTable": []
+    },
+    "summary": {
+        "compared": 155,
+        "agree": 146,
+        "disagree": 9,
+        "disagreeing": [
+            {
+                "name": "legacy-curved-rail",
+                "type": "legacy-curved-rail",
+                "gameTiles": [4, 8],
+                "editorTiles": [4, 4],
+                "cellDelta": 16
+            },
+            {
+                "name": "curved-rail-a",
+                "type": "curved-rail-a",
+                "gameTiles": [2, 4],
+                "editorTiles": [2, 6],
+                "cellDelta": -4
+            },
+            {
+                "name": "dummy-elevated-curved-rail-a",
+                "type": "elevated-curved-rail-a",
+                "gameTiles": [2, 4],
+                "editorTiles": [2, 6],
+                "cellDelta": -4
+            },
+            {
+                "name": "elevated-curved-rail-a",
+                "type": "elevated-curved-rail-a",
+                "gameTiles": [2, 4],
+                "editorTiles": [2, 6],
+                "cellDelta": -4
+            },
+            {
+                "name": "curved-rail-b",
+                "type": "curved-rail-b",
+                "gameTiles": [2, 2],
+                "editorTiles": [2, 5],
+                "cellDelta": -6
+            },
+            {
+                "name": "dummy-elevated-curved-rail-b",
+                "type": "elevated-curved-rail-b",
+                "gameTiles": [2, 2],
+                "editorTiles": [2, 5],
+                "cellDelta": -6
+            },
+            {
+                "name": "elevated-curved-rail-b",
+                "type": "elevated-curved-rail-b",
+                "gameTiles": [2, 2],
+                "editorTiles": [2, 5],
+                "cellDelta": -6
+            },
+            {
+                "name": "dummy-rail-ramp",
+                "type": "rail-ramp",
+                "gameTiles": [2, 16],
+                "editorTiles": [4, 16],
+                "cellDelta": -32
+            },
+            {
+                "name": "rail-ramp",
+                "type": "rail-ramp",
+                "gameTiles": [2, 16],
+                "editorTiles": [4, 16],
+                "cellDelta": -32
+            }
+        ]
+    },
+    "versionDifferences": {
+        "against": "Version: 2.1.12 (build 87038, mac-arm64, steam)",
+        "entitiesCompared": 1016,
+        "footprintsThatMoved": [
+            {
+                "name": "tree-plant",
+                "type": "plant",
+                "Version: 2.0.77 (build 84539, mac-arm64, full)": [1, 1],
+                "Version: 2.1.12 (build 87038, mac-arm64, steam)": [2, 2]
+            },
+            {
+                "name": "small-demolisher-corpse",
+                "type": "simple-entity",
+                "Version: 2.0.77 (build 84539, mac-arm64, full)": [3, 3],
+                "Version: 2.1.12 (build 87038, mac-arm64, steam)": [4, 4]
+            },
+            {
+                "name": "medium-demolisher-corpse",
+                "type": "simple-entity",
+                "Version: 2.0.77 (build 84539, mac-arm64, full)": [5, 5],
+                "Version: 2.1.12 (build 87038, mac-arm64, steam)": [6, 6]
+            },
+            {
+                "name": "big-demolisher-corpse",
+                "type": "simple-entity",
+                "Version: 2.0.77 (build 84539, mac-arm64, full)": [6, 6],
+                "Version: 2.1.12 (build 87038, mac-arm64, steam)": [7, 7]
+            }
+        ],
+        "onlyIn": {
+            "Version: 2.0.77 (build 84539, mac-arm64, full)": [],
+            "Version: 2.1.12 (build 87038, mac-arm64, steam)": [
+                "acid-cloud",
+                "acid-cloud-visual-dummy",
+                "big-volcanic-rock-hot",
+                "fulgora-sunk-ruin-big",
+                "fulgora-sunk-ruin-medium-tall",
+                "huge-volcanic-rock-hot",
+                "landing-pad-unloading-bay",
+                "railgun-turret-explosion",
+                "rocket-turret-explosion",
+                "shotgun-impact-sticker",
+                "small-explosion-hit",
+                "tesla-turret-explosion"
+            ]
+        }
+    },
+    "entities": {
+        "accumulator": {
+            "type": "accumulator",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.8984375, -0.8984375, 0.8984375, 0.8984375],
+            "declaredInDataJson": false
+        },
+        "active-provider-chest": {
+            "type": "logistic-container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "agricultural-tower": {
+            "type": "agricultural-tower",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "arithmetic-combinator": {
+            "type": "arithmetic-combinator",
+            "gameTiles": [1, 2],
+            "editorTiles": [1, 2],
+            "collisionBox": [-0.34765625, -0.6484375, 0.34765625, 0.6484375],
+            "declaredInDataJson": false
+        },
+        "artillery-turret": {
+            "type": "artillery-turret",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "artillery-wagon": {
+            "type": "artillery-wagon",
+            "gameTiles": [2, 5],
+            "editorTiles": [2, 5],
+            "collisionBox": [-0.59765625, -2.3984375, 0.59765625, 2.3984375],
+            "declaredInDataJson": false
+        },
+        "assembling-machine-1": {
+            "type": "assembling-machine",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "assembling-machine-2": {
+            "type": "assembling-machine",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "assembling-machine-3": {
+            "type": "assembling-machine",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "asteroid-collector": {
+            "type": "asteroid-collector",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": true
+        },
+        "beacon": {
+            "type": "beacon",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "big-electric-pole": {
+            "type": "electric-pole",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.6484375, -0.6484375, 0.6484375, 0.6484375],
+            "declaredInDataJson": false
+        },
+        "big-mining-drill": {
+            "type": "mining-drill",
+            "gameTiles": [5, 5],
+            "editorTiles": [5, 5],
+            "collisionBox": [-2.34765625, -2.34765625, 2.34765625, 2.34765625],
+            "declaredInDataJson": false
+        },
+        "biochamber": {
+            "type": "assembling-machine",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "biolab": {
+            "type": "lab",
+            "gameTiles": [5, 5],
+            "editorTiles": [5, 5],
+            "collisionBox": [-2.19921875, -2.19921875, 2.19921875, 2.19921875],
+            "declaredInDataJson": false
+        },
+        "blue-chest": {
+            "type": "container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "boiler": {
+            "type": "boiler",
+            "gameTiles": [3, 2],
+            "editorTiles": [3, 2],
+            "collisionBox": [-1.2890625, -0.7890625, 1.2890625, 0.7890625],
+            "declaredInDataJson": false
+        },
+        "bottomless-chest": {
+            "type": "container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "buffer-chest": {
+            "type": "logistic-container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "bulk-inserter": {
+            "type": "inserter",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.1484375, -0.1484375, 0.1484375, 0.1484375],
+            "declaredInDataJson": false
+        },
+        "burner-generator": {
+            "type": "burner-generator",
+            "gameTiles": [3, 5],
+            "editorTiles": [3, 5],
+            "collisionBox": [-1.34765625, -2.34765625, 1.34765625, 2.34765625],
+            "declaredInDataJson": false
+        },
+        "burner-inserter": {
+            "type": "inserter",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.1484375, -0.1484375, 0.1484375, 0.1484375],
+            "declaredInDataJson": false
+        },
+        "burner-mining-drill": {
+            "type": "mining-drill",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.69921875, -0.69921875, 0.69921875, 0.69921875],
+            "declaredInDataJson": false
+        },
+        "captive-biter-spawner": {
+            "type": "assembling-machine",
+            "gameTiles": [5, 5],
+            "editorTiles": [5, 5],
+            "collisionBox": [-2.19921875, -2.19921875, 2.19921875, 2.19921875],
+            "declaredInDataJson": false
+        },
+        "cargo-bay": {
+            "type": "cargo-bay",
+            "gameTiles": [4, 4],
+            "editorTiles": [4, 4],
+            "collisionBox": [-1.8984375, -1.8984375, 1.8984375, 1.8984375],
+            "declaredInDataJson": false
+        },
+        "cargo-landing-pad": {
+            "type": "cargo-landing-pad",
+            "gameTiles": [8, 8],
+            "editorTiles": [8, 8],
+            "collisionBox": [-3.8984375, -3.8984375, 3.8984375, 3.8984375],
+            "declaredInDataJson": false
+        },
+        "cargo-pod-container": {
+            "type": "temporary-container",
+            "gameTiles": [1, 2],
+            "editorTiles": [1, 2],
+            "collisionBox": [-0.5, 0, 0.5, 1.296875],
+            "declaredInDataJson": false
+        },
+        "cargo-wagon": {
+            "type": "cargo-wagon",
+            "gameTiles": [2, 5],
+            "editorTiles": [2, 5],
+            "collisionBox": [-0.59765625, -2.3984375, 0.59765625, 2.3984375],
+            "declaredInDataJson": false
+        },
+        "centrifuge": {
+            "type": "assembling-machine",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "chemical-plant": {
+            "type": "assembling-machine",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "constant-combinator": {
+            "type": "constant-combinator",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "crash-site-chest-1": {
+            "type": "container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "crash-site-chest-2": {
+            "type": "container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "crusher": {
+            "type": "assembling-machine",
+            "gameTiles": [2, 3],
+            "editorTiles": [2, 3],
+            "collisionBox": [-0.69921875, -1.19921875, 0.69921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "cryogenic-plant": {
+            "type": "assembling-machine",
+            "gameTiles": [5, 5],
+            "editorTiles": [5, 5],
+            "collisionBox": [-2.3984375, -2.3984375, 2.3984375, 2.3984375],
+            "declaredInDataJson": false
+        },
+        "curved-rail-a": {
+            "type": "curved-rail-a",
+            "gameTiles": [2, 4],
+            "editorTiles": [2, 6],
+            "collisionBox": [-0.69921875, -2.515625, 0.69921875, 2.515625],
+            "declaredInDataJson": false
+        },
+        "curved-rail-b": {
+            "type": "curved-rail-b",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 5],
+            "collisionBox": [-0.69921875, -2.4375, 0.69921875, 2.4375],
+            "declaredInDataJson": false
+        },
+        "decider-combinator": {
+            "type": "decider-combinator",
+            "gameTiles": [1, 2],
+            "editorTiles": [1, 2],
+            "collisionBox": [-0.34765625, -0.6484375, 0.34765625, 0.6484375],
+            "declaredInDataJson": false
+        },
+        "display-panel": {
+            "type": "display-panel",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.2890625, -0.2890625, 0.2890625, 0.2890625],
+            "declaredInDataJson": false
+        },
+        "dummy-elevated-curved-rail-a": {
+            "type": "elevated-curved-rail-a",
+            "gameTiles": [2, 4],
+            "editorTiles": [2, 6],
+            "collisionBox": [-0.69921875, -2.515625, 0.69921875, 2.515625],
+            "declaredInDataJson": false
+        },
+        "dummy-elevated-curved-rail-b": {
+            "type": "elevated-curved-rail-b",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 5],
+            "collisionBox": [-0.69921875, -2.4375, 0.69921875, 2.4375],
+            "declaredInDataJson": false
+        },
+        "dummy-elevated-half-diagonal-rail": {
+            "type": "elevated-half-diagonal-rail",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.75, -1.8984375, 0.75, 1.8984375],
+            "declaredInDataJson": false
+        },
+        "dummy-elevated-straight-rail": {
+            "type": "elevated-straight-rail",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.69921875, -0.98828125, 0.69921875, 0.98828125],
+            "declaredInDataJson": false
+        },
+        "dummy-rail-ramp": {
+            "type": "rail-ramp",
+            "gameTiles": [2, 16],
+            "editorTiles": [4, 16],
+            "collisionBox": [-1.59765625, -7.59765625, 1.59765625, 7.59765625],
+            "declaredInDataJson": false
+        },
+        "dummy-rail-support": {
+            "type": "rail-support",
+            "gameTiles": [4, 2],
+            "editorTiles": [4, 2],
+            "collisionBox": [-1.796875, -0.796875, 1.796875, 0.796875],
+            "declaredInDataJson": false
+        },
+        "electric-energy-interface": {
+            "type": "electric-energy-interface",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.8984375, -0.8984375, 0.8984375, 0.8984375],
+            "declaredInDataJson": false
+        },
+        "electric-furnace": {
+            "type": "furnace",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "electric-mining-drill": {
+            "type": "mining-drill",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.34765625, -1.34765625, 1.34765625, 1.34765625],
+            "declaredInDataJson": false
+        },
+        "electromagnetic-plant": {
+            "type": "assembling-machine",
+            "gameTiles": [4, 4],
+            "editorTiles": [4, 4],
+            "collisionBox": [-1.69921875, -1.69921875, 1.69921875, 1.69921875],
+            "declaredInDataJson": false
+        },
+        "elevated-curved-rail-a": {
+            "type": "elevated-curved-rail-a",
+            "gameTiles": [2, 4],
+            "editorTiles": [2, 6],
+            "collisionBox": [-0.69921875, -2.515625, 0.69921875, 2.515625],
+            "declaredInDataJson": false
+        },
+        "elevated-curved-rail-b": {
+            "type": "elevated-curved-rail-b",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 5],
+            "collisionBox": [-0.69921875, -2.4375, 0.69921875, 2.4375],
+            "declaredInDataJson": false
+        },
+        "elevated-half-diagonal-rail": {
+            "type": "elevated-half-diagonal-rail",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.75, -1.8984375, 0.75, 1.8984375],
+            "declaredInDataJson": false
+        },
+        "elevated-straight-rail": {
+            "type": "elevated-straight-rail",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.69921875, -0.98828125, 0.69921875, 0.98828125],
+            "declaredInDataJson": false
+        },
+        "express-loader": {
+            "type": "loader",
+            "gameTiles": [1, 2],
+            "editorTiles": [1, 2],
+            "collisionBox": [-0.3984375, -0.8984375, 0.3984375, 0.8984375],
+            "declaredInDataJson": false
+        },
+        "express-splitter": {
+            "type": "splitter",
+            "gameTiles": [2, 1],
+            "editorTiles": [2, 1],
+            "collisionBox": [-0.8984375, -0.3984375, 0.8984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "express-transport-belt": {
+            "type": "transport-belt",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "express-underground-belt": {
+            "type": "underground-belt",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "factorio-logo-11tiles": {
+            "type": "container",
+            "gameTiles": [11, 2],
+            "editorTiles": [11, 2],
+            "collisionBox": [-5.34765625, -0.84765625, 5.34765625, 0.84765625],
+            "declaredInDataJson": false
+        },
+        "factorio-logo-16tiles": {
+            "type": "container",
+            "gameTiles": [16, 2],
+            "editorTiles": [16, 2],
+            "collisionBox": [-7.84765625, -0.84765625, 7.84765625, 0.84765625],
+            "declaredInDataJson": false
+        },
+        "factorio-logo-22tiles": {
+            "type": "container",
+            "gameTiles": [22, 3],
+            "editorTiles": [22, 3],
+            "collisionBox": [-10.84765625, -1.34765625, 10.84765625, 1.34765625],
+            "declaredInDataJson": false
+        },
+        "fast-inserter": {
+            "type": "inserter",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.1484375, -0.1484375, 0.1484375, 0.1484375],
+            "declaredInDataJson": false
+        },
+        "fast-loader": {
+            "type": "loader",
+            "gameTiles": [1, 2],
+            "editorTiles": [1, 2],
+            "collisionBox": [-0.3984375, -0.8984375, 0.3984375, 0.8984375],
+            "declaredInDataJson": false
+        },
+        "fast-splitter": {
+            "type": "splitter",
+            "gameTiles": [2, 1],
+            "editorTiles": [2, 1],
+            "collisionBox": [-0.8984375, -0.3984375, 0.8984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "fast-transport-belt": {
+            "type": "transport-belt",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "fast-underground-belt": {
+            "type": "underground-belt",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "flamethrower-turret": {
+            "type": "fluid-turret",
+            "gameTiles": [2, 3],
+            "editorTiles": [2, 3],
+            "collisionBox": [-0.69921875, -1.19921875, 0.69921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "fluid-wagon": {
+            "type": "fluid-wagon",
+            "gameTiles": [2, 5],
+            "editorTiles": [2, 5],
+            "collisionBox": [-0.59765625, -2.3984375, 0.59765625, 2.3984375],
+            "declaredInDataJson": false
+        },
+        "foundry": {
+            "type": "assembling-machine",
+            "gameTiles": [5, 5],
+            "editorTiles": [5, 5],
+            "collisionBox": [-2.19921875, -2.19921875, 2.19921875, 2.19921875],
+            "declaredInDataJson": false
+        },
+        "fulgoran-ruin-attractor": {
+            "type": "lightning-attractor",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.20703125, -1.20703125, 1.20703125, 1.20703125],
+            "declaredInDataJson": false
+        },
+        "fusion-generator": {
+            "type": "fusion-generator",
+            "gameTiles": [3, 5],
+            "editorTiles": [3, 5],
+            "collisionBox": [-1.3984375, -2.3984375, 1.3984375, 2.3984375],
+            "declaredInDataJson": false
+        },
+        "fusion-reactor": {
+            "type": "fusion-reactor",
+            "gameTiles": [6, 6],
+            "editorTiles": [6, 6],
+            "collisionBox": [-2.8984375, -2.8984375, 2.8984375, 2.8984375],
+            "declaredInDataJson": false
+        },
+        "gate": {
+            "type": "gate",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.2890625, -0.2890625, 0.2890625, 0.2890625],
+            "declaredInDataJson": false
+        },
+        "gun-turret": {
+            "type": "ammo-turret",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.69921875, -0.69921875, 0.69921875, 0.69921875],
+            "declaredInDataJson": false
+        },
+        "half-diagonal-rail": {
+            "type": "half-diagonal-rail",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.75, -1.8984375, 0.75, 1.8984375],
+            "declaredInDataJson": false
+        },
+        "heat-exchanger": {
+            "type": "boiler",
+            "gameTiles": [3, 2],
+            "editorTiles": [3, 2],
+            "collisionBox": [-1.2890625, -0.7890625, 1.2890625, 0.7890625],
+            "declaredInDataJson": false
+        },
+        "heat-interface": {
+            "type": "heat-interface",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "heat-pipe": {
+            "type": "heat-pipe",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.296875, -0.296875, 0.296875, 0.296875],
+            "declaredInDataJson": false
+        },
+        "heating-tower": {
+            "type": "reactor",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.25, -1.25, 1.25, 1.25],
+            "declaredInDataJson": false
+        },
+        "hidden-electric-energy-interface": {
+            "type": "electric-energy-interface",
+            "gameTiles": [0, 0],
+            "editorTiles": [0, 0],
+            "collisionBox": [0, 0, 0, 0],
+            "declaredInDataJson": false
+        },
+        "infinity-cargo-wagon": {
+            "type": "infinity-cargo-wagon",
+            "gameTiles": [2, 5],
+            "editorTiles": [2, 5],
+            "collisionBox": [-0.59765625, -2.3984375, 0.59765625, 2.3984375],
+            "declaredInDataJson": false
+        },
+        "infinity-chest": {
+            "type": "infinity-container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "infinity-pipe": {
+            "type": "infinity-pipe",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.2890625, -0.2890625, 0.2890625, 0.2890625],
+            "declaredInDataJson": false
+        },
+        "inserter": {
+            "type": "inserter",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.1484375, -0.1484375, 0.1484375, 0.1484375],
+            "declaredInDataJson": false
+        },
+        "iron-chest": {
+            "type": "container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "lab": {
+            "type": "lab",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "land-mine": {
+            "type": "land-mine",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "lane-splitter": {
+            "type": "lane-splitter",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "laser-turret": {
+            "type": "electric-turret",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.69921875, -0.69921875, 0.69921875, 0.69921875],
+            "declaredInDataJson": false
+        },
+        "legacy-curved-rail": {
+            "type": "legacy-curved-rail",
+            "gameTiles": [4, 8],
+            "editorTiles": [4, 4],
+            "collisionBox": [-0.75, -0.546875, 0.75, 1.59765625],
+            "declaredInDataJson": false
+        },
+        "legacy-straight-rail": {
+            "type": "legacy-straight-rail",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.69921875, -0.98828125, 0.69921875, 0.98828125],
+            "declaredInDataJson": false
+        },
+        "lightning-collector": {
+            "type": "lightning-attractor",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.69921875, -0.69921875, 0.69921875, 0.69921875],
+            "declaredInDataJson": false
+        },
+        "lightning-rod": {
+            "type": "lightning-attractor",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.1484375, -0.1484375, 0.1484375, 0.1484375],
+            "declaredInDataJson": false
+        },
+        "linked-belt": {
+            "type": "linked-belt",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "linked-chest": {
+            "type": "linked-container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "loader": {
+            "type": "loader",
+            "gameTiles": [1, 2],
+            "editorTiles": [1, 2],
+            "collisionBox": [-0.3984375, -0.8984375, 0.3984375, 0.8984375],
+            "declaredInDataJson": false
+        },
+        "loader-1x1": {
+            "type": "loader-1x1",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "locomotive": {
+            "type": "locomotive",
+            "gameTiles": [2, 6],
+            "editorTiles": [2, 6],
+            "collisionBox": [-0.59765625, -2.59765625, 0.59765625, 2.59765625],
+            "declaredInDataJson": false
+        },
+        "long-handed-inserter": {
+            "type": "inserter",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.1484375, -0.1484375, 0.1484375, 0.1484375],
+            "declaredInDataJson": false
+        },
+        "market": {
+            "type": "market",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.3984375, -1.3984375, 1.3984375, 1.3984375],
+            "declaredInDataJson": false
+        },
+        "medium-electric-pole": {
+            "type": "electric-pole",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.1484375, -0.1484375, 0.1484375, 0.1484375],
+            "declaredInDataJson": false
+        },
+        "nuclear-reactor": {
+            "type": "reactor",
+            "gameTiles": [5, 5],
+            "editorTiles": [5, 5],
+            "collisionBox": [-2.19921875, -2.19921875, 2.19921875, 2.19921875],
+            "declaredInDataJson": false
+        },
+        "offshore-pump": {
+            "type": "offshore-pump",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.59765625, -1.046875, 0.59765625, 0.296875],
+            "declaredInDataJson": true
+        },
+        "oil-refinery": {
+            "type": "assembling-machine",
+            "gameTiles": [5, 5],
+            "editorTiles": [5, 5],
+            "collisionBox": [-2.3984375, -2.3984375, 2.3984375, 2.3984375],
+            "declaredInDataJson": false
+        },
+        "one-way-valve": {
+            "type": "valve",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "overflow-valve": {
+            "type": "valve",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "passive-provider-chest": {
+            "type": "logistic-container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "pipe": {
+            "type": "pipe",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.2890625, -0.2890625, 0.2890625, 0.2890625],
+            "declaredInDataJson": false
+        },
+        "pipe-to-ground": {
+            "type": "pipe-to-ground",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.2890625, -0.2890625, 0.2890625, 0.19921875],
+            "declaredInDataJson": false
+        },
+        "power-switch": {
+            "type": "power-switch",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.69921875, -0.69921875, 0.69921875, 0.69921875],
+            "declaredInDataJson": false
+        },
+        "programmable-speaker": {
+            "type": "programmable-speaker",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.296875, -0.296875, 0.296875, 0.296875],
+            "declaredInDataJson": false
+        },
+        "proxy-container": {
+            "type": "proxy-container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "pump": {
+            "type": "pump",
+            "gameTiles": [1, 2],
+            "editorTiles": [1, 2],
+            "collisionBox": [-0.2890625, -0.8984375, 0.2890625, 0.8984375],
+            "declaredInDataJson": false
+        },
+        "pumpjack": {
+            "type": "mining-drill",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "radar": {
+            "type": "radar",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "rail-chain-signal": {
+            "type": "rail-chain-signal",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.19921875, -0.19921875, 0.19921875, 0.19921875],
+            "declaredInDataJson": false
+        },
+        "rail-ramp": {
+            "type": "rail-ramp",
+            "gameTiles": [2, 16],
+            "editorTiles": [4, 16],
+            "collisionBox": [-1.59765625, -7.59765625, 1.59765625, 7.59765625],
+            "declaredInDataJson": false
+        },
+        "rail-signal": {
+            "type": "rail-signal",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.19921875, -0.19921875, 0.19921875, 0.19921875],
+            "declaredInDataJson": false
+        },
+        "rail-support": {
+            "type": "rail-support",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.38671875, -1.38671875, 1.38671875, 1.38671875],
+            "declaredInDataJson": false
+        },
+        "railgun-turret": {
+            "type": "ammo-turret",
+            "gameTiles": [3, 5],
+            "editorTiles": [3, 5],
+            "collisionBox": [-1.40625, -1.8984375, 1.40625, 2.09765625],
+            "declaredInDataJson": false
+        },
+        "recycler": {
+            "type": "furnace",
+            "gameTiles": [2, 4],
+            "editorTiles": [2, 4],
+            "collisionBox": [-0.69921875, -1.69921875, 0.69921875, 1.69921875],
+            "declaredInDataJson": false
+        },
+        "red-chest": {
+            "type": "container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "requester-chest": {
+            "type": "logistic-container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "roboport": {
+            "type": "roboport",
+            "gameTiles": [4, 4],
+            "editorTiles": [4, 4],
+            "collisionBox": [-1.69921875, -1.69921875, 1.69921875, 1.69921875],
+            "declaredInDataJson": false
+        },
+        "rocket-silo": {
+            "type": "rocket-silo",
+            "gameTiles": [9, 9],
+            "editorTiles": [9, 9],
+            "collisionBox": [-4.19921875, -4.19921875, 4.19921875, 4.19921875],
+            "declaredInDataJson": false
+        },
+        "rocket-turret": {
+            "type": "ammo-turret",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.19921875, -1.19921875, 1.19921875, 1.19921875],
+            "declaredInDataJson": false
+        },
+        "selector-combinator": {
+            "type": "selector-combinator",
+            "gameTiles": [1, 2],
+            "editorTiles": [1, 2],
+            "collisionBox": [-0.34765625, -0.6484375, 0.34765625, 0.6484375],
+            "declaredInDataJson": false
+        },
+        "simple-entity-with-force": {
+            "type": "simple-entity-with-force",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "simple-entity-with-owner": {
+            "type": "simple-entity-with-owner",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "small-electric-pole": {
+            "type": "electric-pole",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.1484375, -0.1484375, 0.1484375, 0.1484375],
+            "declaredInDataJson": false
+        },
+        "small-lamp": {
+            "type": "lamp",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.1484375, -0.1484375, 0.1484375, 0.1484375],
+            "declaredInDataJson": false
+        },
+        "solar-panel": {
+            "type": "solar-panel",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.3984375, -1.3984375, 1.3984375, 1.3984375],
+            "declaredInDataJson": false
+        },
+        "space-platform-hub": {
+            "type": "space-platform-hub",
+            "gameTiles": [8, 8],
+            "editorTiles": [8, 8],
+            "collisionBox": [-3.8984375, -3.8984375, 3.8984375, 3.8984375],
+            "declaredInDataJson": false
+        },
+        "splitter": {
+            "type": "splitter",
+            "gameTiles": [2, 1],
+            "editorTiles": [2, 1],
+            "collisionBox": [-0.8984375, -0.3984375, 0.8984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "stack-inserter": {
+            "type": "inserter",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.1484375, -0.1484375, 0.1484375, 0.1484375],
+            "declaredInDataJson": false
+        },
+        "steam-engine": {
+            "type": "generator",
+            "gameTiles": [3, 5],
+            "editorTiles": [3, 5],
+            "collisionBox": [-1.25, -2.34765625, 1.25, 2.34765625],
+            "declaredInDataJson": false
+        },
+        "steam-turbine": {
+            "type": "generator",
+            "gameTiles": [3, 5],
+            "editorTiles": [3, 5],
+            "collisionBox": [-1.25, -2.34765625, 1.25, 2.34765625],
+            "declaredInDataJson": false
+        },
+        "steel-chest": {
+            "type": "container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "steel-furnace": {
+            "type": "furnace",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.69921875, -0.69921875, 0.69921875, 0.69921875],
+            "declaredInDataJson": false
+        },
+        "stone-furnace": {
+            "type": "furnace",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.69921875, -0.69921875, 0.69921875, 0.69921875],
+            "declaredInDataJson": false
+        },
+        "stone-wall": {
+            "type": "wall",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.2890625, -0.2890625, 0.2890625, 0.2890625],
+            "declaredInDataJson": false
+        },
+        "storage-chest": {
+            "type": "logistic-container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        },
+        "storage-tank": {
+            "type": "storage-tank",
+            "gameTiles": [3, 3],
+            "editorTiles": [3, 3],
+            "collisionBox": [-1.296875, -1.296875, 1.296875, 1.296875],
+            "declaredInDataJson": false
+        },
+        "straight-rail": {
+            "type": "straight-rail",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.69921875, -0.98828125, 0.69921875, 0.98828125],
+            "declaredInDataJson": false
+        },
+        "substation": {
+            "type": "electric-pole",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.69921875, -0.69921875, 0.69921875, 0.69921875],
+            "declaredInDataJson": false
+        },
+        "tesla-turret": {
+            "type": "electric-turret",
+            "gameTiles": [4, 4],
+            "editorTiles": [4, 4],
+            "collisionBox": [-1.69921875, -1.69921875, 1.69921875, 1.69921875],
+            "declaredInDataJson": false
+        },
+        "thruster": {
+            "type": "thruster",
+            "gameTiles": [4, 5],
+            "editorTiles": [4, 5],
+            "collisionBox": [-1.69921875, -2.19921875, 1.69921875, 2.19921875],
+            "declaredInDataJson": false
+        },
+        "top-up-valve": {
+            "type": "valve",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "train-stop": {
+            "type": "train-stop",
+            "gameTiles": [2, 2],
+            "editorTiles": [2, 2],
+            "collisionBox": [-0.5, -0.5, 0.5, 0.5],
+            "declaredInDataJson": true
+        },
+        "transport-belt": {
+            "type": "transport-belt",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "turbo-loader": {
+            "type": "loader",
+            "gameTiles": [1, 2],
+            "editorTiles": [1, 2],
+            "collisionBox": [-0.3984375, -0.8984375, 0.3984375, 0.8984375],
+            "declaredInDataJson": false
+        },
+        "turbo-splitter": {
+            "type": "splitter",
+            "gameTiles": [2, 1],
+            "editorTiles": [2, 1],
+            "collisionBox": [-0.8984375, -0.3984375, 0.8984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "turbo-transport-belt": {
+            "type": "transport-belt",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "turbo-underground-belt": {
+            "type": "underground-belt",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "underground-belt": {
+            "type": "underground-belt",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.3984375, -0.3984375, 0.3984375, 0.3984375],
+            "declaredInDataJson": false
+        },
+        "wooden-chest": {
+            "type": "container",
+            "gameTiles": [1, 1],
+            "editorTiles": [1, 1],
+            "collisionBox": [-0.34765625, -0.34765625, 0.34765625, 0.34765625],
+            "declaredInDataJson": false
+        }
+    },
+    "errors": []
+}

--- a/tools/oracle/probe-entity-tile-size.mjs
+++ b/tools/oracle/probe-entity-tile-size.mjs
@@ -1,0 +1,434 @@
+/*
+    Issue #142. `PositionGrid` keys integer tiles from `getEntitySize`, which is
+    `e.tile_width || Math.ceil(collision box width)`. The game publishes its own
+    `tile_width`/`tile_height`, and #133 item 1 found the two disagree for every
+    curved rail type - but that was a side observation off a placement probe,
+    over ten prototypes. Nobody has asked the whole table.
+
+    This is the cheapest possible question, per the README: `tile_width` is a
+    read off `prototypes.entity`, with nothing placed, no surface and no
+    `can_place_entity`. It is a **runtime** property of `LuaEntityPrototype`
+    derived by the engine from the collision box, which is why `data.json`
+    carries it for only 3 of 155 entities - those three are the only ones that
+    *declare* it at the data stage. The exporter is not dropping anything; there
+    is nothing at the data stage to drop.
+
+    What it asks:
+
+      1. `tile_width`, `tile_height` and `collision_box` for **every** entity in
+         `prototypes.entity`, not only the rails. The disagreement is a property
+         of how the engine rounds a collision box, so restricting the sweep to
+         the ten prototypes that prompted the issue would answer only whether
+         the rails move, not what else does.
+
+      2. The same, computed the editor's way from `data.json`, for the 155
+         entities the editor knows - so the fixture carries both columns and the
+         disagreement is in the capture rather than in a reader's head. This is
+         the treatment the README asks of any probe comparing the game against
+         the editor's own model, and it is what `probe-rail-occupancy.mjs` does.
+
+    Controls, in the README's sense - each can fail while the hypothesis holds:
+
+      - **Instrument**: the three entities that declare `tile_width` at the data
+        stage (`asteroid-collector`, `offshore-pump`, `train-stop`) must read
+        back the same number at runtime. If they do not, the field being read is
+        not the field `getEntitySize` already consumes and every row below is
+        about something else. This is the control that can genuinely fail: it
+        compares two independent sources of the same quantity.
+      - **Instrument**: the sweep must find more than one distinct `WxH`. A
+        constant would mean the read is not per-prototype, and a table of 1x1s
+        looks exactly like a table of correct 1x1s.
+      - **Coverage**: every entity `data.json` knows must be present in the
+        game's table. A miss means the mod set differs from the one the dataset
+        was exported with, and the comparison column is then about two different
+        games. Reported as a count, and the names are listed.
+      - **Version**: `--cross-check <raw dump>` compares this run against an
+        earlier one from a different binary and reports every entity whose
+        footprint moved. `elevated-rail-collision.json` found a real 2.0.73 /
+        2.1.12 difference (`cargo-bay`), so this is not theoretical - and unlike
+        every earlier probe here, this one can run on a 2.0.x binary, which is
+        the version range the editor actually targets.
+
+    Note `factorio_version` in the mod's `info.json` is **derived from the
+    binary** rather than hardcoded to '2.1' the way every earlier probe here
+    does. A mismatch makes the mod silently skipped with no dump and no message
+    naming the cause, which is the failure mode a 2.0.x run walks straight into.
+
+    Usage: node tools/oracle/probe-entity-tile-size.mjs
+           node tools/oracle/probe-entity-tile-size.mjs --write-fixture && vp check --fix
+
+           # the whole point of this one: the version the editor targets
+           FACTORIO_BIN="/path/to/2.0.77.app/Contents/MacOS/factorio" \
+             node tools/oracle/probe-entity-tile-size.mjs --raw-out /tmp/tile-size-2.0.77.json
+
+           # then stamp the fixture with the cross-version comparison
+           node tools/oracle/probe-entity-tile-size.mjs \
+             --cross-check /tmp/tile-size-2.0.77.json --write-fixture && vp check --fix
+
+    The --fix is not optional if you recapture: vp's formatter collapses short
+    arrays onto one line and JSON.stringify does not.
+*/
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const BIN =
+    process.env.FACTORIO_BIN ??
+    `${process.env.HOME}/Library/Application Support/Steam/steamapps/common/Factorio/factorio.app/Contents/MacOS/factorio`
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO = join(HERE, '..', '..')
+const FIXTURE = join(HERE, 'fixtures', 'entity-tile-size.json')
+const WRITE_FIXTURE = process.argv.includes('--write-fixture')
+
+const flag = name => {
+    const i = process.argv.indexOf(name)
+    return i === -1 ? undefined : process.argv[i + 1]
+}
+const RAW_OUT = flag('--raw-out')
+const CROSS_CHECK = flag('--cross-check')
+
+const MOD = 'bp_entity_tile_size'
+const DUMP = 'entity-tile-size.json'
+
+/*
+    The three entities that carry tile_width in data.json, ie. that declare it
+    at the data stage. Their runtime values must agree with the declared ones or
+    the instrument is reading something else.
+*/
+const DECLARED_IN_DATA = ['asteroid-collector', 'offshore-pump', 'train-stop']
+
+const version = spawnSync(BIN, ['--version'], { encoding: 'utf8' }).stdout ?? ''
+const binaryLine = version.split('\n')[0].trim()
+const binaryVersion = (binaryLine.match(/(\d+)\.(\d+)\.(\d+)/) ?? []).slice(1)
+if (binaryVersion.length !== 3) {
+    console.error(`Could not read a version out of ${BIN}: ${JSON.stringify(binaryLine)}`)
+    process.exit(1)
+}
+/*
+    Derived, not hardcoded. A mod declaring 2.1 against a 2.0.x binary is
+    skipped in silence and the run ends with "No dump" and nothing naming why.
+*/
+const MOD_FACTORIO_VERSION = `${binaryVersion[0]}.${binaryVersion[1]}`
+
+const work = mkdtempSync(join(tmpdir(), 'fbe-oracle-'))
+const writeData = join(work, 'write-data')
+const modDir = join(work, 'mods')
+const modPath = join(modDir, `${MOD}_0.0.1`)
+mkdirSync(writeData, { recursive: true })
+mkdirSync(modPath, { recursive: true })
+
+writeFileSync(
+    join(modPath, 'info.json'),
+    JSON.stringify({
+        name: MOD,
+        version: '0.0.1',
+        title: 'What footprint does the game publish for every entity',
+        author: 'oracle',
+        factorio_version: MOD_FACTORIO_VERSION,
+        dependencies: ['base', 'elevated-rails', 'space-age'],
+    })
+)
+
+writeFileSync(
+    join(modPath, 'control.lua'),
+    `
+local out = {errors = {}, mods = {}, entities = {}, declared = {}, counts = {}}
+
+script.on_init(function()
+  for name, v in pairs(script.active_mods) do out.mods[name] = v end
+
+  local total, sized, nilled, distinct = 0, 0, 0, {}
+  for name, p in pairs(prototypes.entity) do
+    total = total + 1
+    local tw, th = p.tile_width, p.tile_height
+    local cb = p.collision_box
+    out.entities[name] = {
+      type = p.type,
+      tile_width = tw,
+      tile_height = th,
+      collision_box = {
+        cb.left_top.x, cb.left_top.y, cb.right_bottom.x, cb.right_bottom.y,
+      },
+    }
+    if tw == nil or th == nil then
+      nilled = nilled + 1
+    else
+      sized = sized + 1
+      distinct[tw .. "x" .. th] = true
+    end
+  end
+
+  local d = 0
+  for _ in pairs(distinct) do d = d + 1 end
+  out.counts = {total = total, sized = sized, nilled = nilled, distinct_sizes = d}
+
+  -- Instrument control: the three that declare it at the data stage.
+  for _, name in pairs({${DECLARED_IN_DATA.map(n => `"${n}"`).join(', ')}}) do
+    local p = prototypes.entity[name]
+    if p then
+      out.declared[name] = {tile_width = p.tile_width, tile_height = p.tile_height}
+    else
+      out.errors[#out.errors + 1] = "no prototype: " .. name
+    end
+  end
+
+  helpers.write_file("${DUMP}", helpers.table_to_json(out))
+  error("DUMPED-OK")
+end)
+`
+)
+
+writeFileSync(
+    join(work, 'config.ini'),
+    `[path]\nread-data=__PATH__executable__/../data\nwrite-data=${writeData}\n[general]\n[other]\n`
+)
+
+const res = spawnSync(
+    BIN,
+    [
+        '--create',
+        join(work, 'p.zip'),
+        '--mod-directory',
+        modDir,
+        '--config',
+        join(work, 'config.ini'),
+    ],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+)
+
+const dumpPath = join(writeData, 'script-output', DUMP)
+if (!existsSync(dumpPath)) {
+    console.error(
+        `No dump. Mod declared factorio_version ${MOD_FACTORIO_VERSION} against ${binaryLine}.\n` +
+            'Factorio tail:\n' +
+            ((res.stdout ?? '') + (res.stderr ?? '')).slice(-4000)
+    )
+    process.exit(1)
+}
+
+const d = JSON.parse(readFileSync(dumpPath, 'utf8'))
+const list = v => (v === undefined || v === null ? [] : Object.values(v))
+for (const e of list(d.errors)) console.log(`! ${e}`)
+
+console.log(`\n=== binary: ${binaryLine} (mod declared factorio_version ${MOD_FACTORIO_VERSION})`)
+console.log(
+    `=== mods: ${Object.entries(d.mods ?? {})
+        .map(([n, v]) => `${n} ${v}`)
+        .join(', ')}\n`
+)
+
+/* ------------------------------------------------------------------ *
+ * The editor's own rectangle, from the same data.json it loads.       *
+ * ------------------------------------------------------------------ */
+const FD = JSON.parse(
+    readFileSync(join(REPO, 'packages', 'exporter', 'data', 'output', 'data.json'), 'utf8')
+).entities
+
+/** Transcribed from getEntitySize at direction 0, where no width/height swap applies. */
+const editorSize = name => {
+    const e = FD[name]
+    const bb = e.collision_box
+    return {
+        w: e.tile_width || Math.ceil(Math.abs(bb[0][0]) + Math.abs(bb[1][0])),
+        h: e.tile_height || Math.ceil(Math.abs(bb[0][1]) + Math.abs(bb[1][1])),
+        declared: e.tile_width !== undefined && e.tile_height !== undefined,
+    }
+}
+
+const game = d.entities ?? {}
+
+/* ------------------------------------------------------------------ *
+ * Controls                                                            *
+ * ------------------------------------------------------------------ */
+const counts = d.counts ?? {}
+const declaredOk = []
+for (const name of DECLARED_IN_DATA) {
+    const runtime = (d.declared ?? {})[name]
+    const dataStage = FD[name]
+    declaredOk.push({
+        name,
+        dataStage: dataStage ? `${dataStage.tile_width}x${dataStage.tile_height}` : 'ABSENT',
+        runtime: runtime ? `${runtime.tile_width}x${runtime.tile_height}` : 'ABSENT',
+        agrees:
+            !!runtime &&
+            !!dataStage &&
+            runtime.tile_width === dataStage.tile_width &&
+            runtime.tile_height === dataStage.tile_height,
+    })
+}
+
+const known = Object.keys(FD).sort()
+const missingFromGame = known.filter(n => game[n] === undefined)
+
+console.log('=== controls ===')
+console.log(`  entities swept:                        ${counts.total}`)
+console.log(`  with a tile_width and tile_height:     ${counts.sized}`)
+console.log(`  with neither:                          ${counts.nilled}`)
+console.log(
+    `  distinct WxH values:                   ${counts.distinct_sizes}  ${counts.distinct_sizes > 1 ? '(not a constant)' : 'VOID - a constant read says nothing'}`
+)
+for (const c of declaredOk) {
+    console.log(
+        `  declared at the data stage: ${c.name.padEnd(20)} data.json ${c.dataStage.padEnd(5)} runtime ${c.runtime.padEnd(5)} ${c.agrees ? 'agrees' : 'DISAGREES - the instrument is reading a different field'}`
+    )
+}
+console.log(
+    `  data.json entities found in the game:  ${known.length - missingFromGame.length}/${known.length}` +
+        (missingFromGame.length ? `  MISSING: ${missingFromGame.join(', ')}` : '')
+)
+
+/* ------------------------------------------------------------------ *
+ * The comparison                                                      *
+ * ------------------------------------------------------------------ */
+const rows = []
+for (const name of known) {
+    const g = game[name]
+    if (g === undefined) continue
+    const e = editorSize(name)
+    rows.push({
+        name,
+        type: g.type,
+        game: [g.tile_width, g.tile_height],
+        editor: [e.w, e.h],
+        declaredInDataJson: e.declared,
+        agrees: g.tile_width === e.w && g.tile_height === e.h,
+        cellDelta: g.tile_width * g.tile_height - e.w * e.h,
+    })
+}
+
+const disagreements = rows.filter(r => !r.agrees)
+console.log(`\n=== footprint: the game against the editor, over ${rows.length} entities ===`)
+console.log(`  agree:    ${rows.length - disagreements.length}`)
+console.log(`  disagree: ${disagreements.length}`)
+if (disagreements.length) {
+    console.log(
+        `\n  ${'entity'.padEnd(30)} ${'type'.padEnd(24)} ${'game'.padEnd(7)} ${'editor'.padEnd(7)} cells`
+    )
+    for (const r of disagreements.sort(
+        (a, b) => b.cellDelta - a.cellDelta || a.name.localeCompare(b.name)
+    )) {
+        console.log(
+            `  ${r.name.padEnd(30)} ${r.type.padEnd(24)} ${`${r.game[0]}x${r.game[1]}`.padEnd(7)} ${`${r.editor[0]}x${r.editor[1]}`.padEnd(7)} ${r.cellDelta > 0 ? '+' : ''}${r.cellDelta}`
+        )
+    }
+}
+
+/* ------------------------------------------------------------------ *
+ * Cross-version                                                       *
+ * ------------------------------------------------------------------ */
+let versionDifferences
+if (CROSS_CHECK !== undefined) {
+    const other = JSON.parse(readFileSync(resolve(CROSS_CHECK), 'utf8'))
+    const otherEntities = other.entities ?? {}
+    const otherLine = other.binary ?? '(unstamped)'
+    const moved = []
+    const onlyHere = []
+    const onlyThere = []
+    for (const [name, g] of Object.entries(game)) {
+        const o = otherEntities[name]
+        if (o === undefined) {
+            onlyHere.push(name)
+            continue
+        }
+        if (g.tile_width !== o.tile_width || g.tile_height !== o.tile_height) {
+            moved.push({
+                name,
+                type: g.type,
+                [binaryLine]: [g.tile_width, g.tile_height],
+                [otherLine]: [o.tile_width, o.tile_height],
+            })
+        }
+    }
+    for (const name of Object.keys(otherEntities))
+        if (game[name] === undefined) onlyThere.push(name)
+
+    versionDifferences = {
+        against: otherLine,
+        entitiesCompared: Object.keys(game).filter(n => otherEntities[n] !== undefined).length,
+        footprintsThatMoved: moved,
+        onlyIn: { [binaryLine]: onlyHere.sort(), [otherLine]: onlyThere.sort() },
+    }
+
+    console.log(`\n=== cross-version: ${binaryLine} against ${otherLine} ===`)
+    console.log(`  compared:              ${versionDifferences.entitiesCompared}`)
+    console.log(`  footprints that moved: ${moved.length}`)
+    for (const m of moved)
+        console.log(
+            `    ${m.name.padEnd(30)} ${binaryLine}: ${m[binaryLine].join('x')}   ${otherLine}: ${m[otherLine].join('x')}`
+        )
+    console.log(
+        `  only in ${binaryLine}: ${onlyHere.length}${onlyHere.length ? ` (${onlyHere.slice(0, 8).join(', ')}${onlyHere.length > 8 ? ', ...' : ''})` : ''}`
+    )
+    console.log(
+        `  only in ${otherLine}: ${onlyThere.length}${onlyThere.length ? ` (${onlyThere.slice(0, 8).join(', ')}${onlyThere.length > 8 ? ', ...' : ''})` : ''}`
+    )
+}
+
+/* ------------------------------------------------------------------ *
+ * Output                                                              *
+ * ------------------------------------------------------------------ */
+const raw = RAW_OUT === undefined ? join(work, 'entity-tile-size.json') : resolve(RAW_OUT)
+writeFileSync(raw, JSON.stringify({ binary: binaryLine, ...d }, null, 2))
+console.log(`\nraw: ${raw}`)
+
+if (WRITE_FIXTURE) {
+    /* Only the entities the editor knows. The full table is in the raw dump. */
+    const entities = {}
+    for (const r of rows) {
+        const g = game[r.name]
+        entities[r.name] = {
+            type: r.type,
+            gameTiles: r.game,
+            editorTiles: r.editor,
+            collisionBox: g.collision_box,
+            declaredInDataJson: r.declaredInDataJson,
+        }
+    }
+
+    const fixture = {
+        question:
+            'What tile_width/tile_height does the game publish for every entity, and where does that disagree with the rectangle getEntitySize computes from the collision box?',
+        issue: 142,
+        probe: 'tools/oracle/probe-entity-tile-size.mjs',
+        binary: binaryLine,
+        mods: d.mods,
+        versionNote:
+            'Captured on a binary in the 2.0.x range this editor targets (2.0.45 to 2.0.73), unlike every earlier fixture here, which came from 2.1.12. The mod declares factorio_version derived from the binary; hardcoding 2.1 makes a 2.0.x run produce no dump and no message saying why.',
+        measurementCaveats: [
+            'tile_width/tile_height are runtime properties of LuaEntityPrototype, derived by the engine from the collision box. They are not available at the data stage, which is why data.json carries them for only 3 of 155 entities - those three declare them - and why the exporter is not dropping anything.',
+            'editorTiles is computed on this side from packages/exporter/data/output/data.json, mirroring getEntitySize at direction 0, because the question is what the editor computes rather than what the game collides with. The width/height swap getEntitySize applies at directions 4 and 12 is orthogonal and is not captured here.',
+            'This is the published footprint, not occupancy. #133 item 1 measured that a rail blocks cells no rectangle of any size describes, and that the answer depends on the size of the box asking. A correct rectangle is still a rectangle.',
+            'The fixture lists only the 155 entities data.json knows. The game table is larger; the full sweep is summarised in counts and kept in the raw dump.',
+        ],
+        controls: {
+            note: 'Each of these can fail while the hypothesis holds.',
+            entitiesSwept: counts.total,
+            withAFootprint: counts.sized,
+            withoutOne: counts.nilled,
+            distinctFootprints: counts.distinct_sizes,
+            declaredAtTheDataStageAgreesWithRuntime: declaredOk,
+            dataJsonEntitiesMissingFromTheGameTable: missingFromGame,
+        },
+        summary: {
+            compared: rows.length,
+            agree: rows.length - disagreements.length,
+            disagree: disagreements.length,
+            disagreeing: disagreements.map(r => ({
+                name: r.name,
+                type: r.type,
+                gameTiles: r.game,
+                editorTiles: r.editor,
+                cellDelta: r.cellDelta,
+            })),
+        },
+        versionDifferences,
+        entities,
+        errors: list(d.errors),
+    }
+    writeFileSync(FIXTURE, JSON.stringify(fixture, null, 4) + '\n')
+    console.log(`\nwrote ${FIXTURE}`)
+    console.log('now run: vp check --fix')
+}


### PR DESCRIPTION
Closes #142 by measuring it. No editor source changes - the measurement says the change should not be made.

## What was asked

Make the editor's footprints agree with the game's own `tile_width`/`tile_height`, starting with a probe. `getEntitySize` already reads `e.tile_width || Math.ceil(collision box)`, so supplying the value was meant to be the entire job.

## What the game said

`tools/oracle/probe-entity-tile-size.mjs` reads `tile_width`/`tile_height`/`collision_box` off `prototypes.entity` for all 1016 entities - the cheapest possible question, nothing placed, no surface, no `can_place_entity`. All four controls pass, including the one that could genuinely have failed: the three entities that declare `tile_width` at the data stage (`asteroid-collector`, `offshore-pump`, `train-stop`) read back identically at runtime, so the field being read is the field `getEntitySize` already consumes.

**146 of the editor's 155 already agree.** The 9 that differ:

| entity | game | editor | cells |
| --- | --- | --- | --- |
| `legacy-curved-rail` | 4x8 | 4x4 | +16 |
| `curved-rail-a` (+ elevated, + dummy) | 2x4 | 2x6 | -4 |
| `curved-rail-b` (+ elevated, + dummy) | 2x2 | 2x5 | -6 |
| `rail-ramp` (+ dummy) | 2x16 | 4x16 | -32 |

## Why adopting them is wrong

`tile_width` is a **centring parity, not a size**. The runtime docs, one line that settles the issue:

> Specifies the tiling size of the entity, is used to decide, if the center should be in the center of the tile (odd tile size dimension) or on the tile border (even tile size dimension)

It coincides with the enclosing rectangle for the 146 only because most entities are boxes. For **8 of the 9** the published rectangle does not contain the entity's own collision box - `curved-rail-b` is 2x2 against a box 4.88 tiles tall, `rail-ramp` 2x16 against a box 3.6 wide.

Transcribed into the analysis and checked against `fixtures/rail-occupancy.json` **before writing any code** (the #133 item 5 lesson), across all 38 measured orientations:

| | occupied-but-not-keyed | keyed-but-empty |
| --- | --- | --- |
| today | 180 | 96 |
| game's `tile_width` | 188 | 152 |

Worse in both directions. `curved-rail-a` improves by 2 cells of 11 and that is the whole upside; `curved-rail-b` drops from 10 keyed cells to 4 against 14 really blocked, `legacy-curved-rail` doubles to 32 against 18. Since the footprint is also what `getEntityAtPosition` reads, the price is half of `rail-ramp` becoming unclickable.

The real fix for the curved rails is still per-rail measured cell sets - #133 item 1, costed and abandoned as #138.

## What changed

- `tools/oracle/probe-entity-tile-size.mjs`, `tools/oracle/fixtures/entity-tile-size.json` - the capture.
- `tools/oracle/README.md`, `CLAUDE.md` - the finding and three method notes.
- `tests/rail-footprints.spec.ts` - its docstring promised a change that is no longer coming. `tests/__fixtures__/rail-footprints.json` is **untouched**; PR #148's baseline stands as written, now guarding footprints that are staying put rather than waiting on a change.

## Two things worth keeping past this issue

**A mod's `factorio_version` must match the binary, and every earlier probe hardcodes `2.1`** - correct only because 2.1.12 was the only Factorio on the machine. A mismatch is silent: mod skipped, no dump, nothing naming the cause. This one derives it from `factorio --version`, which is the whole of what it took to make the targeted 2.0.x range measurable. This is the **first capture here taken on a 2.0.x binary** (2.0.77 full, base + elevated-rails + quality + space-age).

**The version cross-check found something again, and again it did not matter**: four entities move footprint between 2.0.77 and 2.1.12 - `tree-plant` and the three demolisher corpses - none among the 155.

## Verification

- `vp check` - 209 files formatted, 0 warnings/lint/type errors in 158 files
- `vp test` - 143 passed
- `npx playwright test tests/rail-footprints.spec.ts` - passed, fixture unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBd1VNLFRJTDEMmoCMFz5N