### PR TITLE
ci: compile the Windows-gated exporter code on a Windows runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,26 @@ jobs:
         if: ${{ !cancelled() }}
         run: cargo clippy --locked --manifest-path packages/exporter/Cargo.toml -- -D warnings
 
+      # The Build step above compiles the LINUX cfg block and skips the Windows
+      # one, so a chunk of src/setup.rs is never type-checked by anything. That is
+      # not theoretical: `zip` has exactly one call site in the whole crate,
+      # setup.rs:623, inside `#[cfg(target_os = "windows")]` - so the zip v2 -> v8
+      # PR passed this job green with its only consumer uncompiled. Six majors, and
+      # the check covered none of it.
+      #
+      # `check`, not `build`: type-checking the cfg block is the entire point and
+      # needs no MSVC linker, so this costs a rustup target and seconds rather than
+      # a cross-compilation toolchain. It would also have caught the clippy autofix
+      # that renamed `out_dir`/`stream` - that broke Windows as well as Linux.
+      #
+      # macOS is deliberately not covered: `download()` panics on the
+      # unsupported-OS arm, so there is no macOS cfg block to check.
+      - name: Check the Windows-gated code
+        if: ${{ !cancelled() }}
+        run: |
+          rustup target add x86_64-pc-windows-msvc
+          cargo check --locked --target x86_64-pc-windows-msvc --manifest-path packages/exporter/Cargo.toml
+
   deploy:
     name: Deploy to Cloudflare
     needs: checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,25 +139,50 @@ jobs:
         if: ${{ !cancelled() }}
         run: cargo clippy --locked --manifest-path packages/exporter/Cargo.toml -- -D warnings
 
-      # The Build step above compiles the LINUX cfg block and skips the Windows
-      # one, so a chunk of src/setup.rs is never type-checked by anything. That is
-      # not theoretical: `zip` has exactly one call site in the whole crate,
-      # setup.rs:623, inside `#[cfg(target_os = "windows")]` - so the zip v2 -> v8
-      # PR passed this job green with its only consumer uncompiled. Six majors, and
-      # the check covered none of it.
-      #
-      # `check`, not `build`: type-checking the cfg block is the entire point and
-      # needs no MSVC linker, so this costs a rustup target and seconds rather than
-      # a cross-compilation toolchain. It would also have caught the clippy autofix
-      # that renamed `out_dir`/`stream` - that broke Windows as well as Linux.
-      #
-      # macOS is deliberately not covered: `download()` panics on the
-      # unsupported-OS arm, so there is no macOS cfg block to check.
-      - name: Check the Windows-gated code
-        if: ${{ !cancelled() }}
-        run: |
-          rustup target add x86_64-pc-windows-msvc
-          cargo check --locked --target x86_64-pc-windows-msvc --manifest-path packages/exporter/Cargo.toml
+  # The Linux job above compiles the linux cfg block of src/setup.rs and SKIPS the
+  # Windows one, so a chunk of that file was never checked by anything. Not
+  # theoretical: `zip` has exactly one call site in the whole crate, setup.rs:623,
+  # inside `#[cfg(target_os = "windows")]` - so the zip v2 -> v8 PR passed the
+  # Linux job green with its only consumer uncompiled. Six majors, covered by
+  # nothing. This job is what makes that PR meaningful.
+  #
+  # WHY A WINDOWS RUNNER RATHER THAN A CROSS-CHECK, which is what this was first
+  # written as and is the obvious cheap answer: `cargo check --target
+  # x86_64-pc-windows-msvc` on ubuntu FAILS, because `check` still runs build
+  # scripts, and `zstd-sys` (pulled in by zip) builds C and refuses the GNU
+  # compiler for an msvc target. Measured, not predicted - the cross-check was
+  # committed, and CI rejected it. Any `-sys` crate reintroduces this, so the
+  # native runner is the durable answer rather than chasing a mingw toolchain.
+  #
+  # macOS is deliberately not covered: `download()` panics on the unsupported-OS
+  # arm, so there is no macOS cfg block to check.
+  #
+  # Free on this repo - GitHub-hosted minutes are unmetered for public repos, so
+  # the 2x Windows billing multiplier costs nothing here.
+  rust-windows:
+    name: Rust exporter (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Record toolchain
+        run: cargo --version && rustc --version
+
+      - name: Cache cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            packages/exporter/target
+          key: cargo-${{ runner.os }}-${{ hashFiles('packages/exporter/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+
+      - name: Build
+        run: cargo build --locked --manifest-path packages/exporter/Cargo.toml
 
   deploy:
     name: Deploy to Cloudflare


### PR DESCRIPTION
Adds a `Rust exporter (Windows)` job running `cargo build --locked` on `windows-latest`.

## Why, concretely

`src/setup.rs`'s `download()` splits into `#[cfg(target_os = "windows")]` and `#[cfg(target_os = "linux")]` blocks. The existing job runs on `ubuntu-latest`, so it compiles the second and **never checks the first**.

That gap already let something through today. **`zip` has exactly one call site in the entire crate** - `setup.rs:623`, inside the Windows block. So #179, `zip 2.2.1 -> 8.0.0`, **passed CI green with its only consumer uncompiled**. Six majors, covered by nothing. #179 is deliberately still open pending this job.

It would also have caught the `cargo clippy --fix` renames reverted in #180: `out_dir` and `stream` are referenced in both cfg blocks, so that autofix broke Windows as well as Linux.

## Why a Windows runner rather than a cross-check

This PR was **first written as `cargo check --target x86_64-pc-windows-msvc` on the existing ubuntu job, and CI rejected it** - see the second commit. `cargo check` still runs build scripts, and `zstd-sys` (pulled in by zip) compiles C and refuses the GNU compiler for an msvc target:

```
warning: zstd-sys@2.0.16+zstd.1.5.7: GNU compiler is not supported for this target
```

My reasoning that "check needs no linker" was right and beside the point - it needs no linker, but it does need the target's **C toolchain** for any `-sys` crate. Chasing a mingw setup would fix zstd and break on the next `-sys` dependency; a native runner does not have the problem at all.

The two commits are kept rather than squashed away so the failed approach and the reason are on record.

`build` rather than `check`, since the MSVC toolchain is present natively and this then matches what the Linux job does. Unmetered - GitHub-hosted minutes are free on public repos, so the 2x Windows multiplier costs nothing.

macOS is deliberately not covered: `download()` panics on the unsupported-OS arm, so there is no macOS cfg block to check.

## Verification

`Rust exporter (Windows): success` on this PR's final run, alongside `Rust exporter` and `checks`. The first commit's run is the failure described above, left visible in the history.

Once this merges, #179 (`zip v8`) can be rebased and will be meaningfully checked for the first time.