### PR TITLE
Remove the dead buffer dep, and record the constraints a dependency audit needs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,8 +426,91 @@ cd packages/worker && npx wrangler login
 
 ## Version Constraints
 
-- **basisu v1.16.4** encoder/transcoder must match - bundled transcoder at `packages/editor/src/basis/transcoder.1.16.4.js`
-- **Current basisu binary** is macOS ARM64 (`packages/exporter/basisu`) - needs cross-platform support (see TODO in exporter)
+The four things a dependency audit needs before it can say anything useful, and
+the reason a bare `npm outdated` here is misleading. Everything below was
+measured on 2026-07-29; re-derive rather than trust, since the circumstance that
+justifies a hold expires without anyone editing this file.
+
+### Held on purpose
+
+- **`typed-factorio` stays on 3.x.** Not neglect - upstream publishes a
+  **dedicated `factorio-2.0` dist-tag** pointing at exactly the version this
+  project runs: `npm view typed-factorio dist-tags` gives
+  `{latest: 4.2.0, factorio-2.0: 3.36.0}`. The mapping is in package metadata
+  (`npm view typed-factorio@<v> factorioVersion`): **3.36.0 describes Factorio
+  2.0.75, 4.2.0 describes 2.1.9**. The 3.x line is also the more recently
+  published of the two. Issue #155 targets 2.0.77, which keeps this on the 3.x
+  side - if it lands, look for a 3.37.x tracking 2.0.77, **not** v4. Note it is
+  consumed as ambient types via the tsconfig `types` array, with zero `import`
+  sites, so a major would change global types everywhere at once with nothing to
+  stage the migration through.
+- **basisu v1.16.4** encoder/transcoder must match - bundled transcoder at
+  `packages/editor/src/basis/transcoder.1.16.4.js`. Newer basisu (v2.10 exists)
+  brings HDR and ASTC codecs this project has no use for, and a bump re-encodes
+  all 8776 tracked `.basis` files. Blocked behind #155's unanswered question of
+  whether basisu encoding is deterministic - that decides whether the diff is
+  reviewable at all.
+- **Current basisu binary** is macOS ARM64 (`packages/exporter/basisu`);
+  `setup.rs:501` hardcodes `"./basisu"` with no `cfg(target_os)` switch, and
+  there is **no Linux binary at all** since `354ad057`, so the exporter cannot
+  encode sprites on `ubuntu-latest`.
+- **`.npmrc` sets `legacy-peer-deps=true`** and it is load-bearing, not laziness:
+  `typed-factorio` declares non-optional peers on `lua-types` and
+  `typescript-to-lua`, and `typescript-to-lua` pins `typescript: "6.0.2"`
+  **exactly** against this project's 7.0.2. v4 declares the same peers, so
+  upgrading would not fix it. It silences every peer conflict in the tree,
+  including future real ones - re-test at each `typed-factorio` bump.
+
+### Coupled - these move together or not at all
+
+- **`vite-plus` 0.2.6 pins the whole toolchain.** Vite, Rolldown, oxlint, oxfmt
+  and Vitest are **not independently upgradable** - there is no `vite` package in
+  the tree at all, the root `overrides` aliases it
+  (`"vite": "npm:@voidzero-dev/vite-plus-core@0.2.6"`). So "bump vitest" has no
+  answer except "bump vite-plus". **0.2.6 is `latest`, not a lagging pin.**
+- The pin appears in **five** places that must move as one: root, editor and
+  website `package.json`; the root `overrides`; and
+  `.github/actions/setup-vp/action.yml`, which carries both `VP_VERSION`, a cache
+  key, **and a sha256 of the installer script** - the part people forget.
+- **`@playwright/test`** needs `npx playwright install` in the same commit as any
+  bump, or every spec fails on a missing `chrome-headless-shell` and reads as a
+  suite-wide regression.
+
+### How updates actually get applied
+
+npm workspaces. `npm update --save` for the routine pass (`d0971109`), carets
+preferred over exact pins (`a5a20c04`). Anything proposed has to be expressible
+that way. **The gate is `vp check` + `vp test` + `npx playwright test`**, and the
+Playwright half needs both dev servers up via `npm run localpreview`.
+
+Dependabot is configured for **npm and github-actions only**
+(`.github/dependabot.yml`) - there is **no `cargo` entry**, so the Rust exporter
+gets security alerts but no version updates, and it has drifted accordingly.
+
+### Settled - do not re-raise without new information
+
+- **`pathfinding` (last published 2016) stays.** Its output is pinned by
+  `generators.test.ts` against a committed fixture, so swapping it is a "did the
+  oil outpost generator change?" question rather than a dependency change. No
+  CVE, no network or parsing surface - the risk is bus-factor. If it ever moves,
+  vendor the BFS and prove it against the existing fixture.
+- **`npm audit` is 0.** Measured, not assumed.
+
+### Known and unfixed
+
+- `packages/worker/wrangler.jsonc` `compatibility_date` is **2026-03-01**, five
+  months stale. Every flag that has defaulted on since is inert for a worker that
+  only does a 301 and a CORS proxy, so this is hygiene rather than risk.
+- Three declared-but-unused dependencies: `@types/delaunator` (delaunator ships
+  its own `index.d.ts`, and the bundled types are _more_ precise under `strict`),
+  and in Rust, `http` and `tokio-stream`.
+- **The Rust exporter is never compiled in CI** - `.github/workflows/ci.yml` has
+  no `cargo` step, so Rust breakage is invisible until someone builds locally on
+  macOS.
+- `ajv` is ~100 kB minified and **nothing branches on its result** - the load
+  proceeds identically either way, and `ModdedBlueprintError` /
+  `TrainBlueprintError` are declared, exported, handled, and never thrown. Decide
+  what blueprint validation is _for_ before optimising it.
 
 ## Playwright Blueprint Diagnostics
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3434,26 +3434,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3485,30 +3465,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/buffer": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
             }
         },
         "node_modules/bundle-name": {
@@ -3936,26 +3892,6 @@
             "version": "0.2.5",
             "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.5.tgz",
             "integrity": "sha512-G7HLD+WKcrOyJP5VQwYZNC3Z6FcQ7YYjEFiFoIj8PfEr73mu421o8B1N5DKUcc8K37EsJ2XXWA8DtrDz/2dReg=="
-        },
-        "node_modules/ieee754": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "BSD-3-Clause"
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -5844,7 +5780,6 @@
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.20.0",
-                "buffer": "^6.0.3",
                 "delaunator": "^5.1.0",
                 "eventemitter3": "^5.0.4",
                 "pako": "^3.0.1",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -17,7 +17,6 @@
     },
     "dependencies": {
         "ajv": "^8.20.0",
-        "buffer": "^6.0.3",
         "delaunator": "^5.1.0",
         "eventemitter3": "^5.0.4",
         "pako": "^3.0.1",


### PR DESCRIPTION
Output of two dependency audits (npm; and Rust/Actions/toolchain). One deletion, and a lot of recording.

**The headline is that there is almost nothing to upgrade.** `npm outdated --workspaces` returns exactly **one row**, `npm audit` is **0**, `vite-plus` and Playwright are on today's latest, and every GitHub Action is current on node24. The one outdated row is a deliberate hold.

So the value here is not upgrades. It is deleting one dead dependency and writing down why the next audit should not bother.

## The deletion

`buffer` was left declared in `packages/editor/package.json` when #156 removed the last import. Confirmed unused three ways, and the bundle already contains no `base64-js` or `ieee754`. The lockfile drops all three packages.

## The recording

`CLAUDE.md`'s Version Constraints section is restructured into the four things an audit needs before it can say anything useful - **held on purpose / coupled / how updates get applied / settled** - because every useful finding was of that kind rather than a version number.

Measured on 2026-07-29, not recalled:

- **`typed-factorio`'s hold is upstream-sanctioned**, which was not previously written down. `npm view typed-factorio dist-tags` gives a dedicated **`factorio-2.0` tag pointing at 3.36.0**, and package metadata maps **3.36.0 -> Factorio 2.0.75** against **4.2.0 -> 2.1.9**. #155 targets 2.0.77, which keeps this on the 3.x side - so if #155 lands, look for a 3.37.x, not v4.
- **`vite-plus` 0.2.6 is `latest`, not a lagging pin** - and it pins Vite, Rolldown, oxlint, oxfmt and Vitest *as a unit*. There is no `vite` package in the tree at all; the root `overrides` aliases it to `@voidzero-dev/vite-plus-core`. So "bump vitest" has no answer except "bump vite-plus". The pin lives in **five** places, one of which is an installer **checksum** in `setup-vp/action.yml`.
- **`.npmrc`'s `legacy-peer-deps` is load-bearing**: `typescript-to-lua` pins `typescript: "6.0.2"` *exactly* against this project's 7.0.2, and typed-factorio v4 declares the same peers, so upgrading would not fix it.
- **Dependabot covers npm and github-actions but not cargo.** The Rust exporter gets security alerts and no version updates, and has drifted accordingly - and `.github/workflows/ci.yml` has no `cargo` step, so Rust breakage is invisible until someone builds locally on macOS.

Also now recorded rather than rediscovered: `pathfinding` (last published 2016) stays because `generators.test.ts` pins its output against a committed fixture, so swapping it is a "did the oil outpost generator change?" question; `wrangler.jsonc`'s `compatibility_date` is five months stale but every newly-default flag is inert for a 301 and a CORS proxy; and **`ajv` is ~100 kB that nothing branches on** - `ModdedBlueprintError` and `TrainBlueprintError` are declared, exported, handled, and never thrown.

## Deliberately not in this PR

Each is a real finding with a real cost, and none is a regression:

| | Why separate |
| --- | --- |
| `dat.gui` -> `lil-gui` | The only change a user would notice - it is the documented dead click zone. Rewrites CSS and needs the `dat.gui.closed` localStorage key carried across. |
| Drop `pako` for `CompressionStream` | ~66 kB. Low risk (round-trip hashes the object, not the bytes) but its own PR. |
| The `ajv` question | Needs a decision on what validation is *for* before any code. |
| Rust: remove unused `http`/`tokio-stream`, `lazy_static` -> `LazyLock`, `zip` 2->8, reqwest 0.13 | Wants a `cargo check` in CI first, or the PRs are unreviewable green-by-default. |
| Dependabot `cargo` entry, `compatibility_date` bump | Small, but each is its own one-liner. |

## Verification

- `vp check` - 0 warnings, lint or type errors in 159 files
- `vp test` - 143 passed
- `npx playwright test` round-trip + string-tolerance - 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBd1VNLFRJTDEMmoCMFz5N