### PR TITLE
#142 follow-up: fold the decisive comparison into the probe

### DIFF
--- a/tools/oracle/README.md
+++ b/tools/oracle/README.md
@@ -157,6 +157,15 @@ model wants the same treatment.
   corruption-class rows, which the re-run caught in eight seconds and no test
   would have suggested. Transcribe the rule into the probe, not only into the
   source.
+- **A transcribed rule needs a coordinate control, not only a logic one.**
+  `probe-entity-tile-size.mjs` compares two candidate footprints against
+  `fixtures/rail-occupancy.json`, whose blocked cells are stored **relative to
+  `floor(position)`** rather than in world coordinates. The first transcription
+  keyed its rectangles absolutely, and both arms inflated together - 440/356
+  against 435/399 - which preserved the verdict and looked entirely plausible.
+  Nothing about the shape of the output said it was wrong. What says so is a row
+  where the answer is known independently: a cardinal `straight-rail` is exact
+  on both arms, so it must come back all zeros, and it is asserted.
 - **Include a control that can invalidate the probe itself.** Not a control for
   the behaviour, one for the measurement. `probe-copy-settings-schedule.mjs` runs
   a case where `copy_settings` is never called, because `create_blueprint` groups

--- a/tools/oracle/fixtures/entity-tile-size.json
+++ b/tools/oracle/fixtures/entity-tile-size.json
@@ -115,6 +115,674 @@
             }
         ]
     },
