### PR TITLE
test: select all with ControlOrMeta so the display panel spec passes on macOS

### DIFF
--- a/tests/display-panel-editor.spec.ts
+++ b/tests/display-panel-editor.spec.ts
@@ -155,7 +155,14 @@ test('editing the text field writes through to the serialized blueprint', async 
     await openEditorOn(page, 1)
 
     await focusInputWithValue(page, INITIAL_TEXT)
-    await page.keyboard.press('Control+A')
+    /*
+        Select-all, and it has to be ControlOrMeta rather than Control. On macOS
+        Control+A is the emacs "beginning of line" binding, not select-all, so
+        nothing is selected and the typed text lands in *front* of what is
+        already there - the assertion below gets "New textOld text". It passes
+        on Linux either way, which is why it reached the default branch.
+    */
+    await page.keyboard.press('ControlOrMeta+A')
     await page.keyboard.type('New text')
     // Tabbing away is what commits the change in the running app.
     await page.keyboard.press('Tab')


### PR DESCRIPTION
`tests/display-panel-editor.spec.ts`, added in #197, presses `Control+A` to select the existing text before typing over it. On macOS that is the emacs "beginning of line" binding rather than select-all, so nothing gets selected and the typed text lands in front of what is already there. The assertion receives `"New textOld text"`.

It is the only `Control+A` in the suite. It passes on Linux, which is how it reached the default branch: CI here never runs Playwright, so the four green checks on #197 said nothing about it.

Measured on the merged tree before the fix: 178 passed, 1 failed, 5.4 minutes. With `ControlOrMeta+A` the spec passes over three repeats, and `vp check` is clean.

The rest of #197 is fine, and mutation-checked: removing the `case 'display-panel':` from `factory.ts` fails the first two tests, and removing either half of the `entityInfo.visible` swap in `EntityContainer` fails the third and only the third. Coverage of the alt-mode checkbox, the icon picker and the connected branch is still missing and is coming separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174k7bAYBrsUSddaafLE9Ky