### PR TITLE
chore: drop three declared-but-unused dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -506,9 +506,15 @@ gets security alerts but no version updates, and it has drifted accordingly.
 - `packages/worker/wrangler.jsonc` `compatibility_date` is **2026-03-01**, five
   months stale. Every flag that has defaulted on since is inert for a worker that
   only does a 301 and a CORS proxy, so this is hygiene rather than risk.
-- Three declared-but-unused dependencies: `@types/delaunator` (delaunator ships
-  its own `index.d.ts`, and the bundled types are _more_ precise under `strict`),
-  and in Rust, `http` and `tokio-stream`.
+- ~~Three declared-but-unused dependencies~~ - **removed**, and the way they were
+  found is the reusable part: Renovate proposed an update for each, which is what
+  surfaced that nothing imported them. A dependency bot is a census as much as an
+  upgrade tool. `@types/delaunator` went because delaunator ships its own
+  `index.d.ts` and the bundled types are _more_ precise under `strict` - `vp check`
+  staying at 0 after the removal is the proof, not an assumption. `http` and
+  `tokio-stream` had **0** occurrences of `http::` and `tokio_stream` in
+  `packages/exporter/src/`; both remain in `Cargo.lock` as transitives of reqwest
+  and hyper, so only the two direct-dependency lines went.
 - **The Rust exporter is compiled in CI but never run**, and the gap between those
   two is the thing to know. The `Rust exporter` job in `.github/workflows/ci.yml`
   runs `cargo build --locked` on `ubuntu-latest`; `--locked` is the load-bearing

--- a/package-lock.json
+++ b/package-lock.json
@@ -2210,13 +2210,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/delaunator": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/@types/delaunator/-/delaunator-5.0.3.tgz",
-            "integrity": "sha512-6tTLP8NX0OwtB/fmW9bXp4EWPptawTSsrSGjboWRuzqkxNEEJGyzRPHbr8wnV2DBWfAZ+EPTOvW3B/KysJrl2g==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/earcut": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
@@ -5788,7 +5781,6 @@
                 "utility-types": "^3.11.0"
             },
             "devDependencies": {
-                "@types/delaunator": "5.0.3",
                 "@types/pathfinding": "0.1.0",
                 "typed-factorio": "^3.36.0",
                 "vite-plus": "0.2.6"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -25,7 +25,6 @@
         "utility-types": "^3.11.0"
     },
     "devDependencies": {
-        "@types/delaunator": "5.0.3",
         "@types/pathfinding": "0.1.0",
         "typed-factorio": "^3.36.0",
         "vite-plus": "0.2.6"

--- a/packages/exporter/Cargo.lock
+++ b/packages/exporter/Cargo.lock
@@ -382,7 +382,6 @@ dependencies = [
  "dotenvy",
  "futures",
  "globset",
- "http",
  "hyper",
  "hyper-staticfile",
  "hyper-util",
@@ -394,7 +393,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-stream",
  "tokio-util",
  "zip",
 ]

--- a/packages/exporter/Cargo.toml
+++ b/packages/exporter/Cargo.toml
@@ -16,12 +16,10 @@ async-recursion = "1.1.1"
 lazy_static = "1.5.0"
 async-compression = { version = "0.4.18", features = ["tokio", "lzma"] }
 indicatif = "0.18"
-tokio-stream = "0.1.17"
 tokio-tar = { package = "astral-tokio-tar", version = "0.6.1" }
 tokio-util = { version = "0.7.13", features = ["io"] }
 hyper-staticfile = "0.10.1"
 hyper = { version = "1.5.1", features = ["http1", "server"] }
 hyper-util = { version = "0.1.10", features = ["tokio"] }
-http = "1.2.0"
 zip = "2.2.1"
 dotenvy = "0.15.7"


### PR DESCRIPTION
Removes `@types/delaunator`, and the Rust crates `http` and `tokio-stream`.

**How they were found is the part worth keeping.** Renovate's first run proposed an update for each of these, which is what surfaced that nothing imports them. CLAUDE.md had listed all three under "Known and unfixed" since the July audit; what the bot added was a reason to look at them today. A dependency bot is a census as much as an upgrade tool.

This also closes 2 of the 18 updates queued for Monday, permanently, rather than reviewing bumps to code nothing calls.

## Evidence, per dependency

| Dep | Why it goes | Check |
|---|---|---|
| `@types/delaunator` | delaunator ships its own `index.d.ts`, and CLAUDE.md records that the bundled types are *more* precise under `strict` - so removing the `@types` package is an improvement, not a neutral tidy. | `vp check` stays at **0** with `lint.options.typeCheck` on. That is the proof; had the bundled types been worse, this is where it would have shown. |
| `http` | `grep` finds **0** occurrences of `http::` in `packages/exporter/src/`. | `cargo build --locked` clean. |
| `tokio-stream` | **0** occurrences of `tokio_stream` in `packages/exporter/src/`. | `cargo build --locked` clean. |

Both crates remain in `Cargo.lock` as transitives of reqwest and hyper - only the two direct-dependency lines go, which is why the lock diff is 2 lines rather than a re-resolve.

## Verification

- `vp check .` - 211 files formatted, 0 warnings/lint/type errors across 159 files
- `vp test run` - 143 passed
- `cargo build --locked --manifest-path packages/exporter/Cargo.toml` - clean, and `--locked` confirms the lockfile edit is coherent

Playwright was not run: nothing here touches editor behaviour, and the only runtime dependency involved is delaunator, whose *implementation* is unchanged - only its type declarations moved from a separate package to its own bundled ones, which is a compile-time question that `vp check` already answers.

## Note

CLAUDE.md's "Known and unfixed" entry is updated rather than deleted, since the *method* generalises: the bot proposing an update to something is a prompt to check whether it is used at all.