### PR TITLE
test: throw on a blueprint left at the top level of test-blueprints/

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,16 @@ const baseURL = process.env.FBE_BASE_URL ?? 'http://localhost:8080'
 
 export default defineConfig({
     testDir: './tests',
+    /*
+        Specs only. Playwright's default also collects *.test.ts, and tests/
+        now holds one - blueprint-files.test.ts, a vitest test, because Playwright
+        does not run in CI and the corpus guard in #190 has to (see the `corpus`
+        project in vite.config.ts). Without this it would be collected by both
+        runners and fail under Playwright, which cannot supply `describe`/`it`.
+
+        A no-op for what actually runs: all 40 existing files here are .spec.ts.
+    */
+    testMatch: '**/*.spec.ts',
     timeout: 120_000,
     expect: {
         timeout: 60_000,

--- a/test-blueprints/README.md
+++ b/test-blueprints/README.md
@@ -13,6 +13,24 @@ Every file is a raw Factorio blueprint string, exactly as the game exports it -
 one line, no trailing newline. `tests/helpers/blueprint-files.ts` reads them
 with a `.trim()`.
 
+## Where a new blueprint goes
+
+`test-blueprints/<collection>/<name>.txt`. The collection folder is not optional:
+`discoverBlueprintFiles` walks one level down, so a `.txt` left at the top level
+of this directory is loaded by no spec. It now **throws** naming the file rather
+than skipping it in silence (issue #190), and `vp test` runs that check in CI, so
+a stray file fails a PR instead of waiting to be noticed.
+
+That guard exists because the silence had already cost something. The old corpus
+carried a top-level `wormeyman-tests/a.txt` holding 368 blueprints which no spec
+ever read, but which a hand count of the directory did - and that is where the
+"1452 `control_behavior` sections" in `tests/pre-2-0-shape-migrations.spec.ts`
+came from, against a discovered corpus really holding 1295.
+
+Adding a file also moves the pinned fixtures under `tests/__fixtures__/`, which
+are fixed points rather than snapshots. Expect that to be the larger half of the
+change.
+
 Provenance is recorded the way `tools/oracle/fixtures/` records its own.
 
 ## EARN - ElderAxe

--- a/tests/helpers/blueprint-files.test.ts
+++ b/tests/helpers/blueprint-files.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it } from 'vite-plus/test'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { discoverBlueprintFiles } from './blueprint-files'
+
+/*
+    A vitest test rather than a Playwright spec, and that is the whole point of
+    it rather than a filing decision. `discoverBlueprintFiles` is pure Node - no
+    browser, no dev server, no FD - but more importantly Playwright does not run
+    in CI here, and `vp test` does. A guard that only fires on someone's local
+    run is most of the way back to the silence #190 is about: a contributor drops
+    test-blueprints/foo.txt, it merges green, and it is found whenever somebody
+    next happens to run the browser suite.
+
+    So the last test below calls the function bare, against the real corpus, and
+    that call is what makes a committed stray file a red CI run.
+
+    This is the only .test.ts under tests/. playwright.config.ts pins a testMatch
+    of spec files only, so Playwright does not also try to run this file as a
+    spec - the other 40 files there are all .spec.ts, so that narrowing changed
+    nothing about what Playwright collects.
+*/
+
+/** A real blueprint string, so a file that gets read is a file that parses. */
+const A_BLUEPRINT =
+    '0eNqrVkrKTFeyUlAqSS0uUdJRykjMS8lJLVayqlZKzEspSy0qzsxLVzBUsjIyMDIwsjA2NDU2NTOtBQC/qA9M'
+
+const tempRoots: string[] = []
+
+function makeRoot(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fbe-corpus-'))
+    tempRoots.push(dir)
+    return dir
+}
+
+function writeBlueprint(dir: string, relativePath: string): void {
+    const full = path.join(dir, relativePath)
+    fs.mkdirSync(path.dirname(full), { recursive: true })
+    fs.writeFileSync(full, A_BLUEPRINT)
+}
+
+afterEach(() => {
+    while (tempRoots.length > 0) {
+        fs.rmSync(tempRoots.pop() as string, { recursive: true, force: true })
+    }
+})
+
+describe('discoverBlueprintFiles', () => {
+    it('throws naming a blueprint that sits at the top level', () => {
+        const root = makeRoot()
+        writeBlueprint(root, 'EARN/proper.txt')
+        writeBlueprint(root, 'orphan.txt')
+
+        /*
+            The name has to be in the message. "A file was skipped" sends whoever
+            hits this back to reading readdirSync calls; "orphan.txt" sends them
+            to the file. This is the assertion that a fix which throws a bare
+            Error fails.
+        */
+        expect(() => discoverBlueprintFiles(root)).toThrow(/orphan\.txt/)
+    })
+
+    it('names every stray file, not just the first', () => {
+        const root = makeRoot()
+        writeBlueprint(root, 'b-second.txt')
+        writeBlueprint(root, 'a-first.txt')
+
+        /*
+            Reporting one at a time turns cleaning up three files into three
+            runs, and the loop is over a list already in hand.
+
+            What this does *not* pin is the sort, and it is worth saying so
+            rather than leaving the assertion looking stronger than it is:
+            mutation-checked, deleting the `.sort` from the stray list leaves
+            this green, because readdirSync happens to answer in name order on
+            APFS. The sort is there for the same reason the collection walk
+            sorts - directory order is a filesystem property and ext4 returns
+            hash order - so the case that needs it is the one no test on this
+            machine can reach.
+        */
+        let message = ''
+        try {
+            discoverBlueprintFiles(root)
+        } catch (e) {
+            message = (e as Error).message
+        }
+
+        expect(message).toContain('a-first.txt, b-second.txt')
+    })
+
+    it('is untroubled by a non-.txt file at the top level', () => {
+        const root = makeRoot()
+        writeBlueprint(root, 'EARN/proper.txt')
+        fs.writeFileSync(path.join(root, 'README.md'), '# corpus\n')
+
+        /*
+            The control, and it can fail while the two tests above pass: the
+            corpus root really does hold a README.md that #186 put there, so a
+            guard written as "any file at the top level" would throw on a clean
+            checkout and take all 40 specs with it.
+        */
+        const files = discoverBlueprintFiles(root)
+        expect(files.map(f => f.name)).toEqual(['EARN/proper'])
+    })
+
+    it('still discovers a normal corpus, sorted', () => {
+        const root = makeRoot()
+        writeBlueprint(root, 'ZETA/b.txt')
+        writeBlueprint(root, 'ALPHA/b.txt')
+        writeBlueprint(root, 'ALPHA/a.txt')
+
+        /*
+            The guard is a filter that only ever throws, so nothing it does
+            should change what a clean corpus discovers. Order included:
+            blueprint-round-trip.spec.ts folds the corpus into one hash in
+            iteration order, so a resort here is a fixture diff there.
+        */
+        const files = discoverBlueprintFiles(root)
+        expect(files.map(f => f.name)).toEqual(['ALPHA/a', 'ALPHA/b', 'ZETA/b'])
+        expect(files.map(f => f.collection)).toEqual(['ALPHA', 'ALPHA', 'ZETA'])
+        expect(files.every(f => fs.existsSync(f.filePath))).toBe(true)
+    })
+
+    it('finds the committed corpus clean', () => {
+        /*
+            Called bare, so this reads test-blueprints/ through the same default
+            every spec uses. This is the test that runs in CI on every push and
+            so the one that makes a committed stray file fail a PR rather than
+            wait for somebody's local Playwright run.
+
+            The count assertion is not decoration: without it a corpus that had
+            gone missing entirely would satisfy "did not throw", since an absent
+            root returns an empty list by design.
+        */
+        const files = discoverBlueprintFiles()
+
+        expect(files.length).toBeGreaterThan(0)
+        expect(new Set(files.map(f => f.collection))).toEqual(new Set(['EARN', 'JEPAKAZOL']))
+    })
+})

--- a/tests/helpers/blueprint-files.ts
+++ b/tests/helpers/blueprint-files.ts
@@ -12,11 +12,54 @@ export interface BlueprintFile {
 
 const TESTS_DIR = path.resolve(process.cwd(), 'test-blueprints')
 
-export function discoverBlueprintFiles(): BlueprintFile[] {
+/**
+ * Every `.txt` in `test-blueprints/{collection}/`, sorted.
+ *
+ * `root` exists so blueprint-files.test.ts can point this at a directory it
+ * built, rather than writing a stray file into the committed corpus and relying
+ * on cleanup it might not reach. Every caller in tests/ passes nothing.
+ *
+ * @throws if `root` holds a `.txt` directly. See the comment on that check.
+ */
+export function discoverBlueprintFiles(root: string = TESTS_DIR): BlueprintFile[] {
     const files: BlueprintFile[] = []
 
-    if (!fs.existsSync(TESTS_DIR)) {
+    if (!fs.existsSync(root)) {
         return files
+    }
+
+    const entries = fs.readdirSync(root, { withFileTypes: true })
+
+    /*
+        A blueprint sitting at the top level is read by nothing, and until #190
+        it was also *reported* by nothing - this walked one level down and a
+        stray file simply did not exist as far as the suite was concerned.
+
+        That silence has already cost something. The old corpus carried
+        wormeyman-tests/a.txt, 368 blueprints that no spec ever loaded but that a
+        hand measurement of the directory counted, which is where
+        pre-2-0-shape-migrations.spec.ts got "1452 control_behavior sections"
+        against a discovered corpus holding 1295. The 157 difference was exactly
+        that file, and the figure sat wrong until #186 re-measured it.
+
+        Throwing rather than adopting the file is the louder answer and the right
+        one now that test-blueprints/ is committed and public: the point of #186
+        is that a fresh clone and the specs see the same corpus, and a file that
+        only one of them can see breaks that quietly. A contributor who drops one
+        here gets told where it belongs instead of silently getting no coverage.
+    */
+    const stray = entries
+        .filter(d => d.isFile() && d.name.endsWith('.txt'))
+        .map(d => d.name)
+        .sort((a, b) => a.localeCompare(b))
+
+    if (stray.length > 0) {
+        throw new Error(
+            `${stray.length} blueprint file(s) sit directly in ${root} and so are read by no spec: ` +
+                `${stray.join(', ')}. Blueprints live in ` +
+                `${path.basename(root)}/<collection>/<name>.txt - move each one into a ` +
+                `collection folder, or delete it.`
+        )
     }
 
     /*
@@ -27,13 +70,12 @@ export function discoverBlueprintFiles(): BlueprintFile[] {
         point only on the machine that recorded it, which is the one thing a
         committed corpus must not be.
     */
-    const collections = fs
-        .readdirSync(TESTS_DIR, { withFileTypes: true })
+    const collections = entries
         .filter(d => d.isDirectory())
         .sort((a, b) => a.name.localeCompare(b.name))
 
     for (const collection of collections) {
-        const collectionPath = path.join(TESTS_DIR, collection.name)
+        const collectionPath = path.join(root, collection.name)
         const txtFiles = fs
             .readdirSync(collectionPath)
             .filter(f => f.endsWith('.txt'))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -222,6 +222,34 @@ export default defineConfig({
                     exclude: ['tests/**', '**/node_modules/**', '**/dist/**'],
                 },
             },
+            {
+                /*
+                    The tests under tests/ that need no browser. Two reasons they
+                    are here rather than in a package's own project.
+
+                    Playwright does not run in CI, and `vp test` does, so a check
+                    that lives only in a .spec.ts gates nothing - which is the
+                    whole point of the corpus guard in tests/helpers/
+                    blueprint-files.test.ts (#190). It has to fail a PR, not
+                    somebody's laptop.
+
+                    And the root tsconfig is the only one here that puts `node`
+                    in `types`; packages/editor narrows it back to typed-factorio
+                    so browser code cannot reach node globals. A test that reads
+                    a file off disk therefore has to sit under a directory the
+                    root config owns, whatever package it is testing.
+
+                    Only *.test.ts is collected. The 40 specs next door are
+                    Playwright's and would fail immediately under vitest, having
+                    no browser fixtures; playwright.config.ts pins the mirror
+                    image of this so neither runner collects the other's files.
+                */
+                test: {
+                    name: 'unit',
+                    environment: 'node',
+                    include: ['tests/**/*.test.ts'],
+                },
+            },
         ],
     },
 })


### PR DESCRIPTION
`discoverBlueprintFiles` walks `test-blueprints/` one level down - collections, then `.txt` files inside each. A `.txt` at the top level was read by nothing and reported by nothing, which is silence in both directions: a contributor who drops one gets no coverage and no error, and anyone measuring the directory with a shell glob gets a number the suite does not agree with.

It throws now, naming every stray file and where it belongs. That is the loudest of the three options in #190, and the issue argues for it on the grounds that the corpus is committed and public: the point of #186 is that a fresh clone and the specs see the same thing, and a file only one of them can see breaks that quietly.

```
Error: 1 blueprint file(s) sit directly in .../test-blueprints and so are read by
no spec: oops-stray.txt. Blueprints live in test-blueprints/<collection>/<name>.txt
- move each one into a collection folder, or delete it.
```

## Two decisions worth reviewing

**`discoverBlueprintFiles` takes an optional root.** The alternative was a test that writes a stray file into the real `test-blueprints/` and deletes it afterwards, which inverts the bug being fixed: a run killed between the write and the cleanup leaves the corpus poisoned, and then every later run throws. All 11 existing callers pass nothing and are untouched.

**The test is vitest, not Playwright, and that is the point rather than a filing decision.** Playwright does not run in CI here; `vp test` does. A guard that only fires on someone's local run is most of the way back to the silence being fixed, so the last test calls the function bare against the real corpus. That call is what turns a committed stray file into a red PR. Verified end to end by planting `test-blueprints/oops-stray.txt` and watching `vp test` fail naming it.

That needed a `unit` vitest project for `tests/**/*.test.ts`. `tests/` is also the only directory here whose tsconfig carries node types, `packages/editor` having narrowed them away on purpose, so it is where a test that reads a file off disk has to live regardless of what it is testing. Playwright's `testMatch` is narrowed to specs so the two runners do not collect each other's files.

## Verification

- `vp check .` clean, 218 files formatted, 0 warnings or errors
- `vp test` 154 passing across 12 files (was 148 across 11)
- `npx playwright test` **176 passed**, unchanged, still 40 files - the `testMatch` narrowing is a no-op today since every existing spec is already `.spec.ts`

Mutation-checked, four ways:

| Mutation | Result |
| --- | --- |
| Remove the throw | 2 tests fail |
| Throw a bare `Error` without the filename | the same 2 fail |
| Guard on any top-level file rather than `.txt` | the README control and the real-corpus test fail |
| Drop the `sort` on the stray list | **nothing fails** |

The last one is honest rather than fixed: `readdirSync` answers in name order on APFS, so the case the sort exists for is not reachable on this machine. The test comment says so rather than leaving the assertion looking stronger than it is.

Closes #190
