### PR TITLE
Add a settings editor for display-panel entities

### DIFF
--- a/packages/editor/src/UI/InventoryDialog.ts
+++ b/packages/editor/src/UI/InventoryDialog.ts
@@ -63,6 +63,9 @@ export class InventoryDialog extends Dialog {
     /** Scrollbar thumb rendered alongside the items viewport */
     private readonly m_ScrollThumb: Graphics
 
+    /** Whether the recipe panel was built - `setPosition` needs it after the constructor has returned */
+    private readonly m_ShowRecipePanel: boolean
+
     // Items viewport geometry (matches the layout comment above)
     private static readonly VP_X = 12
     private static readonly VP_Y = 126
@@ -70,15 +73,52 @@ export class InventoryDialog extends Dialog {
     private static readonly VP_H = 304
     private static readonly ROW_H = 38
 
+    /** Whether an item qualifies for a group tab, mirroring the population loop below */
+    private static itemQualifies(itemName: string, itemsFilter: string[] | undefined): boolean {
+        if (itemsFilter === undefined) {
+            const itemData = FD.items[itemName]
+            if (!itemData) return false
+            if (!itemData.place_result && !itemData.place_as_tile) return false
+            if (itemData.place_result && !FD.entities[itemData.place_result]) return false
+            return true
+        }
+        return itemsFilter.includes(itemName)
+    }
+
+    /**
+     * Widen the dialog if more group tabs need to fit than the 404px base
+     * layout was designed for. `DisplayPanelIcon` is the first caller whose
+     * filter (items + fluids + virtual signals) spans enough of
+     * `FD.inventoryLayout` to hit this - up to 7 tabs against Space Age data,
+     * where every other filtered caller stays within a handful of the base
+     * game's own groups.
+     */
+    private static computeWidth(itemsFilter: string[] | undefined): number {
+        let groupCount = 0
+        for (const group of FD.inventoryLayout) {
+            if (group.name === 'creative' && itemsFilter !== undefined) continue
+            const hasItems = group.subgroups.some(subgroup =>
+                subgroup.items.some(item => InventoryDialog.itemQualifies(item.name, itemsFilter))
+            )
+            if (hasItems) groupCount += 1
+        }
+        return Math.max(404, groupCount * 70 + 22)
+    }
+
     public constructor(
         title = 'Inventory',
         itemsFilter: string[] | undefined,
         // Not optional: picking an item is the whole point of the dialog, and all
         // five call sites pass one. Optional only made the invocation below a
         // type error, with nothing to do about it that was not a fiction.
-        selectedCallBack: (selectedItem: string) => void
+        selectedCallBack: (selectedItem: string) => void,
+        // Off for DisplayPanelIcon: it picks from items/fluids/signals with no
+        // recipe, so the panel would only ever show as a permanently empty bar.
+        showRecipePanel = true
     ) {
-        super(404, 442, title)
+        super(InventoryDialog.computeWidth(itemsFilter), 442, title)
+
+        this.m_ShowRecipePanel = showRecipePanel
 
         const D = InventoryDialog
 
@@ -227,27 +267,33 @@ export class InventoryDialog extends Dialog {
             }
         }
 
-        const recipePanel = new Container()
-        recipePanel.position.set(0, 442)
-        this.addChild(recipePanel)
-
-        const recipeBackground = F.DrawRectangle(
-            404,
-            78,
-            colors.dialog.background.color,
-            colors.dialog.background.alpha,
-            colors.dialog.background.border
-        )
-        recipeBackground.position.set(0, 0)
-        recipePanel.addChild(recipeBackground)
-
+        // Detached placeholders when the recipe panel is hidden - keeps
+        // updateRecipeVisualization a safe no-op rather than needing its own
+        // showRecipePanel check, since item buttons call it unconditionally.
         this.m_RecipeLabel = new Text({ text: '', style: styles.dialog.label })
-        this.m_RecipeLabel.position.set(12, 10)
-        recipePanel.addChild(this.m_RecipeLabel)
-
         this.m_RecipeContainer = new Container()
-        this.m_RecipeContainer.position.set(12, 36)
-        recipePanel.addChild(this.m_RecipeContainer)
+
+        if (this.m_ShowRecipePanel) {
+            const recipePanel = new Container()
+            recipePanel.position.set(0, 442)
+            this.addChild(recipePanel)
+
+            const recipeBackground = F.DrawRectangle(
+                this.width,
+                78,
+                colors.dialog.background.color,
+                colors.dialog.background.alpha,
+                colors.dialog.background.border
+            )
+            recipeBackground.position.set(0, 0)
+            recipePanel.addChild(recipeBackground)
+
+            this.m_RecipeLabel.position.set(12, 10)
+            recipePanel.addChild(this.m_RecipeLabel)
+
+            this.m_RecipeContainer.position.set(12, 36)
+            recipePanel.addChild(this.m_RecipeContainer)
+        }
 
         this.refreshScrollbar()
     }
@@ -267,14 +313,19 @@ export class InventoryDialog extends Dialog {
         const thumbY = D.VP_Y + (scroll / maxScroll) * (D.VP_H - thumbH)
         this.m_ScrollThumb.visible = true
         this.m_ScrollThumb.height = thumbH
-        this.m_ScrollThumb.position.set(D.VP_X + D.VP_W, thumbY)
+        // Anchored to the dialog's actual right border (mirrors the 12px left
+        // margin) rather than a fixed VP_X + VP_W: computeWidth can widen the
+        // dialog well past the base 404px layout the viewport geometry was
+        // designed for, and a fixed-offset thumb would strand itself deep
+        // inside the dialog instead of at its edge.
+        this.m_ScrollThumb.position.set(this.width - 12 - 4, thumbY)
     }
 
     /** Override automatically set position of dialog due to additional area for recipe */
     protected override setPosition(): void {
         this.position.set(
             G.app.screen.width / 2 - this.width / 2,
-            G.app.screen.height / 2 - 520 / 2
+            G.app.screen.height / 2 - (this.m_ShowRecipePanel ? 520 : 442) / 2
         )
     }
 

--- a/packages/editor/src/UI/UIContainer.ts
+++ b/packages/editor/src/UI/UIContainer.ts
@@ -85,9 +85,10 @@ export class UIContainer extends Container {
     public createInventory(
         title: string | undefined,
         itemsFilter: string[] | undefined,
-        selectedCallBack: (selectedItem: string) => void
+        selectedCallBack: (selectedItem: string) => void,
+        showRecipePanel = true
     ): InventoryDialog {
-        const inv = new InventoryDialog(title, itemsFilter, selectedCallBack)
+        const inv = new InventoryDialog(title, itemsFilter, selectedCallBack, showRecipePanel)
         this.dialogsContainer.addChild(inv)
         return inv
     }

--- a/packages/editor/src/UI/editors/DisplayPanelEditor.ts
+++ b/packages/editor/src/UI/editors/DisplayPanelEditor.ts
@@ -1,0 +1,137 @@
+import { Container, Text } from 'pixi.js'
+import { Entity } from '../../core/Entity'
+import { ICondition } from '../../types'
+import { TextInput } from '../controls/TextInput'
+import { Checkbox } from '../controls/Checkbox'
+import F from '../controls/functions'
+import { styles } from '../style'
+import G from '../../common/globals'
+import { Editor } from './Editor'
+import { DisplayPanelIcon } from './components/DisplayPanelIcon'
+
+const ROW_HEIGHT = 26
+const MAX_ROWS = 20
+const ROW_WIDTH = 296
+const CONDITION_ICON_SIZE = 18
+const ICON_COL_WIDTH = 24
+const COMPARATOR_COL_WIDTH = 18
+const VALUE_COL_WIDTH = 40
+const CONDITION_WIDTH = ICON_COL_WIDTH + COMPARATOR_COL_WIDTH + VALUE_COL_WIDTH
+
+/** Icon(s) + comparator + value, laid out in fixed-width columns to line up across rows */
+function createConditionDisplay(condition: ICondition | undefined): Container {
+    const container = new Container()
+    if (!condition || !condition.first_signal?.name) return container
+
+    const icon = F.CreateIcon(condition.first_signal.name, CONDITION_ICON_SIZE)
+    icon.position.set(ICON_COL_WIDTH / 2, CONDITION_ICON_SIZE / 2)
+    container.addChild(icon)
+
+    const comparatorLabel = new Text({
+        text: condition.comparator || '<',
+        style: styles.dialog.label,
+    })
+    comparatorLabel.position.set(ICON_COL_WIDTH, (CONDITION_ICON_SIZE - comparatorLabel.height) / 2)
+    container.addChild(comparatorLabel)
+
+    const valueX = ICON_COL_WIDTH + COMPARATOR_COL_WIDTH
+    if (condition.second_signal?.name) {
+        const secondIcon = F.CreateIcon(condition.second_signal.name, CONDITION_ICON_SIZE)
+        secondIcon.position.set(valueX + CONDITION_ICON_SIZE / 2, CONDITION_ICON_SIZE / 2)
+        container.addChild(secondIcon)
+    } else {
+        const constLabel = new Text({
+            text: `${condition.constant ?? 0}`,
+            style: styles.dialog.label,
+        })
+        constLabel.position.set(valueX, (CONDITION_ICON_SIZE - constLabel.height) / 2)
+        container.addChild(constLabel)
+    }
+
+    return container
+}
+
+/**
+ * Display Panel Editor.
+ *
+ * A circuit-connected panel's text and icon come from `control_behavior.parameters`
+ * instead of the top-level `text`/`icon` fields this editor writes, so editing
+ * those live per the connected signals is not something this UI can offer -
+ * see the wiki's "custom text depending on circuit conditions". Showing the
+ * conditions read-only at least answers "why does this panel say that".
+ */
+export class DisplayPanelEditor extends Editor {
+    public constructor(entity: Entity) {
+        const allParameters = entity.displayPanelParameters || []
+        const parameters = allParameters.slice(0, MAX_ROWS)
+        const connected = entity.generateConnector
+        const rowCount = parameters.length + (allParameters.length > MAX_ROWS ? 1 : 0)
+        const height = connected ? 222 + rowCount * ROW_HEIGHT : 214
+
+        super(320, height, entity)
+
+        const alwaysShow = new Checkbox(
+            entity.displayPanelAlwaysShow,
+            "Always show text in 'Alt-mode'"
+        )
+        alwaysShow.position.set(12, connected ? 160 : 168)
+        this.addChild(alwaysShow)
+
+        alwaysShow.on('changed', () => {
+            this.m_Entity.displayPanelAlwaysShow = alwaysShow.checked
+        })
+
+        this.onEntityChange('displayPanelAlwaysShow', alwaysShowValue => {
+            alwaysShow.checked = alwaysShowValue
+        })
+
+        if (connected) {
+            this.addLabel(12, 190, 'Conditions (read only):')
+            parameters.forEach((param, i) => {
+                const row = new Container()
+                row.position.set(12, 210 + i * ROW_HEIGHT)
+
+                if (param.icon?.name) {
+                    const icon = F.CreateIcon(param.icon.name, 20)
+                    icon.position.set(10, 10)
+                    row.addChild(icon)
+                }
+
+                const text = param.text ? `"${param.text}"` : ''
+                row.addChild(this.addLabel(24, 4, text))
+
+                const conditionDisplay = createConditionDisplay(param.condition)
+                conditionDisplay.position.x = ROW_WIDTH - CONDITION_WIDTH
+                row.addChild(conditionDisplay)
+
+                this.addChild(row)
+            })
+            if (allParameters.length > MAX_ROWS) {
+                this.addLabel(
+                    12,
+                    210 + parameters.length * ROW_HEIGHT,
+                    `+${allParameters.length - MAX_ROWS} more`
+                )
+            }
+            return
+        }
+
+        this.addLabel(140, 46, 'Icon:')
+        const icon = new DisplayPanelIcon(entity)
+        icon.position.set(140, 65)
+        this.addChild(icon)
+
+        this.addLabel(140, 110, 'Text:')
+        const textInput = new TextInput(G.app.renderer, 150, entity.displayPanelText || '', 100)
+        textInput.position.set(140, 129)
+        this.addChild(textInput)
+
+        textInput.on('changed', () => {
+            this.m_Entity.displayPanelText = textInput.text || undefined
+        })
+
+        this.onEntityChange('displayPanelText', text => {
+            textInput.text = text || ''
+        })
+    }
+}

--- a/packages/editor/src/UI/editors/components/DisplayPanelIcon.ts
+++ b/packages/editor/src/UI/editors/components/DisplayPanelIcon.ts
@@ -1,0 +1,63 @@
+import { FederatedPointerEvent } from 'pixi.js'
+import EventEmitter from 'eventemitter3'
+import G from '../../../common/globals'
+import { Entity, EntityEvents } from '../../../core/Entity'
+import { ISignal } from '../../../types'
+import { Slot } from '../../controls/Slot'
+import F from '../../controls/functions'
+
+/** Icon Slot for a Display Panel Entity */
+export class DisplayPanelIcon extends Slot<undefined> {
+    /** Blueprint Editor Entity reference */
+    private readonly m_Entity: Entity
+
+    public constructor(entity: Entity) {
+        super(undefined)
+
+        this.m_Entity = entity
+        this.updateContent(this.m_Entity.displayPanelIcon)
+        this.on('pointerdown', this.onSlotPointerDown)
+
+        this.onEntityChange('displayPanelIcon', icon => this.updateContent(icon))
+    }
+
+    private onEntityChange<T extends EventEmitter.EventNames<EntityEvents>>(
+        event: T,
+        fn: EventEmitter.EventListener<EntityEvents, T>
+    ): void {
+        this.m_Entity.on(event, fn)
+        this.once('destroyed', () => this.m_Entity.off(event, fn))
+    }
+
+    /** Update Content Icon */
+    private updateContent(icon: ISignal | undefined): void {
+        if (icon === undefined || icon.name === undefined) {
+            if (this.content !== undefined) {
+                this.content = undefined
+            }
+        } else {
+            this.content = F.CreateIcon(icon.name)
+        }
+        this.emit('changed')
+    }
+
+    /** Event handler for click on slot */
+    private readonly onSlotPointerDown = (e: FederatedPointerEvent): void => {
+        e.stopPropagation()
+        if (e.button === 0) {
+            G.UI.createInventory(
+                'Select Icon',
+                this.m_Entity.acceptedDisplayPanelIcons,
+                name => {
+                    this.m_Entity.displayPanelIcon = {
+                        name,
+                        type: this.m_Entity.displayPanelIconType(name),
+                    }
+                },
+                false
+            )
+        } else if (e.button === 2) {
+            this.m_Entity.displayPanelIcon = undefined
+        }
+    }
+}

--- a/packages/editor/src/UI/editors/factory.ts
+++ b/packages/editor/src/UI/editors/factory.ts
@@ -8,6 +8,7 @@ import { MiningEditor } from './MiningEditor'
 import { SplitterEditor } from './SplitterEditor'
 import { TempEditor } from './TempEditor'
 import { TrainStopEditor } from './TrainStopEditor'
+import { DisplayPanelEditor } from './DisplayPanelEditor'
 
 /**
  * Factory Function for creating Editor based on Entity Number
@@ -79,6 +80,10 @@ export function createEditor(entity: Entity): Editor | undefined {
         // Train stop
         case 'train-stop':
             editor = new TrainStopEditor(entity)
+            break
+        // Display panel
+        case 'display-panel':
+            editor = new DisplayPanelEditor(entity)
             break
         default: {
             return undefined

--- a/packages/editor/src/containers/EntityContainer.ts
+++ b/packages/editor/src/containers/EntityContainer.ts
@@ -107,6 +107,10 @@ export class EntityContainer {
             }
         }
 
+        const onDisplayPanelIconChange = (): void => {
+            this.redraw()
+        }
+
         const onEntityDestroy = (): void => {
             this.redrawSurroundingEntities()
 
@@ -134,6 +138,9 @@ export class EntityContainer {
         this.m_Entity.on('filters', this.redrawEntityInfo)
         this.m_Entity.on('splitterInputPriority', this.redrawEntityInfo)
         this.m_Entity.on('splitterOutputPriority', this.redrawEntityInfo)
+        this.m_Entity.on('displayPanelIcon', onDisplayPanelIconChange)
+        this.m_Entity.on('displayPanelText', this.redrawEntityInfo)
+        this.m_Entity.on('displayPanelAlwaysShow', this.redrawEntityInfo)
 
         this.m_Entity.on('destroy', onEntityDestroy)
 
@@ -147,6 +154,9 @@ export class EntityContainer {
             this.m_Entity.off('filters', this.redrawEntityInfo)
             this.m_Entity.off('splitterInputPriority', this.redrawEntityInfo)
             this.m_Entity.off('splitterOutputPriority', this.redrawEntityInfo)
+            this.m_Entity.off('displayPanelIcon', onDisplayPanelIconChange)
+            this.m_Entity.off('displayPanelText', this.redrawEntityInfo)
+            this.m_Entity.off('displayPanelAlwaysShow', this.redrawEntityInfo)
 
             this.m_Entity.off('destroy', onEntityDestroy)
 
@@ -334,7 +344,8 @@ export class EntityContainer {
             this.m_Entity.type === 'arithmetic-combinator' ||
             this.m_Entity.type === 'decider-combinator' ||
             this.m_Entity.type === 'inserter' ||
-            this.m_Entity.type === 'logistic-container'
+            this.m_Entity.type === 'logistic-container' ||
+            this.m_Entity.type === 'display-panel'
         ) {
             if (this.entityInfo !== undefined) {
                 this.entityInfo.destroy()
@@ -351,6 +362,16 @@ export class EntityContainer {
 
         G.UI.updateEntityInfoPanel(this.m_Entity)
         this.visualizationArea.show()
+
+        // The always-show label (drawn by createEntityInfo, above) and the hover
+        // tooltip (all lines, per the wiki) would otherwise stack on top of each
+        // other while hovering a panel that has both enabled.
+        if (this.m_Entity.type === 'display-panel' && this.m_Entity.displayPanelText) {
+            if (this.entityInfo !== undefined) {
+                this.entityInfo.visible = false
+            }
+            G.BPC.overlayContainer.showEntityTooltip(this.m_Entity, this.position)
+        }
     }
 
     public pointerOutEventHandler(): void {
@@ -359,6 +380,13 @@ export class EntityContainer {
 
         G.UI.updateEntityInfoPanel(undefined)
         this.visualizationArea.hide()
+
+        if (this.m_Entity.type === 'display-panel' && this.m_Entity.displayPanelText) {
+            if (this.entityInfo !== undefined) {
+                this.entityInfo.visible = true
+            }
+            G.BPC.overlayContainer.hideEntityTooltip()
+        }
     }
 
     private redrawSurroundingEntities(position: IPoint = this.m_Entity.position): void {

--- a/packages/editor/src/containers/EntityContainer.ts
+++ b/packages/editor/src/containers/EntityContainer.ts
@@ -278,6 +278,19 @@ export class EntityContainer {
         return this.m_Entity
     }
 
+    /**
+     * Whether the entity info overlay is currently shown, `false` when there is
+     * none to show at all. Exposed for tests/display-panel-editor.spec.ts: the
+     * hover-tooltip/always-show swap in pointerOverEventHandler and
+     * pointerOutEventHandler toggles this container's own `visible` rather than
+     * anything `overlayInfoTally` (tests/overlay-container.spec.ts) can see,
+     * since that tally reads what `createEntityInfo` built, not whether the
+     * container it produced is currently on screen.
+     */
+    public get entityInfoVisible(): boolean {
+        return this.entityInfo?.visible ?? false
+    }
+
     public get position(): IPoint {
         return {
             x: this.m_Entity.position.x * 32,

--- a/packages/editor/src/containers/OverlayContainer.ts
+++ b/packages/editor/src/containers/OverlayContainer.ts
@@ -1,4 +1,4 @@
-import { Container, Graphics, Sprite } from 'pixi.js'
+import { Container, Graphics, Sprite, Text, TextStyle } from 'pixi.js'
 import { IPoint } from '../types'
 import FD, {
     getFluidBoxes,
@@ -38,6 +38,7 @@ export class OverlayContainer extends Container {
     private readonly cursorBoxes = new Container()
     private readonly undergroundLines = new Container()
     private readonly selectionArea = new Graphics()
+    private readonly entityTooltip = new Container()
     private copyCursorBox: Container | undefined
     // Absent outside a selection drag, same as `copyCursorBox` above.
     private selectionAreaUpdateFn: ((endX: number, endY: number) => void) | undefined
@@ -46,7 +47,32 @@ export class OverlayContainer extends Container {
         super()
         this.bpc = bpc
 
-        this.addChild(this.entityInfos, this.cursorBoxes, this.undergroundLines, this.selectionArea)
+        this.addChild(
+            this.entityInfos,
+            this.cursorBoxes,
+            this.undergroundLines,
+            this.selectionArea,
+            this.entityTooltip
+        )
+    }
+
+    /**
+     * All lines of a display panel's text, shown above the entity on hover
+     * regardless of `always_show` - per the wiki, the always-show option only
+     * controls whether the first line is visible without hovering.
+     */
+    public showEntityTooltip(entity: Entity, position: IPoint): void {
+        this.entityTooltip.removeChildren()
+
+        if (entity.type !== 'display-panel' || !entity.displayPanelText) return
+
+        const label = createDisplayPanelLabel(entity.displayPanelText)
+        label.position.set(position.x, position.y - 24)
+        this.entityTooltip.addChild(label)
+    }
+
+    public hideEntityTooltip(): void {
+        this.entityTooltip.removeChildren()
     }
 
     /** undefined when the entity has nothing to draw, which is most of them. */
@@ -351,6 +377,22 @@ export class OverlayContainer extends Container {
             entityInfo.addChild(arrows)
         }
 
+        // Only the first line, and only while `always_show` is on - the wiki's
+        // "even when not selected" case. All lines regardless of `always_show`
+        // is the hover tooltip instead, see `showEntityTooltip`.
+        if (
+            entity.type === 'display-panel' &&
+            entity.displayPanelAlwaysShow &&
+            entity.displayPanelText
+        ) {
+            const firstLine = entity.displayPanelText.split('\n')[0]
+            if (firstLine) {
+                const label = createDisplayPanelLabel(firstLine)
+                label.position.set(0, -40)
+                entityInfo.addChild(label)
+            }
+        }
+
         if (entityInfo.children.length !== 0) {
             entityInfo.position.set(position.x, position.y)
             return entityInfo
@@ -608,4 +650,33 @@ export class OverlayContainer extends Container {
             this.selectionAreaUpdateFn = undefined
         }
     }
+}
+
+/**
+ * A single line of display panel text, on a padded semi-transparent
+ * background, anchored above its own origin - callers position the origin at
+ * the point in the world the label should hang above.
+ */
+function createDisplayPanelLabel(text: string): Container {
+    const label = new Text({
+        text,
+        style: new TextStyle({ fontSize: 16, fill: 0xffffff, align: 'center' }),
+    })
+    label.anchor.set(0.5, 1)
+
+    const paddingX = 10
+    const paddingY = 6
+    const background = new Graphics()
+        .rect(
+            -label.width / 2 - paddingX,
+            -label.height - paddingY,
+            label.width + paddingX * 2,
+            label.height + paddingY * 2
+        )
+        .fill({ color: 0x000000, alpha: 0.25 })
+
+    const container = new Container()
+    container.addChild(background, label)
+    container.scale.set(0.5, 0.5)
+    return container
 }

--- a/packages/editor/src/core/Entity.ts
+++ b/packages/editor/src/core/Entity.ts
@@ -8,6 +8,7 @@ import {
     ComparatorString,
     ArithmeticOperation,
     ISignal,
+    ICondition,
     SelectorCombinatorOperation,
     LogisticSection,
     LogisticSections,
@@ -175,6 +176,9 @@ export interface EntityEvents {
     wagonInventory: []
     launchToOrbitAutomatically: []
     useTransitionalRequests: []
+    displayPanelIcon: [icon: ISignal | undefined]
+    displayPanelText: [text: string | undefined]
+    displayPanelAlwaysShow: [alwaysShow: boolean]
 }
 
 /** Entity Base Class */
@@ -1642,6 +1646,90 @@ export class Entity extends EventEmitter<EntityEvents> {
     public get displayPanelIcon(): ISignal | undefined {
         if (this.type !== 'display-panel') return undefined
         return this.m_rawEntity.icon || this.m_rawEntity.control_behavior?.parameters?.[0]?.icon
+    }
+
+    public set displayPanelIcon(icon: ISignal | undefined) {
+        if (this.m_rawEntity.icon === icon) return
+
+        this.m_BP.history
+            .updateValue(this.m_rawEntity, 'icon', icon, 'Change display panel icon')
+            .onDone(() => this.emit('displayPanelIcon', this.displayPanelIcon))
+            .commit()
+    }
+
+    /**
+     * Entity Display Panel text.
+     *
+     * Falls back to the first circuit-network condition's text (mirrors the
+     * icon getter above) so a panel imported with only `control_behavior.parameters`
+     * set still shows something here, even though this UI only ever writes the
+     * top-level `text` field.
+     */
+    public get displayPanelText(): string | undefined {
+        if (this.type !== 'display-panel') return undefined
+        return this.m_rawEntity.text ?? this.m_rawEntity.control_behavior?.parameters?.[0]?.text
+    }
+
+    public set displayPanelText(text: string | undefined) {
+        if (this.m_rawEntity.text === text) return
+
+        this.m_BP.history
+            .updateValue(this.m_rawEntity, 'text', text, 'Change display panel text')
+            .onDone(() => this.emit('displayPanelText', this.displayPanelText))
+            .commit()
+    }
+
+    /**
+     * Whether the display panel's first line of text is always shown above the
+     * entity, rather than only on hover. Stored as `undefined` rather than
+     * `false` when off, to avoid persisting a field Factorio itself omits.
+     */
+    public get displayPanelAlwaysShow(): boolean {
+        return !!this.m_rawEntity.always_show
+    }
+
+    public set displayPanelAlwaysShow(alwaysShow: boolean) {
+        if (this.displayPanelAlwaysShow === alwaysShow) return
+
+        this.m_BP.history
+            .updateValue(
+                this.m_rawEntity,
+                'always_show',
+                alwaysShow || undefined,
+                'Change display panel always show text'
+            )
+            .onDone(() => this.emit('displayPanelAlwaysShow', this.displayPanelAlwaysShow))
+            .commit()
+    }
+
+    /** Read-only circuit-network conditions of a circuit-connected display panel. Editing these is not yet supported. */
+    public get displayPanelParameters():
+        | { text?: string; icon?: ISignal; condition?: ICondition }[]
+        | undefined {
+        if (this.type !== 'display-panel') return undefined
+        return this.m_rawEntity.control_behavior?.parameters
+    }
+
+    /**
+     * Names of everything a display panel's icon can be set to: items,
+     * fluids, and virtual signals. Unlike `acceptedRecipes`/`acceptedModules`
+     * this does not depend on `this` at all - the panel places no constraint
+     * on its own icon - but lives here rather than as a free function so
+     * `DisplayPanelIcon` can read it the same way it reads every other
+     * accepted-* list.
+     */
+    public get acceptedDisplayPanelIcons(): string[] {
+        const itemNames = FD.inventoryLayout.flatMap(group =>
+            group.subgroups.flatMap(subgroup => subgroup.items.map(item => item.name))
+        )
+        return [...itemNames, ...Object.keys(FD.fluids), ...Object.keys(FD.signals)]
+    }
+
+    /** The `ISignal.type` a name from `acceptedDisplayPanelIcons` should be set with. */
+    public displayPanelIconType(name: string): ISignal['type'] {
+        if (FD.fluids[name]) return 'fluid'
+        if (FD.signals[name]) return 'virtual'
+        return undefined
     }
 
     public get mayCraftWithFluid(): boolean {

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -411,6 +411,15 @@ const testApi = {
     openDialogCount: () => editor.openDialogCount,
     topDialogBounds: () => editor.topDialogBounds,
     /*
+        Whether the entity's info overlay container is currently visible - not
+        what it was built with, which overlayInfoTally already covers, but
+        whether EntityContainer has it switched on right now. The display panel
+        editor swaps this opposite the hover tooltip so the two never draw at
+        once; nothing else needed to read it before.
+    */
+    entityInfoVisible: (entityNumber: number) =>
+        EntityContainer.containerOf(entityNumber).entityInfoVisible,
+    /*
         The size of EntityContainer.mappings, the static entity-number -> container
         index. Loading a blueprint should leave it holding exactly that
         blueprint's containers; anything above is retention from a previously

--- a/tests/display-panel-editor.spec.ts
+++ b/tests/display-panel-editor.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect } from '@playwright/test'
+import {
+    encodeBlueprint as encode,
+    packVersion as version,
+    decodeBlueprintString,
+} from './helpers/encode-blueprint'
+import { suppressOverlays } from './helpers/overlays'
+
+/*
+    The display panel editor.
+
+    `DisplayPanelEditor` was never registered in `UI/editors/factory.ts`, so a
+    display panel could be placed but had no editor at all - no way to set its
+    icon, its text, or whether that text always shows. The commented-out chest
+    editor case sat unreachable the same way for two releases with every check
+    green, because nothing here runs Playwright in CI - see CLAUDE.md. That is
+    the reason this spec exists rather than a general policy: `overlay-container
+    .spec.ts` tallies what `createEntityInfo` returns and would keep passing if
+    the editor stopped opening entirely, since it never opens one.
+
+    What it cannot see either is the visibility swap `EntityContainer.
+    pointerOverEventHandler`/`pointerOutEventHandler` do: the always-show label
+    and the full-text hover tooltip draw in different containers, so they hide
+    `entityInfo` on hover and restore it on hover-out, rather than removing or
+    rebuilding anything the tally would notice. `entityInfoVisible` is a new
+    `__fbe_test` hook for exactly that; nothing before this needed to read it.
+
+    Locating controls: the dialog is drawn with pixi, so there is no selector
+    for the text field. `topDialogBounds` plus `DisplayPanelEditor`'s own layout
+    constants would give the field's position, but the field is a real DOM
+    `<input>` - `TextInput` is the one control in UI/ that is - so it is found
+    and driven directly instead, the way tests/text-input.spec.ts does.
+
+    Runs against the dev server like the rest of tests/ - see CLAUDE.md for the
+    two servers that have to be up.
+*/
+
+type Page = import('@playwright/test').Page
+
+const INITIAL_TEXT = 'Old text'
+
+/** always_show: true so the panel draws its persistent label with no hover needed. */
+const DISPLAY_PANEL = encode({
+    item: 'blueprint',
+    version: version(2, 0, 55),
+    icons: [{ index: 1, signal: { type: 'item', name: 'display-panel' } }],
+    entities: [
+        {
+            entity_number: 1,
+            name: 'display-panel',
+            position: { x: 0.5, y: 0.5 },
+            text: INITIAL_TEXT,
+            always_show: true,
+        },
+    ],
+})
+
+async function load(page: Page, source: string): Promise<string[]> {
+    const errors: string[] = []
+    page.on('pageerror', e => errors.push(String(e)))
+
+    await suppressOverlays(page)
+    await page.goto('/')
+    await page.waitForFunction(() => window.__fbe_test !== undefined, { timeout: 60_000 })
+    await page.evaluate(async (src: string) => {
+        const t = window.__fbe_test
+        await t.loadBp(await t.getBlueprintOrBookFromSource(src))
+    }, source)
+    return errors
+}
+
+/** Where entity `n` sits on screen right now - loading re-centres the view, so this is read fresh rather than computed from the encoded position. */
+async function screenPositionOf(
+    page: Page,
+    entityNumber: number
+): Promise<{ x: number; y: number }> {
+    const at = await page.evaluate(
+        (n: number) => window.__fbe_test.entityScreenPosition(n),
+        entityNumber
+    )
+    if (!at) throw new Error(`no entity ${entityNumber} in the loaded blueprint`)
+    return at
+}
+
+/*
+    Hovers the entity, which is enough to enter EDIT and to run the
+    pointerOver/pointerOut visibility swap - a left click on top of that is
+    `openEntityGUI` and is what actually opens the dialog.
+
+    Steps away first: hovering is driven by GridData's `update32`, which only
+    fires when the pointer crosses a tile boundary, so moving to a point the
+    pointer already occupies emits nothing. Same reason as chest-editor.spec.ts.
+*/
+async function hover(page: Page, at: { x: number; y: number }): Promise<void> {
+    await page.mouse.move(at.x, at.y + 240)
+    await page.mouse.move(at.x, at.y)
+}
+
+async function openEditorOn(page: Page, entityNumber: number): Promise<void> {
+    const at = await screenPositionOf(page, entityNumber)
+    await hover(page, at)
+    expect(await page.evaluate(() => window.__fbe_test.editorMode())).toBe('EDIT')
+
+    await page.mouse.down()
+    await page.mouse.up()
+}
+
+const dialogCount = (page: Page): Promise<number> =>
+    page.evaluate(() => window.__fbe_test.openDialogCount())
+
+const entityInfoVisible = (page: Page, entityNumber: number): Promise<boolean> =>
+    page.evaluate((n: number) => window.__fbe_test.entityInfoVisible(n), entityNumber)
+
+/*
+    Focuses the DOM input currently holding `value` - DisplayPanelEditor's own
+    text field, told apart from the settings pane's inputs by having an inline
+    style. TextInput writes that, nothing else on the page does. Borrowed from
+    tests/text-input.spec.ts's focusInputWithValue.
+*/
+async function focusInputWithValue(page: Page, value: string): Promise<void> {
+    await page.evaluate((v: string) => {
+        const el = [...document.querySelectorAll('input, textarea')].find(
+            i => (i as HTMLInputElement).style.cssText !== '' && (i as HTMLInputElement).value === v
+        )
+        if (!el) throw new Error(`no input holding "${v}"`)
+        ;(el as HTMLInputElement).focus()
+    }, value)
+}
+
+async function decodedEntities(page: Page): Promise<Record<string, unknown>[]> {
+    const source = await page.evaluate(() => window.__fbe_test.encodeLoaded())
+    return decodeBlueprintString(source).blueprint.entities
+}
+
+test('clicking a display panel opens its editor, and it closes again', async ({ page }) => {
+    const errors = await load(page, DISPLAY_PANEL)
+    expect(await dialogCount(page)).toBe(0)
+
+    await openEditorOn(page, 1)
+    expect(await dialogCount(page)).toBe(1)
+
+    await page.keyboard.press('Escape')
+    expect(await dialogCount(page)).toBe(0)
+    expect(errors, `page errors: ${errors.join(' | ')}`).toEqual([])
+})
+
+test('editing the text field writes through to the serialized blueprint', async ({ page }) => {
+    /*
+        Asserted against the serialized blueprint rather than against the model
+        a getter would read back, since a setter that wrote a correct value into
+        the wrong shape would still make Entity.displayPanelText answer right -
+        `serialize()` is the thing a real export depends on.
+    */
+    const errors = await load(page, DISPLAY_PANEL)
+    await openEditorOn(page, 1)
+
+    await focusInputWithValue(page, INITIAL_TEXT)
+    await page.keyboard.press('Control+A')
+    await page.keyboard.type('New text')
+    // Tabbing away is what commits the change in the running app.
+    await page.keyboard.press('Tab')
+
+    const entities = await decodedEntities(page)
+    expect(entities).toHaveLength(1)
+    expect(entities[0]).toMatchObject({ text: 'New text' })
+    expect(errors, `page errors: ${errors.join(' | ')}`).toEqual([])
+})
+
+test('hovering hides the always-show label behind the tooltip, and moving away restores it', async ({
+    page,
+}) => {
+    const errors = await load(page, DISPLAY_PANEL)
+
+    // Not hovering: the always-show label is the only thing there is to draw.
+    expect(await entityInfoVisible(page, 1)).toBe(true)
+
+    const at = await screenPositionOf(page, 1)
+    await hover(page, at)
+    expect(await page.evaluate(() => window.__fbe_test.editorMode())).toBe('EDIT')
+    expect(await entityInfoVisible(page, 1)).toBe(false)
+
+    await page.mouse.move(at.x, at.y + 240)
+    expect(await page.evaluate(() => window.__fbe_test.editorMode())).toBe('NONE')
+    expect(await entityInfoVisible(page, 1)).toBe(true)
+
+    expect(errors, `page errors: ${errors.join(' | ')}`).toEqual([])
+})

--- a/tests/helpers/fbe-test-api.ts
+++ b/tests/helpers/fbe-test-api.ts
@@ -194,6 +194,13 @@ export interface FbeTestApi {
      * control inside one. Throws when nothing is open.
      */
     topDialogBounds: () => { x: number; y: number; width: number; height: number }
+    /**
+     * Whether `EntityContainer.entityInfo` is currently visible for this
+     * entity - the persistent always-show label and the hover tooltip toggle
+     * it opposite each other so the two never stack. See
+     * tests/display-panel-editor.spec.ts.
+     */
+    entityInfoVisible: (entityNumber: number) => boolean
 }
 
 /**

--- a/tests/overlay-container.spec.ts
+++ b/tests/overlay-container.spec.ts
@@ -156,6 +156,7 @@ const EXPECTED_REAL: Record<string, number[]> = {
     'constant-combinator': [-1, 1],
     'cryogenic-plant': [4],
     'decider-combinator': [2],
+    'display-panel': [-1, 1],
     'electric-furnace': [-1, 1],
     'electromagnetic-plant': [1, 2, 4],
     'express-splitter': [-1, 1],


### PR DESCRIPTION
Display-panel entity could be placed but had no editor at all - no way to set its icon or text, and the sprite-level icon rendering (EntitySprite/ spriteDataBuilder) only ever read whatever a blueprint import already carried.

Adds:
- An icon picker (DisplayPanelIcon, a Slot like Recipe/Modules) backed by a new Entity.acceptedDisplayPanelIcons - items, fluids, and virtual signals, matching what the game itself allows.
- A text field and an "Always show text in 'Alt-mode'" checkbox. Per the wiki, hovering always shows every line regardless of that setting; the checkbox only controls whether the first line stays visible above the entity without hovering. Rendered via two new OverlayContainer entry points (showEntityTooltip/hideEntityTooltip for the hover case, a block in createEntityInfo for the always-show case) and wired into EntityContainer's redraw/pointer handling, which previously had no display-panel awareness at all.
- A read-only list of a circuit-connected panel's control_behavior.parameters conditions - editing those live is a separate, larger feature and out of scope here.

InventoryDialog changes, needed by the icon picker rather than by display-panel itself:
- computeWidth widens the dialog when a filter populates more group tabs than the fixed 404px layout was designed for. The icon picker's items+fluids+signals filter is the first caller to hit this - up to 7 tabs against Space Age data, so the 5-groups-max layout used to hide the last tab(s) behind the dialog's own edge.
- The existing scroll viewport/scrollbar already handled tall groups, but the scrollbar thumb was pinned to a fixed VP_X + VP_W offset - correct at the old fixed width, but stranded well short of the actual right edge once computeWidth widens the dialog. Anchored it to `this.width` instead.
- A showRecipePanel flag (default on, matching every existing caller) lets the icon picker skip the recipe panel, which would otherwise render as a permanently empty bar - none of items/fluids/signals have a recipe.