### PR TITLE
docs: correct the exporter note that sends a macOS run at code macOS cannot reach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -589,8 +589,19 @@ one per package that has earned it.
   basisu - `./basisu` is a runtime `Command::new` at `src/setup.rs:501`, there is
   no `build.rs`, and no dependency is platform-gated. **Running** it needs both, and
   the tracked basisu binary is macOS ARM64 only, so a crate that changes runtime
-  behaviour without breaking the build passes green. Anything touching image, zip,
-  tar or compression handling still wants a local run on macOS.
+  behaviour without breaking the build passes green. Anything touching image
+  handling still wants a local run on macOS - `image::*` at `setup.rs:134-150` is
+  ungated and runs there. **Archive handling is the exception, and a macOS run
+  cannot reach it at all.** `download()` panics on macOS at `setup.rs:568`, where
+  the `"macos" => "osx"` arm of the `std::env::consts::OS` match is commented out,
+  and both extraction branches sit below that panic: `zip::ZipArchive` under
+  `#[cfg(target_os = "windows")]` and `tokio_tar` over an `async-compression`
+  `LzmaDecoder` under `#[cfg(target_os = "linux")]`. So for zip, tar or
+  compression the ubuntu and Windows CI compiles are the only evidence available
+  short of running the exporter on one of those platforms, and a macOS run is
+  theatre. Measured while merging the `async-compression` 0.4.19 -> 0.4.43 bump,
+  which swapped the lzma backend from `xz2` to `liblzma` and so looked exactly
+  like the case this note was written for.
 - `ajv` is ~100 kB minified and **nothing branches on its result** - the load
   proceeds identically either way, and `ModdedBlueprintError` /
   `TrainBlueprintError` are declared, exported, handled, and never thrown. Decide


### PR DESCRIPTION
## What

The `Rust exporter is compiled in CI but never run` note under **Known and unfixed** ended by saying that anything touching image, zip, tar or compression handling still wants a local run on macOS. Half of that is unreachable code.

## The measurement

`download()` panics on macOS at `packages/exporter/src/setup.rs:568`, because the `"macos" => "osx"` arm of the `std::env::consts::OS` match is commented out:

```rust
let os = match std::env::consts::OS {
    "linux" => "linux64",
    "windows" => "win64-manual",
    // "macos" => "osx",
    _ => panic!("unsupported OS"),
};
```

Both extraction branches sit below that panic, inside the same function:

- `zip::ZipArchive` at `setup.rs:623`, under `#[cfg(target_os = "windows")]`
- `tokio_tar::Archive` over an `async-compression` `LzmaDecoder` at `setup.rs:629-631`, under `#[cfg(target_os = "linux")]`

So a macOS run reaches neither. For zip, tar or compression the ubuntu and Windows CI compiles are the only evidence available short of running the exporter on one of those platforms.

The image half holds and is kept as-is: `image::*` at `setup.rs:134-150` is ungated and does run on macOS.

## Why it surfaced now

Found while merging #196, the `async-compression` 0.4.19 -> 0.4.43 bump. That bump swapped the lzma backend from `xz2` to `liblzma` (adding `compression-codecs` and `compression-core` as transitives), which is exactly the shape of change this note was written to catch - and following the note would have meant a macOS run that could not have exercised a single line of it.

## Verification

`vp check` clean - 216 files formatted, 0 lint or type errors. Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjgP62MzShZ8WCYVbS2X85