### PR TITLE
docs: correct two stale notes in renovate.json5

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -99,14 +99,22 @@
 
     // NOTHING MERGES UNREAD. No exceptions, including GitHub Action digest re-pins.
     //
-    // The local reason is specific and stronger than the usual one: CI here runs
+    // The local reason is specific and stronger than the usual one: CI runs
     // `vp check` (oxfmt + oxlint + tsc), `vp test` (vitest units + the type-check
-    // gate) and nothing else. It does NOT run Playwright - and tests/ is where
-    // essentially all of this project's behavioural coverage lives, 25-odd specs
-    // covering placement, paste, sprites and the blueprint round trip. It also
-    // never compiles packages/exporter. So a green check here proves the repo is
-    // CONSISTENT under lint and types; it says nothing about whether a bump is
-    // CORRECT.
+    // gate), and compiles packages/exporter on ubuntu and Windows. It does NOT run
+    // Playwright - and tests/ is where essentially all of this project's
+    // behavioural coverage lives, 25-odd specs covering placement, paste, sprites
+    // and the blueprint round trip. So a green check here proves the repo is
+    // CONSISTENT under lint and types and that the Rust side still builds; it says
+    // nothing about whether a bump is CORRECT.
+    //
+    // This paragraph used to end "it also never compiles packages/exporter", which
+    // the `Rust exporter` and `Rust exporter (Windows)` jobs at ci.yml:89 and :163
+    // contradict - and which the cargo rule below already contradicted in the same
+    // file, noting that an earlier draft said the opposite and was corrected. The
+    // conclusion is unchanged either way: the exporter is COMPILED and never RUN,
+    // which is the boundary the cargo note draws, and the Playwright gap carries
+    // this argument on its own.
     //
     // The sibling repo has the counterexample on record: pako 3.0.0 flipped a hash
     // default that passes a green suite while silently breaking a byte-exactness

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -282,9 +282,20 @@
             // Note also that with the default `rangeStrategy: auto` most crate bumps
             // land as Cargo.lock-only diffs, with no Cargo.toml change to read - the
             // job's `--locked` is what checks the lockfile Renovate wrote is coherent.
+            //
+            // The note used to end by asking for a local macOS run on image, zip, tar
+            // or compression bumps. Half of that was unreachable and it is corrected
+            // below: `download()` panics on macOS at src/setup.rs:568, where the
+            // `"macos" => "osx"` arm is commented out, and BOTH extraction branches sit
+            // below that panic - zip under cfg(windows), tokio-tar over an
+            // async-compression LzmaDecoder under cfg(linux). So no macOS run can reach
+            // an archive crate, and asking for one sends the reader at code that cannot
+            // execute. The image half survives: image::* at src/setup.rs:134-150 is
+            // ungated. Same correction as CLAUDE.md's "Known and unfixed" entry, which
+            // was fixed first; keep the two in step.
             matchManagers: ['cargo'],
             prBodyNotes: [
-                'CI compiles this crate (the `Rust exporter` job) but **cannot run it** - the exporter needs a Factorio install to extract from, and sprite encoding shells out to `./basisu`, for which only a macOS ARM64 binary is tracked. So a green check means it still builds and the lockfile is coherent; a crate that changes runtime behaviour without breaking the build will pass. For anything touching image, zip, tar or compression handling, run the exporter locally on macOS before merging.',
+                'CI compiles this crate (the `Rust exporter` job) but **cannot run it** - the exporter needs a Factorio install to extract from, and sprite encoding shells out to `./basisu`, for which only a macOS ARM64 binary is tracked. So a green check means it still builds and the lockfile is coherent; a crate that changes runtime behaviour without breaking the build will pass. For anything touching **image** handling, run the exporter locally on macOS before merging. For **zip, tar or compression**, a macOS run is not an option and should not be attempted: `download()` panics on macOS (`src/setup.rs:568`), and both extraction branches sit below that panic - `zip` under `cfg(target_os = "windows")` and `tokio-tar` over an `async-compression` `LzmaDecoder` under `cfg(target_os = "linux")`. The ubuntu and Windows compiles are the only evidence available short of running the exporter on one of those platforms.',
             ],
         },
         {


### PR DESCRIPTION
Two comments in `renovate.json5` that outlived the thing they described. Config only, no code touched.

## 1. The cargo PR-body note asks for a run that cannot happen

Every cargo PR body ends with:

> For anything touching image, zip, tar or compression handling, run the exporter locally on macOS before merging.

The archive half is unreachable code. #198 corrected it in CLAUDE.md; this corrects the copy that actually reaches readers. **#200 carried the wrong instruction verbatim this morning**, which is how it surfaced.

`download()` panics on macOS at `packages/exporter/src/setup.rs:568` - the `"macos" => "osx"` arm of the `std::env::consts::OS` match is commented out:

```rust
let os = match std::env::consts::OS {
    "linux" => "linux64",
    "windows" => "win64-manual",
    // "macos" => "osx",
    _ => panic!("unsupported OS"),
};
```

Both extraction branches sit below that panic, in the same function:

| Crate | Site | Gate |
|---|---|---|
| `zip::ZipArchive` | `setup.rs:623` | `#[cfg(target_os = "windows")]` |
| `tokio_tar` + `async-compression` `LzmaDecoder` | `setup.rs:629-631` | `#[cfg(target_os = "linux")]` |

The note now splits the cases: **image** handling still wants a local macOS run (`image::*` at `setup.rs:134-150` is ungated and does run there), while **zip, tar or compression** should not be attempted on macOS, with the ubuntu and Windows compiles named as the real evidence.

## 2. The automerge note says CI never compiles the exporter

`renovate.json5:107` ended "it also never compiles packages/exporter". The `Rust exporter` and `Rust exporter (Windows)` jobs at `ci.yml:89` and `:163` are exactly that, and they ran and passed on all five PRs merged today.

The file already disagreed with itself: the cargo rule lower down says the opposite, and records that an earlier draft of *that* rule said the opposite and was corrected deliberately. The half that was right carried the correction note.

The paragraph's conclusion is unchanged - the exporter is **compiled and never run**, which is the boundary the cargo note draws, and the Playwright gap carries the argument on its own. Only the supporting claim was wrong.

## Why both are worth fixing rather than leaving

This file is the one place a reviewer meets these claims at the moment they act on them, since `prBodyNotes` renders into every PR body. A wrong note here is read more often than a wrong line in CLAUDE.md, and acted on directly.

## Verification

- `npx --yes --package renovate -- renovate-config-validator` (run from outside the repo root, per this file's own header): **Config validated successfully**
- 7 `packageRules`, unchanged count
- `vp check` clean - 216 files formatted, 0 lint/type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjgP62MzShZ8WCYVbS2X85