+    "proposedChangeAgainstMeasuredOccupancy": {
+        "note": "Computed here from fixtures/rail-occupancy.json against the wooden-chest reference, not from this run of the game. It is what decides whether adopting the published numbers is an improvement, and the answer is that it is not.",
+        "orientations": 38,
+        "reference": "wooden-chest",
+        "cellsAreRelativeToFloorOfPosition": true,
+        "alignmentControl": {
+            "note": "A cardinal straight-rail is the one case where both arms and the measurement coincide exactly. Anything but zeros means the coordinate systems are not lined up and the totals are meaningless.",
+            "passes": true
+        },
+        "arms": {
+            "today": {
+                "missed": 180,
+                "empty": 96
+            },
+            "gameTiles": {
+                "missed": 188,
+                "empty": 152
+            }
+        },
+        "perRail": {
+            "straight-rail@0": {
+                "rail": "straight-rail",
+                "direction": 0,
+                "blocked": 4,
+                "today": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 0,
+                    "empty": 0
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 0,
+                    "empty": 0
+                }
+            },
+            "straight-rail@2": {
+                "rail": "straight-rail",
+                "direction": 2,
+                "blocked": 8,
+                "today": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 4,
+                    "empty": 0
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 4,
+                    "empty": 0
+                }
+            },
+            "straight-rail@4": {
+                "rail": "straight-rail",
+                "direction": 4,
+                "blocked": 4,
+                "today": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 0,
+                    "empty": 0
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 0,
+                    "empty": 0
+                }
+            },
+            "straight-rail@6": {
+                "rail": "straight-rail",
+                "direction": 6,
+                "blocked": 8,
+                "today": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 4,
+                    "empty": 0
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 4,
+                    "empty": 0
+                }
+            },
+            "half-diagonal-rail@0": {
+                "rail": "half-diagonal-rail",
+                "direction": 0,
+                "blocked": 12,
+                "today": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 8,
+                    "empty": 0
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 8,
+                    "empty": 0
+                }
+            },
+            "half-diagonal-rail@2": {
+                "rail": "half-diagonal-rail",
+                "direction": 2,
+                "blocked": 12,
+                "today": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 8,
+                    "empty": 0
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 8,
+                    "empty": 0
+                }
+            },
+            "half-diagonal-rail@4": {
+                "rail": "half-diagonal-rail",
+                "direction": 4,
+                "blocked": 12,
+                "today": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 8,
+                    "empty": 0
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 8,
+                    "empty": 0
+                }
+            },
+            "half-diagonal-rail@6": {
+                "rail": "half-diagonal-rail",
+                "direction": 6,
+                "blocked": 12,
+                "today": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 8,
+                    "empty": 0
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 8,
+                    "empty": 0
+                }
+            },
+            "curved-rail-a@0": {
+                "rail": "curved-rail-a",
+                "direction": 0,
+                "blocked": 11,
+                "today": {
+                    "tiles": [2, 6],
+                    "keyed": 12,
+                    "missed": 2,
+                    "empty": 3
+                },
+                "gameTiles": {
+                    "tiles": [2, 4],
+                    "keyed": 8,
+                    "missed": 3,
+                    "empty": 0
+                }
+            },
+            "curved-rail-a@2": {
+                "rail": "curved-rail-a",
+                "direction": 2,
+                "blocked": 11,
+                "today": {
+                    "tiles": [2, 6],
+                    "keyed": 12,
+                    "missed": 2,
+                    "empty": 3
+                },
+                "gameTiles": {
+                    "tiles": [2, 4],
+                    "keyed": 8,
+                    "missed": 3,
+                    "empty": 0
+                }
+            },
+            "curved-rail-a@4": {
+                "rail": "curved-rail-a",
+                "direction": 4,
+                "blocked": 11,
+                "today": {
+                    "tiles": [6, 2],
+                    "keyed": 12,
+                    "missed": 2,
+                    "empty": 3
+                },
+                "gameTiles": {
+                    "tiles": [4, 2],
+                    "keyed": 8,
+                    "missed": 3,
+                    "empty": 0
+                }
+            },
+            "curved-rail-a@6": {
+                "rail": "curved-rail-a",
+                "direction": 6,
+                "blocked": 11,
+                "today": {
+                    "tiles": [6, 2],
+                    "keyed": 12,
+                    "missed": 2,
+                    "empty": 3
+                },
+                "gameTiles": {
+                    "tiles": [4, 2],
+                    "keyed": 8,
+                    "missed": 3,
+                    "empty": 0
+                }
+            },
+            "curved-rail-a@8": {
+                "rail": "curved-rail-a",
+                "direction": 8,
+                "blocked": 11,
+                "today": {
+                    "tiles": [2, 6],
+                    "keyed": 12,
+                    "missed": 2,
+                    "empty": 3
+                },
+                "gameTiles": {
+                    "tiles": [2, 4],
+                    "keyed": 8,
+                    "missed": 3,
+                    "empty": 0
+                }
+            },
+            "curved-rail-a@10": {
+                "rail": "curved-rail-a",
+                "direction": 10,
+                "blocked": 11,
+                "today": {
+                    "tiles": [2, 6],
+                    "keyed": 12,
+                    "missed": 2,
+                    "empty": 3
+                },
+                "gameTiles": {
+                    "tiles": [2, 4],
+                    "keyed": 8,
+                    "missed": 3,
+                    "empty": 0
+                }
+            },
+            "curved-rail-a@12": {
+                "rail": "curved-rail-a",
+                "direction": 12,
+                "blocked": 11,
+                "today": {
+                    "tiles": [6, 2],
+                    "keyed": 12,
+                    "missed": 2,
+                    "empty": 3
+                },
+                "gameTiles": {
+                    "tiles": [4, 2],
+                    "keyed": 8,
+                    "missed": 3,
+                    "empty": 0
+                }
+            },
+            "curved-rail-a@14": {
+                "rail": "curved-rail-a",
+                "direction": 14,
+                "blocked": 11,
+                "today": {
+                    "tiles": [6, 2],
+                    "keyed": 12,
+                    "missed": 2,
+                    "empty": 3
+                },
+                "gameTiles": {
+                    "tiles": [4, 2],
+                    "keyed": 8,
+                    "missed": 3,
+                    "empty": 0
+                }
+            },
+            "curved-rail-b@0": {
+                "rail": "curved-rail-b",
+                "direction": 0,
+                "blocked": 14,
+                "today": {
+                    "tiles": [2, 5],
+                    "keyed": 10,
+                    "missed": 6,
+                    "empty": 2
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 10,
+                    "empty": 0
+                }
+            },
+            "curved-rail-b@2": {
+                "rail": "curved-rail-b",
+                "direction": 2,
+                "blocked": 14,
+                "today": {
+                    "tiles": [2, 5],
+                    "keyed": 10,
+                    "missed": 6,
+                    "empty": 2
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 10,
+                    "empty": 0
+                }
+            },
+            "curved-rail-b@4": {
+                "rail": "curved-rail-b",
+                "direction": 4,
+                "blocked": 14,
+                "today": {
+                    "tiles": [5, 2],
+                    "keyed": 10,
+                    "missed": 7,
+                    "empty": 3
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 10,
+                    "empty": 0
+                }
+            },
+            "curved-rail-b@6": {
+                "rail": "curved-rail-b",
+                "direction": 6,
+                "blocked": 14,
+                "today": {
+                    "tiles": [5, 2],
+                    "keyed": 10,
+                    "missed": 7,
+                    "empty": 3
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 10,
+                    "empty": 0
+                }
+            },
+            "curved-rail-b@8": {
+                "rail": "curved-rail-b",
+                "direction": 8,
+                "blocked": 14,
+                "today": {
+                    "tiles": [2, 5],
+                    "keyed": 10,
+                    "missed": 7,
+                    "empty": 3
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 10,
+                    "empty": 0
+                }
+            },
+            "curved-rail-b@10": {
+                "rail": "curved-rail-b",
+                "direction": 10,
+                "blocked": 14,
+                "today": {
+                    "tiles": [2, 5],
+                    "keyed": 10,
+                    "missed": 7,
+                    "empty": 3
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 10,
+                    "empty": 0
+                }
+            },
+            "curved-rail-b@12": {
+                "rail": "curved-rail-b",
+                "direction": 12,
+                "blocked": 14,
+                "today": {
+                    "tiles": [5, 2],
+                    "keyed": 10,
+                    "missed": 6,
+                    "empty": 2
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 10,
+                    "empty": 0
+                }
+            },
+            "curved-rail-b@14": {
+                "rail": "curved-rail-b",
+                "direction": 14,
+                "blocked": 14,
+                "today": {
+                    "tiles": [5, 2],
+                    "keyed": 10,
+                    "missed": 6,
+                    "empty": 2
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 10,
+                    "empty": 0
+                }
+            },
+            "legacy-straight-rail@0": {
+                "rail": "legacy-straight-rail",
+                "direction": 0,
+                "blocked": 4,
+                "today": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 0,
+                    "empty": 0
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 0,
+                    "empty": 0
+                }
+            },
+            "legacy-straight-rail@2": {
+                "rail": "legacy-straight-rail",
+                "direction": 2,
+                "blocked": 5,
+                "today": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 2,
+                    "empty": 1
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 2,
+                    "empty": 1
+                }
+            },
+            "legacy-straight-rail@4": {
+                "rail": "legacy-straight-rail",
+                "direction": 4,
+                "blocked": 4,
+                "today": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 0,
+                    "empty": 0
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 0,
+                    "empty": 0
+                }
+            },
+            "legacy-straight-rail@6": {
+                "rail": "legacy-straight-rail",
+                "direction": 6,
+                "blocked": 5,
+                "today": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 2,
+                    "empty": 1
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 2,
+                    "empty": 1
+                }
+            },
+            "legacy-straight-rail@10": {
+                "rail": "legacy-straight-rail",
+                "direction": 10,
+                "blocked": 5,
+                "today": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 2,
+                    "empty": 1
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 2,
+                    "empty": 1
+                }
+            },
+            "legacy-straight-rail@14": {
+                "rail": "legacy-straight-rail",
+                "direction": 14,
+                "blocked": 5,
+                "today": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 2,
+                    "empty": 1
+                },
+                "gameTiles": {
+                    "tiles": [2, 2],
+                    "keyed": 4,
+                    "missed": 2,
+                    "empty": 1
+                }
+            },
+            "legacy-curved-rail@0": {
+                "rail": "legacy-curved-rail",
+                "direction": 0,
+                "blocked": 18,
+                "today": {
+                    "tiles": [4, 4],
+                    "keyed": 16,
+                    "missed": 8,
+                    "empty": 6
+                },
+                "gameTiles": {
+                    "tiles": [4, 8],
+                    "keyed": 32,
+                    "missed": 1,
+                    "empty": 15
+                }
+            },
+            "legacy-curved-rail@2": {
+                "rail": "legacy-curved-rail",
+                "direction": 2,
+                "blocked": 18,
+                "today": {
+                    "tiles": [4, 4],
+                    "keyed": 16,
+                    "missed": 8,
+                    "empty": 6
+                },
+                "gameTiles": {
+                    "tiles": [8, 4],
+                    "keyed": 32,
+                    "missed": 8,
+                    "empty": 22
+                }
+            },
+            "legacy-curved-rail@4": {
+                "rail": "legacy-curved-rail",
+                "direction": 4,
+                "blocked": 18,
+                "today": {
+                    "tiles": [4, 4],
+                    "keyed": 16,
+                    "missed": 8,
+                    "empty": 6
+                },
+                "gameTiles": {
+                    "tiles": [8, 4],
+                    "keyed": 32,
+                    "missed": 1,
+                    "empty": 15
+                }
+            },
+            "legacy-curved-rail@6": {
+                "rail": "legacy-curved-rail",
+                "direction": 6,
+                "blocked": 18,
+                "today": {
+                    "tiles": [4, 4],
+                    "keyed": 16,
+                    "missed": 8,
+                    "empty": 6
+                },
+                "gameTiles": {
+                    "tiles": [4, 8],
+                    "keyed": 32,
+                    "missed": 8,
+                    "empty": 22
+                }
+            },
+            "legacy-curved-rail@8": {
+                "rail": "legacy-curved-rail",
+                "direction": 8,
+                "blocked": 18,
+                "today": {
+                    "tiles": [4, 4],
+                    "keyed": 16,
+                    "missed": 8,
+                    "empty": 6
+                },
+                "gameTiles": {
+                    "tiles": [4, 8],
+                    "keyed": 32,
+                    "missed": 1,
+                    "empty": 15
+                }
+            },
+            "legacy-curved-rail@10": {
+                "rail": "legacy-curved-rail",
+                "direction": 10,
+                "blocked": 18,
+                "today": {
+                    "tiles": [4, 4],
+                    "keyed": 16,
+                    "missed": 8,
+                    "empty": 6
+                },
+                "gameTiles": {
+                    "tiles": [8, 4],
+                    "keyed": 32,
+                    "missed": 8,
+                    "empty": 22
+                }
+            },
+            "legacy-curved-rail@12": {
+                "rail": "legacy-curved-rail",
+                "direction": 12,
+                "blocked": 18,
+                "today": {
+                    "tiles": [4, 4],
+                    "keyed": 16,
+                    "missed": 8,
+                    "empty": 6
+                },
+                "gameTiles": {
+                    "tiles": [8, 4],
+                    "keyed": 32,
+                    "missed": 1,
+                    "empty": 15
+                }
+            },
+            "legacy-curved-rail@14": {
+                "rail": "legacy-curved-rail",
+                "direction": 14,
+                "blocked": 18,
+                "today": {
+                    "tiles": [4, 4],
+                    "keyed": 16,
+                    "missed": 8,
+                    "empty": 6
+                },
+                "gameTiles": {
+                    "tiles": [4, 8],
+                    "keyed": 32,
+                    "missed": 8,
+                    "empty": 22
+                }
+            }
+        }
+    },
     "versionDifferences": {
         "against": "Version: 2.1.12 (build 87038, mac-arm64, steam)",
         "entitiesCompared": 1016,

--- a/tools/oracle/probe-entity-tile-size.mjs
+++ b/tools/oracle/probe-entity-tile-size.mjs
@@ -317,6 +317,141 @@ if (disagreements.length) {
 }
 
 /* ------------------------------------------------------------------ *
+ * The proposed rule, checked against every measured row before any    *
+ * code is written. This is the #133 item 5 lesson and it is why this  *
+ * probe ends in "do not implement": adopting the game's numbers is a  *
+ * change to what PositionGrid keys, and fixtures/rail-occupancy.json  *
+ * already holds what the game really blocks around all 38 measured    *
+ * rail orientations. Transcribing the rule here rather than into      *
+ * prose is what keeps the decisive number re-derivable.               *
+ * ------------------------------------------------------------------ */
+const OCCUPANCY = join(HERE, 'fixtures', 'rail-occupancy.json')
+
+/** getEntitySize's width/height swap, which applies to whichever pair of numbers it is given. */
+const swapForDirection = (type, dir, w, h) => {
+    if (w === h) return { x: w, y: h }
+    const dd =
+        type === 'curved-rail-a' || type === 'curved-rail-b'
+            ? Math.floor((dir % 8) / 4) * 4
+            : (Math.round(dir / 4) * 4) % 16
+    return dd === 4 || dd === 12 ? { x: h, y: w } : { x: w, y: h }
+}
+
+/*
+    PositionGrid.processArea, expressed the way rail-occupancy.json expresses a
+    blocked cell: **relative to floor(position)**, not in world coordinates. Get
+    that wrong and both arms inflate together, which looks like a plausible
+    answer rather than like a bug - it read 440/356 against 435/399 on the first
+    run here. The `straight-rail@0` control below is what tells them apart.
+*/
+const keyedCells = (size, px, py) => {
+    const x0 = Math.round(px - size.x / 2)
+    const y0 = Math.round(py - size.y / 2)
+    const out = new Set()
+    for (let x = x0; x < x0 + size.x; x++)
+        for (let y = y0; y < y0 + size.y; y++)
+            out.add(`${x - Math.floor(px)},${y - Math.floor(py)}`)
+    return out
+}
+
+let occupancy
+if (existsSync(OCCUPANCY)) {
+    const occ = JSON.parse(readFileSync(OCCUPANCY, 'utf8'))
+    const arms = { today: { missed: 0, empty: 0 }, gameTiles: { missed: 0, empty: 0 } }
+    const perRail = {}
+
+    for (const r of Object.values(occ.rails)) {
+        /*
+            The wooden-chest reference, which is the one rail-occupancy.json's
+            own summary uses. The four references disagree with each other by
+            design - see the probe-entity note in the README - so a single arm
+            has to name which one it is comparing against.
+        */
+        const chest = Object.values(r.references).find(x => x.reference === 'wooden-chest')
+        if (chest === undefined) continue
+        const blocked = new Set(Object.values(chest.blocked ?? {}).map(c => `${c.x},${c.y}`))
+
+        const e = editorSize(r.name)
+        const g = game[r.name]
+        const sides = {
+            today: swapForDirection(g.type, r.direction, e.w, e.h),
+            gameTiles: swapForDirection(g.type, r.direction, g.tile_width, g.tile_height),
+        }
+
+        const row = { rail: r.name, direction: r.direction, blocked: blocked.size }
+        for (const [arm, size] of Object.entries(sides)) {
+            const cells = keyedCells(size, r.position.x, r.position.y)
+            const missed = [...blocked].filter(c => !cells.has(c)).length
+            const empty = [...cells].filter(c => !blocked.has(c)).length
+            arms[arm].missed += missed
+            arms[arm].empty += empty
+            row[arm] = { tiles: [size.x, size.y], keyed: cells.size, missed, empty }
+        }
+        perRail[`${r.name}@${r.direction}`] = row
+    }
+
+    /*
+        Alignment control. A cardinal `straight-rail` is the one case where the
+        editor's rectangle, the game's published numbers and the measured
+        blocked cells all coincide exactly, so it must come back 0 missed and 0
+        empty on both arms. If it does not, the two coordinate systems are not
+        lined up and every total above is arithmetic on unrelated cells - which
+        is not a wrong answer so much as an answer to no question.
+    */
+    const aligned = ['straight-rail@0', 'straight-rail@4'].every(k => {
+        const row = perRail[k]
+        return (
+            row !== undefined &&
+            row.today.missed === 0 &&
+            row.today.empty === 0 &&
+            row.gameTiles.missed === 0 &&
+            row.gameTiles.empty === 0
+        )
+    })
+
+    occupancy = {
+        note: 'Computed here from fixtures/rail-occupancy.json against the wooden-chest reference, not from this run of the game. It is what decides whether adopting the published numbers is an improvement, and the answer is that it is not.',
+        orientations: Object.keys(perRail).length,
+        reference: 'wooden-chest',
+        cellsAreRelativeToFloorOfPosition: true,
+        alignmentControl: {
+            note: 'A cardinal straight-rail is the one case where both arms and the measurement coincide exactly. Anything but zeros means the coordinate systems are not lined up and the totals are meaningless.',
+            passes: aligned,
+        },
+        arms,
+        perRail,
+    }
+
+    console.log(
+        `\n=== the proposed change, against ${occupancy.orientations} measured orientations (wooden-chest reference) ===`
+    )
+    console.log(
+        `  alignment control (a cardinal straight-rail is exact on both arms): ${aligned ? 'passes' : 'FAILS - the totals below are arithmetic on unrelated cells'}`
+    )
+    console.log(
+        `  today:             ${arms.today.missed} occupied-but-not-keyed, ${arms.today.empty} keyed-but-empty`
+    )
+    console.log(
+        `  game's tile_width: ${arms.gameTiles.missed} occupied-but-not-keyed, ${arms.gameTiles.empty} keyed-but-empty`
+    )
+    const better =
+        arms.gameTiles.missed <= arms.today.missed && arms.gameTiles.empty <= arms.today.empty
+    console.log(
+        `  verdict: adopting the published numbers is ${better ? 'an improvement' : 'WORSE, and on both axes - do not implement'}`
+    )
+    for (const row of Object.values(perRail)) {
+        if (row.today.keyed === row.gameTiles.keyed) continue
+        console.log(
+            `    ${`${row.rail}@${row.direction}`.padEnd(26)} ${String(row.blocked).padStart(2)} blocked   ` +
+                `today ${row.today.tiles.join('x').padEnd(4)} keys ${String(row.today.keyed).padStart(2)} (${row.today.missed} missed, ${row.today.empty} empty)   ` +
+                `game ${row.gameTiles.tiles.join('x').padEnd(4)} keys ${String(row.gameTiles.keyed).padStart(2)} (${row.gameTiles.missed} missed, ${row.gameTiles.empty} empty)`
+        )
+    }
+} else {
+    console.log(`\n=== proposed-change check SKIPPED: no ${OCCUPANCY}`)
+}
+
+/* ------------------------------------------------------------------ *
  * Cross-version                                                       *
  * ------------------------------------------------------------------ */
 let versionDifferences
@@ -424,6 +559,7 @@ if (WRITE_FIXTURE) {
                 cellDelta: r.cellDelta,
             })),
         },
