### PR TITLE
build(deps): take nanoid to 3.3.18 to clear GHSA-2v37-7h3g-55p8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4378,9 +4378,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
## What

`npm audit` reports **4** advisories where CLAUDE.md records **3**. The new one is `nanoid` 3.3.16 - high, [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8), "custom generators can loop indefinitely when size is zero", affecting `<3.3.17`.

This moves it to 3.3.18. Lockfile only, one package.

## Why it is fixable when undici is not

It is transitive-only:

```
vite-plus@0.2.6 -> @voidzero-dev/vite-plus-core@0.2.6 -> postcss@8.5.24 -> nanoid@3.3.16
```

It appears in no `package.json`, so Renovate structurally cannot propose it - per CLAUDE.md, Renovate only matches alerts against dependencies it extracts from a manifest, which is why every transitive-only advisory here is Dependabot-only.

What makes a fix possible is that **postcss declares a range** (`"nanoid": "^3.3.16"`) rather than an exact pin. So `npm update nanoid --package-lock-only` moves exactly one package and touches nothing else:

```
 package-lock.json | 6 +++---
 node_modules/nanoid: 3.3.16 -> 3.3.18
```

That is the same tell CLAUDE.md records from the `fast-uri` fix. Contrast `undici`, pinned exactly by miniflare (`undici: 7.28.0`), which is why the three remaining advisories stay blocked upstream and are untouched here.

Deliberately **not** `npm audit fix` - measured on this repo it pulls an unrelated **alpha major** of miniflare, and `--force` *downgrades* wrangler.

## Scope

Dev-only. `npm audit --omit=dev` is 0 both before and after. nanoid reaches the build through postcss's CSS pipeline, so the website build is the check that matters rather than the test suite.

## Verification

| Check | Result |
|---|---|
| `npm audit` | 4 -> **3** (2 moderate, 1 high), back to the documented undici-only baseline |
| `npm audit --omit=dev` | 0, unchanged |
| `vp check` | clean - 216 files formatted, 0 lint/type errors |
| `vp test` | 143/143 |
| `vp build` (website) | built in 2.96s |

`cargo audit` was also run while investigating: 276 crates, exit 0, no advisories - so #196's `async-compression` bump introduced nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjgP62MzShZ8WCYVbS2X85