+        proposedChangeAgainstMeasuredOccupancy: occupancy,
         versionDifferences,
         entities,
         errors: list(d.errors),


### PR DESCRIPTION
Follow-up to #153. Probe and docs only; no editor source.

The number that settled #142 - adopting the game's `tile_width` makes agreement with measured occupancy worse in both directions - was computed in a throwaway script and then existed only as prose. This repo's rule is that a transcribed rule belongs in the probe, where a re-run reproduces it; `generate-rail-signal-spots.mjs` exists for exactly that reason.

The probe now reads `fixtures/rail-occupancy.json` and reports both arms itself:

```
=== the proposed change, against 38 measured orientations (wooden-chest reference) ===
  alignment control (a cardinal straight-rail is exact on both arms): passes
  today:             180 occupied-but-not-keyed, 96 keyed-but-empty
  game's tile_width: 188 occupied-but-not-keyed, 152 keyed-but-empty
  verdict: adopting the published numbers is WORSE, and on both axes - do not implement
```

plus the per-rail rows and a `proposedChangeAgainstMeasuredOccupancy` block in the fixture.

## What transcribing it caught

On the first run, 440/356 against 435/399. `rail-occupancy.json` stores blocked cells **relative to `floor(position)`**, not in world coordinates, and keying the rectangles absolutely inflated both arms together. The verdict survived and the output looked entirely plausible - nothing about its shape said it was wrong.

Hence the **alignment control**: a cardinal `straight-rail` is the one case where the editor's rectangle, the game's published numbers and the measured blocked cells all coincide exactly, so it must come back all zeros on both arms. It is asserted, printed, and recorded in the fixture. With it passing, the probe reproduces the numbers already published in #153 exactly - so nothing in that PR's prose needs correcting.

Method note added to `tools/oracle/README.md`: **a transcribed rule needs a coordinate control, not only a logic one.**

## Verification

- `vp check` - 0 warnings, lint or type errors in 158 files
- probe re-run on 2.0.77 with the 2.1.12 cross-check; fixture regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBd1VNLFRJTDEMmoCMFz5N