### PR TITLE
Measure the game's zoom ladder, range and off-rung rule

### DIFF
--- a/docs/superpowers/specs/2026-08-10-zoom-levels-design.md
+++ b/docs/superpowers/specs/2026-08-10-zoom-levels-design.md
@@ -1,0 +1,180 @@
+# Zoom levels that behave like the game's
+
+Issue #206. Design settled 2026-08-10.
+
+## The problem, measured
+
+The complaint is that scrolling does not feel like Factorio. Reading the code turns that into three separate defects, none of which is about units.
+
+**The units already agree.** `EntityContainer.position` multiplies world coordinates by 32 (`EntityContainer.ts:296`), so the editor draws 32 px per tile at scale 1. Factorio's runtime API at 2.0.77 says of `LuaPlayer::zoom`: "The baseline zoom level is 1. Values greater than 1 will zoom in closer to the world and values between 0 and 1 will zoom out away from the world." Same baseline, same pixels per tile. The editor's scale number is already Factorio's zoom number, so nothing needs converting. Everything below is about which values we step through and where we stop.
+
+### Defect 1: the step is asymmetric, so zoom does not round-trip
+
+`BlueprintContainer.zoom()` uses a flat `zoomFactor = 0.1` and calls `viewport.zoomBy(+/-0.1)`. `Viewport.zoomBy` does `this.scaleX += delta`, and `scaleX` is reset to 1 after every `_updateMatrix`, so the value multiplied into the transform is `1 + delta`.
+
+Zoom in is therefore `x 1.1` and zoom out is `x 0.9`, and those are not inverses:
+
+```
+1.1 x 0.9 = 0.99
+```
+
+One notch in and one notch out leaves the view 1% further out than it started, with nothing to snap back. Ten round trips lose about 10%.
+
+### Defect 2: the wheel discards how far you scrolled
+
+```js
+if (Math.sign(e.deltaY) === 1) {
+    this.zoom(false)
+} else {
+    this.zoom(true)
+}
+```
+
+Only the sign is read. A trackpad emitting a burst of small pixel deltas and a mouse emitting one notch produce the same fixed jump. This is the likeliest single cause of "does not feel like the game". `WheelEvent.deltaMode` also varies across devices and browsers (pixels, lines, pages), so raw `deltaY` is not comparable without normalising.
+
+### Defect 3: the ceiling is soft and there is no floor
+
+`maxZoom` is `3`, passed at `BlueprintContainer.ts:87`, so 96 px per tile. The guard is:
+
+```js
+if (Math.sign(deltaX) === 1 && this.origTransform.a > this.maxZoom) return
+```
+
+It tests **before** applying, so from 2.99 a tick still lands at 3.289 - the ceiling is soft by a full step. Zooming out has no clamp anywhere; grepping `Viewport.ts` and `BlueprintContainer.ts` finds no floor. Because the step is multiplicative it approaches 0 asymptotically rather than going negative, so it degrades into an unusable speck instead of breaking outright.
+
+## What the game gives us, and what it does not
+
+From the 2.0.77 install's own `doc-html/runtime-api.json`, which is a better source than the online docs for a pinned version:
+
+- zoom 1.0 is baseline, `> 1` closer, `0 < z < 1` further out
+- `ZoomSpecification` supports either a fixed `zoom` or a dynamic `distance` in tiles computed against the window's aspect ratio
+- `max_distance` defaults to **500** tiles along the window's longest axis, a hard limit on how far a player can see
+
+Not available from either source: the per-notch step, and the character controller's default `zoom_limits`. Those are engine constants. `factorio-data` at the 2.0.77 tag was grepped and holds only `camera_zoom` values inside Factoriopedia and tips-and-tricks simulations (1.0 to 4), which are scripted camera positions rather than player limits; `core/prototypes/utility-constants.lua` has `zoom_to_world_can_use_nightvision` and friends but no threshold or range.
+
+So the range must be asked of the game. The step cannot be, without a human scrolling, and we have chosen not to require that.
+
+## Decisions
+
+### A fixed ladder, not corrected continuous constants
+
+Zoom moves through an ordered array of levels; a notch moves the index by one.
+
+This kills defect 1 **by construction** rather than by arithmetic - there is no accumulation, so in-then-out returns the exact value it started on. It makes the ceiling and floor exact rather than soft. And it is the only model a test can assert: a continuous multiplier can only be tested for its clamps, whereas a ladder can be pinned whole, which matters because nothing under `tests/` reads a zoom level today.
+
+Rejected: continuous with a symmetric step (`x k` and `x 1/k`). Smaller diff and it fixes the drift, but "the same as the game" stays approximate and the levels passed through are whatever the starting scale happened to be times `k^n`.
+
+Rejected: continuous while scrolling, snapping on settle. Best feel in principle, but it needs a settle timer, and the viewport's existing dirty-flag-and-ticker split has already produced one hard-to-find bug around deferred state (#144).
+
+### Scale stays the source of truth; the first notch snaps
+
+`centerViewPort` fits a loaded blueprint by computing a continuous scale from its bounds, so the zoom after a load is almost never a ladder value.
+
+The state stays a continuous scale. A notch finds the nearest ladder value to the current scale, moves one index from there, and clamps. Loading therefore still fits a blueprint exactly, and mobile pinch stays continuous with no special case.
+
+Rejected: storing the ladder index as truth. Simplest state, but loading would snap to the nearest level, so a blueprint would no longer fit its viewport - it would land slightly over- or under-filled. That changes framing for every blueprint, breaks the fit-to-bounds guarantee that `rail-signal-snapping.spec.ts` relies on when it derives zoom from two entities a known distance apart, and cannot express pinch-to-zoom at all.
+
+Rejected: an index whose ladder gains the computed fit value per blueprint. Preserves the fit and keeps integer state, but the ladder is then not constant, so no test can assert it and the levels only match the game away from wherever you started.
+
+### Wheel events accumulate a normalised delta
+
+`deltaY` is normalised via `deltaMode` into a common unit and added to a running total. Each time the total crosses a threshold, one rung is stepped and the threshold subtracted, keeping the remainder.
+
+A mouse notch crosses the threshold in one event; a trackpad needs several; slow scrolling still arrives because the remainder carries.
+
+Rejected: one step per event. Smallest diff, but it leaves the defect most likely to explain the original complaint, and a discrete ladder makes it more visible than continuous zoom does.
+
+Rejected: rungs proportional to magnitude. Most responsive to a flick, but one event could jump most of the ladder, which with discrete levels reads as teleporting - the same failure the rail signal `R` key had before its ordering was fixed.
+
+## Architecture
+
+### `packages/editor/src/core/zoomLevels.ts` (new, pure)
+
+No pixi, no FD, no globals, following `railSignalSnapping.ts`, `throughput.ts` and `util.ts`. It owns the ladder and every decision about it:
+
+```ts
+export const ZOOM_LEVELS: readonly number[] // ascending, contains the value 1.0
+export function stepZoom(scale: number, direction: 1 | -1): number
+export function clampZoom(scale: number): number
+export class WheelAccumulator {
+    feed(deltaY: number, deltaMode: number): number
+}
+```
+
+`ZOOM_LEVELS` is a **committed literal array**, not computed at runtime. It is generated once from the probe's measured endpoints and the chosen ratio, then written into the file, so the ladder a test asserts is the ladder that ships. Regenerating it is a deliberate act, the same rule the other measured tables here follow.
+
+`stepZoom` is where the snap lives: nearest ladder value to the current continuous scale, move one index, clamp. From `0.83` on a ladder containing `1.0`, a notch in yields the rung above `1.0`.
+
+`WheelAccumulator.feed` returns a **signed** rung count - negative for zoom out, positive for zoom in, `0` when the threshold has not been crossed. Usually -1, 0 or 1.
+
+### `Viewport.ts`
+
+Keeps its continuous scale and its accumulating matrix. Two changes:
+
+- gains a real floor
+- the ceiling test moves to **after** the multiply, so it stops being soft by a step
+
+**The measured range replaces `maxZoom = 3`.** The ladder's endpoints become the editor's limits, so the constructor argument at `BlueprintContainer.ts:87` is superseded by `ZOOM_LEVELS[0]` and its last element. If the probe reports a ceiling above 3 the editor gains reach it did not have, and if below, it loses some - either is intended, since the stated goal is the game's range. The one number that must not move silently is the floor, because there is none today and anything is stricter than nothing.
+
+`zoomBy` stays as it is for **mobile pinch**, which feeds a genuinely continuous `scaleDelta` derived from finger distance and cannot be expressed in rungs. Pinch gets `clampZoom` only; the ladder never touches it.
+
+### `BlueprintContainer.ts`
+
+Loses `zoomFactor = 0.1`. Owns a `WheelAccumulator` and calls `setCurrentScale(stepZoom(...))` once per rung crossed. `zoom(zoomIn)` stays public as editor-package API; note it currently has exactly one caller, the wheel handler, and there are no keyboard zoom bindings.
+
+## The probe
+
+`tools/oracle/probe-zoom-limits.mjs`, fixture `tools/oracle/fixtures/zoom-limits.json`, version-stamped 2.0.77 with `factorio_version` derived from `factorio --version` rather than hardcoded.
+
+It measures the effective range **two independent ways**, and that is the control rather than an afterthought:
+
+1. read `player.zoom_limits` directly
+2. write `player.zoom = 10000` and read back; write `player.zoom = 0.00001` and read back. The docs state that writes outside the limits are always valid but reads are clamped, so what comes back is the true ceiling and floor.
+
+The two must agree. A disagreement is the finding, not a number to average.
+
+Two things make this unlike every previous probe in this repo, and both belong in its README:
+
+- **It needs a `LuaPlayer`.** Every previous probe read prototypes or queried a surface. A headless server has no player until one connects, so this runs against the 2.0.77 client with a freeplay scenario and the usual `error()`-out dump. If no player can be obtained, that **voids the section** rather than producing zeros to be read as a finding, per the elevated-rail lesson.
+- **Limits are per controller type.** The character controller is the one that means "like the game"; god and spectator will differ. Recording all of them costs nothing and says whether the number chosen is the one a player actually experiences.
+
+## The ladder's ratio is deliberately not chosen here
+
+The ratio is the one number in this design that is pure feel, and it is left to a driving session inside the implementation PR.
+
+The reason is a scar: rail signal snapping shipped fully tested and mutation-checked with a 4-tile snap radius that left the signal 390px from the pointer and an `R` key that jumped diagonally across the track. Both were found in one sitting by driving the editor and printing positions, and no passing test could have shown either.
+
+The change in coarseness is real and worth stating: today's continuous `x 1.1` needs eleven notches to double, where a ladder at ratio 1.5 doubles in under two. A defensible starting point is around 1.33:
+
+```
+... 0.33, 0.44, 0.59, 0.79, 1.0, 1.33, 1.78, 2.37, 3.16 ...
+```
+
+Ship a starting ratio, drive it, print numbers, then throw the measuring probe away - it is an instrument, not a test.
+
+## Testing
+
+Everything with a decision in it is pure, so `packages/editor/src/core/zoomLevels.test.ts` runs under `vp test` in **CI**. That is the point: nothing under `tests/` reads a zoom level today, and Playwright never runs in CI (#210).
+
+- **round trip** - `stepZoom` in then out returns the exact starting value. Defect 1, now impossible by construction and pinned so it stays that way.
+- **ladder invariants** - strictly ascending, contains exactly `1.0`, spans the measured range.
+- **clamps are exact** - stepping in at the top rung stays at the top rung rather than overshooting, and the same at the floor, which does not exist today at all. Defect 3.
+- **snap from off-ladder** - from `0.83`, a notch in gives the rung above `1.0`.
+- **accumulator** - one mouse notch is one rung; N trackpad events make one rung; the remainder carries so slow scrolling arrives; `deltaMode` line and page units normalise to the same result as pixels. Defect 2.
+
+Playwright covers only what a browser can see: that a wheel event over the canvas moves the viewport scale, and that loading a blueprint still fits it. The second is a guard rather than a feature - it is what would catch a `centerViewPort` regression, and it exists because the specs deriving zoom from blueprint bounds would otherwise fail confusingly.
+
+## Sequencing
+
+Two PRs against `wormeyman-space-age-support`, squash-merged, no issue number in either subject.
+
+1. **The probe and its fixture.** Pure measurement, no behaviour change, reviews as evidence. Its result picks the ladder's endpoints.
+2. **The ladder, the wiring, and the tests.** One reviewable behaviour change. The ratio driving session happens inside it, before merge.
+
+Landing `zoomLevels.ts` on its own between the two was considered and rejected: a pure module nothing calls is dead code at merge time, and its unit tests are what make it reviewable anyway.
+
+## Out of scope
+
+- Matching the game's exact per-notch step. It is an input-handling constant no headless probe can reach, and getting it means a manual scrolling session against a logging mod. The measured range plus a chosen ratio is the agreed substitute. **Tracked as #211**, which is blocked on this work landing and carries the method, including the control that makes it worth doing: the endpoints of a hand-scrolled ladder must equal the limits this design's headless probe measures independently, so the two instruments check each other.
+- Changing what `centerViewPort` computes. The fit stays exact; that is the point of keeping scale as truth.
+- Mobile pinch behaviour beyond gaining a clamp.

--- a/docs/superpowers/specs/2026-08-10-zoom-levels-design.md
+++ b/docs/superpowers/specs/2026-08-10-zoom-levels-design.md
@@ -1,6 +1,59 @@
 # Zoom levels that behave like the game's
 
-Issue #206. Design settled 2026-08-10.
+Issue #206. Design settled 2026-08-10; measured against the game 2026-08-11, which
+answered every number this document left open and corrected two of its claims.
+
+## What the probe found (2026-08-11)
+
+`tools/oracle/probe-zoom-limits.mjs`, fixture `tools/oracle/fixtures/zoom-limits.json`,
+against the 2.0.77 client over four sessions with a human at the wheel.
+
+- **The step is `2^(1/7)` - seven notches per doubling - and the ladder is
+  absolute, anchored at exactly 1.0.** Every one of the 23 non-clamp values
+  scrolled through is an exact `2^(n/7)`, worst deviation in `n` of 4.2e-10.
+  The ratio this document declined to choose did not need choosing.
+- **A notch from between two rungs snaps to the _nearest_ rung and then moves one
+  index** - the rule guessed under "the first notch snaps", now measured. Two
+  further rules survived the obvious probe and one of them is wrong: from 0.83 a
+  notch in gives 0.905724 under both `nearest+step` and "next rung in the
+  direction of travel", and only a notch **out** separates them (0.742997
+  against 0.820335). It answered 0.742997.
+- **The ceiling is 3**, exactly what `BlueprintContainer.ts:87` already passes.
+  The editor's ceiling was never wrong; only its softness was.
+- **A step that would overshoot a limit lands on the limit exactly**, not on the
+  last rung before it. So the clamp value is reachable and is not itself a rung.
+- **The floor is not a number, it is a rule**: at most `distance = 200` tiles
+  across the window, capped at `max_distance = 500`. On a 16:9 window that is
+  exactly 0.3; on the 3736x2044-at-scale-2 window measured it is 0.283889, which
+  the documented formula reproduces to 1e-9.
+- **The units claim is confirmed exactly.** That floor formula only lands on the
+  measured value at 32 px per tile per unit zoom, against the window in logical
+  pixels (`display_resolution / display_scale`). The editor's 32 and the game's
+  are the same 32.
+- `furthest_game_view` is a **third** limit this document did not know about, and
+  it is `distance 200` for the character, god and spectator controllers alike -
+  the game never draws the world further out than 200 tiles across. God and
+  spectator may zoom out further (to 0.015625 and 0.00390625), but that range
+  renders as **chart view**, which the editor does not have.
+
+### The one decision the measurement did not settle: the floor
+
+**Adopting the game's world-view floor is not open to us.** 30 of the 367 corpus
+blueprints are wider than 200 tiles and the widest is 397, which needs zoom 0.151
+to fit at a 1920px viewport where the game's floor is 0.300. Taking the game's
+number literally would make 8% of real blueprints impossible to view whole. The
+200-tile limit exists so a player cannot see ungenerated chunks - a constraint
+that does not apply to an editor at all.
+
+**The floor is 0.1, the game's own map editor floor** (decided 2026-08-11). It is
+the game's number for the editing context rather than an invented constant, and
+it fits the widest corpus blueprint with room to spare. So the ladder runs
+`2^(n/7)` for `n` in -23..11, clamped exactly at 0.1 and 3 - clamping to the
+limit itself rather than to the last rung, which is what the game does.
+
+Everything below is the design as settled on 2026-08-10, before any of this was
+measured. Where it disagrees with the section above, the section above is what
+was found.
 
 ## The problem, measured
 
@@ -116,6 +169,8 @@ Keeps its continuous scale and its accumulating matrix. Two changes:
 
 **The measured range replaces `maxZoom = 3`.** The ladder's endpoints become the editor's limits, so the constructor argument at `BlueprintContainer.ts:87` is superseded by `ZOOM_LEVELS[0]` and its last element. If the probe reports a ceiling above 3 the editor gains reach it did not have, and if below, it loses some - either is intended, since the stated goal is the game's range. The one number that must not move silently is the floor, because there is none today and anything is stricter than nothing.
 
+**Measured 2026-08-11: the ceiling is 3, so `maxZoom` was already right** and the only change at the top is that the clamp stops being soft by a step. The floor is 0.1, and the anticipation above is exactly inverted - the number that moves is not the ceiling, and the floor is not adopted from the game's range at all but from its map editor, because the game's own world-view floor cannot express a 397-tile blueprint. See "the one decision the measurement did not settle" at the top.
+
 `zoomBy` stays as it is for **mobile pinch**, which feeds a genuinely continuous `scaleDelta` derived from finger distance and cannot be expressed in rungs. Pinch gets `clampZoom` only; the ladder never touches it.
 
 ### `BlueprintContainer.ts`
@@ -139,6 +194,10 @@ Two things make this unlike every previous probe in this repo, and both belong i
 - **Limits are per controller type.** The character controller is the one that means "like the game"; god and spectator will differ. Recording all of them costs nothing and says whether the number chosen is the one a player actually experiences.
 
 ## The ladder's ratio is deliberately not chosen here
+
+**Superseded 2026-08-11: it is `2^(1/7)`, measured.** The rest of this section is what was believed before the probe ran, and why it was wrong is worth keeping. The ratio was called pure feel and handed to a driving session because the design assumed a human scrolling against a logging mod was too expensive to ask for. It took one sitting. This section was reasoning about a number that was sitting in the game waiting to be read - and the guessed starting point below, 1.33, is three real notches wide. Shipping it would have felt wrong in exactly the way #206 complains about, and no test could have said so.
+
+---
 
 The ratio is the one number in this design that is pure feel, and it is left to a driving session inside the implementation PR.
 
@@ -175,6 +234,6 @@ Landing `zoomLevels.ts` on its own between the two was considered and rejected: 
 
 ## Out of scope
 
-- Matching the game's exact per-notch step. It is an input-handling constant no headless probe can reach, and getting it means a manual scrolling session against a logging mod. The measured range plus a chosen ratio is the agreed substitute. **Tracked as #211**, which is blocked on this work landing and carries the method, including the control that makes it worth doing: the endpoints of a hand-scrolled ladder must equal the limits this design's headless probe measures independently, so the two instruments check each other.
+- ~~Matching the game's exact per-notch step.~~ **Done on 2026-08-11, before any of this shipped, and #211 is answered rather than blocked.** It is `2^(1/7)`. The reasoning that put it out of scope was sound and the conclusion was wrong: it is indeed an input-handling constant no headless probe can reach, and it did need a manual scrolling session against a logging mod - which turned out to cost one sitting rather than being a reason to ship a substitute. The control named here is the one that passed: the hand-scrolled endpoints equal the independently measured limits at both ends, in all four sessions. **The lesson is the cost estimate, not the method** - "no headless probe can reach it" was allowed to stand in for "not worth measuring", and those are different claims.
 - Changing what `centerViewPort` computes. The fit stays exact; that is the point of keeping scale as truth.
 - Mobile pinch behaviour beyond gaining a clamp.

--- a/tools/oracle/README.md
+++ b/tools/oracle/README.md
@@ -51,6 +51,7 @@ This is the part that saves time, and it is not "open a disassembler":
 | `probe-rail-signal-spots.mjs`        | Every legal signal position, and whether the #95 window clipped them (#133)   |
 | `probe-elevated-rail-support.mjs`    | What holds an elevated rail up, and whether a tile grid can express it (#141) |
 | `probe-entity-tile-size.mjs`         | What `tile_width`/`tile_height` the game publishes for every entity (#142)    |
+| `probe-zoom-limits.mjs`              | What zoom range and what per-notch step the game uses (#206, #211)            |
 
 One script here is not a probe and asks the game nothing:
 
@@ -232,6 +233,45 @@ model wants the same treatment.
   configuration, so 20 is the number that describes real exports, and the corpus
   confirms it: every export spaces its supports exactly 20 apart. Measuring only
   the walk would have produced a rule that refuses every real elevated bridge.
+- **Some questions need a human, and that is a cost rather than a wall.**
+  `probe-zoom-limits.mjs` is the first probe here that runs the **graphics
+  client** rather than a headless `--create`, because zoom belongs to a
+  `LuaPlayer` and a created map has nobody in it. It is also the first that does
+  not `error("DUMPED-OK")` out: the automated half writes its dump and the mod
+  keeps running while a human scrolls, appending every changed `player.zoom` to
+  disk as it happens, so a quit at any moment loses nothing. #206's design had
+  written the per-notch step off as unreachable - "an input-handling constant no
+  headless probe can reach" - and proposed shipping a guessed 1.33 in its place.
+  The real answer is `2^(1/7)`, three notches of the real ladder away from the
+  guess, and getting it took one sitting. **"No headless probe can reach it" is
+  not the same claim as "not worth measuring"**, and the first was allowed to
+  stand in for the second.
+- **Which hypotheses a probe value can separate is part of the question.** Three
+  rules for what a zoom notch does from an off-ladder start agree on every
+  sample taken from a rung, so only an off-rung start says anything - and _which
+  pair_ it separates depends on where in the gap it sits. 0.83 sits below its
+  gap's midpoint, so a notch **in** rules out "multiply where you are" and
+  cannot tell "snap to the nearest rung then step" from "move to the next rung
+  in the direction of travel": both say 0.905724, exactly. A notch **out** from
+  the same value separates them (0.742997 against 0.820335) and settled it.
+  Reading the first probe as a verdict would have adopted the wrong rule with a
+  number that matched to nine digits. Evaluate every probe against every rule,
+  and report the rules that survive **all** of them rather than the one that
+  fits the last.
+- **A script-set value is not a measured one**, and it enters the same stream.
+  The command that sets an off-ladder zoom trips the live sampler on the same
+  tick, so 0.83 arrives looking exactly like a rung the wheel stopped on - it
+  would join the distinct set, sit between two real rungs, and break the
+  constant-ratio check for a reason that has nothing to do with the game. Tag
+  what the probe itself wrote, and exclude it by tag rather than by value.
+- **Ask what a limit _is_ before comparing it to a number.** `zoom_limits` has
+  three fields, not two, and they are not all the same kind of thing. `closest`
+  is a zoom; `furthest` is a **rule** - at most `distance = 200` tiles across the
+  window, capped at 500 - so comparing it to a readback answers "DISAGREE" for a
+  limit that is perfectly correct. Transcribing the documented formula turned an
+  incomparable field into a third instrument that agrees with the readback to
+  1e-9. The third field, `furthest_game_view`, was not known to the design at
+  all and is the one that matters to a viewer with no map view.
 - **Entities snap, so a requested position is not a measured one.** A rail asked
   for at (-4,-4) lands at (-3,-3) on the 2-tile rail grid, and several accepted
   (position, direction) triples collapse to one real placement. Read offsets off
@@ -275,6 +315,38 @@ This is also the first capture here taken on a **2.0.x** binary rather than on
 2.1.12, and the cross-check paid for itself again: four entities move footprint
 between 2.0.77 and 2.1.12 (`tree-plant` and the three demolisher corpses), none
 of them among the 155 the editor knows.
+
+And what zoom the game uses (issue #206, `fixtures/zoom-limits.json`), the first
+measurement here that needed a human and the first to answer a question a design
+had already given up on:
+
+- The step is **`2^(1/7)`** - seven notches per doubling - on a ladder anchored
+  at exactly 1.0. All 23 non-clamp values scrolled through are exact `2^(n/7)`,
+  worst deviation in `n` of 4.2e-10 across four sessions.
+- From a value on no rung, a notch **snaps to the nearest rung and then moves one
+  index**. See the hypothesis-separation gotcha above for why that took two
+  probes in opposite directions rather than one.
+- A step that would overshoot a limit **lands on the limit exactly**, so the
+  clamp value is reachable and is not itself a rung.
+- The ceiling is **3**, which is already what the editor passes as `maxZoom`.
+- The floor is a rule, not a number: at most **200 tiles across the window**,
+  hard-capped at 500. That is 0.3 on a 16:9 window and 0.283889 on the
+  3736x2044-at-scale-2 window measured, which the documented formula reproduces
+  to 1e-9 - and only at **32 px per tile against the window in logical pixels**
+  (`display_resolution / display_scale`), which is the same 32 the editor draws
+  with. `furthest_game_view` is `distance 200` for the character, god and
+  spectator controllers alike: the game never renders the world further out than
+  that, and god and spectator's extra range (to 0.015625 and 0.00390625) is
+  chart view.
+
+The floor is also where the measurement **refused the change it was capturing
+evidence for**, which is now the third time that has happened here. #206's stated
+goal is the game's range, but 30 of the 367 corpus blueprints are wider than 200
+tiles - the widest is 397, needing zoom 0.151 to fit at 1920px against a floor of
+0.300 - so adopting the game's own floor makes 8% of real blueprints impossible
+to view whole. The game's 200-tile limit exists to stop a player seeing
+ungenerated chunks, a constraint an editor does not have. Its **map editor**
+floor, 0.1, is the number that transfers.
 
 ## Fixture policy
 

--- a/tools/oracle/fixtures/zoom-limits.json
+++ b/tools/oracle/fixtures/zoom-limits.json
@@ -1,0 +1,401 @@
+{
+    "provenance": {
+        "issue": 206,
+        "binary": "Version: 2.0.77 (build 84539, mac-arm64, full)",
+        "modFactorioVersion": "2.0",
+        "capturedBy": "tools/oracle/probe-zoom-limits.mjs",
+        "mods": {
+            "base": "2.0.77",
+            "bp_zoom_limits": "0.0.1",
+            "elevated-rails": "2.0.77",
+            "quality": "2.0.77",
+            "space-age": "2.0.77"
+        },
+        "display": {
+            "resolution": {
+                "width": 3736,
+                "height": 2044
+            },
+            "scale": 2
+        },
+        "note": "Zoom is a property of a player controller, so this ran against the graphics client with a human at the wheel for the ladder half. The editor targets 2.0.45 to 2.0.73 and the corpus spans 2.0.32 to 2.1.12."
+    },
+    "characterController": {
+        "limitsRead": {
+            "closest": {
+                "zoom": 3
+            },
+            "furthest": {
+                "distance": 200,
+                "max_distance": 500
+            },
+            "furthest_game_view": {
+                "distance": 200,
+                "max_distance": 500
+            }
+        },
+        "readbackClosest": 3,
+        "readbackFurthest": 0.2838888888888889,
+        "observedGameViewFloor": 0.2838888888888889,
+        "renderModesSeen": ["1"]
+    },
+    "scrolledLadder": {
+        "sampleCount": 51,
+        "rungFormula": "2^(n/7), baseline 2^0 = 1.0",
+        "notchesPerDoubling": 7,
+        "ratio": 1.1040895136738123,
+        "distinct": [
+            0.2838888888888889, 0.30475341356374647, 0.33647504817086915, 0.37149857229706473,
+            0.4101676780165656, 0.45286183214446296, 0.5000000000120853, 0.5520447568483433,
+            0.6095068271127607, 0.6729500963254726, 0.7429971445761708, 0.8203353560133031,
+            0.9057236642670341, 1, 1.10408951367, 1.219013654196057, 1.3459001926184142,
+            1.4859942891164242, 1.6406707119869501, 1.8114473284902843, 1.9999999999516587,
+            2.2081790272866266, 2.438027308333185, 2.691800385171766, 3
+        ],
+        "worstRungDeviationInN": 4.184510515869988e-10,
+        "plateaus": [
+            {
+                "z": 1,
+                "heldTicks": 721,
+                "rm": "1"
+            },
+            {
+                "z": 1.10408951367,
+                "heldTicks": 1,
+                "rm": "1"
+            },
+            {
+                "z": 1.219013654196057,
+                "heldTicks": 1,
+                "rm": "1"
+            },
+            {
+                "z": 1.3459001926184142,
+                "heldTicks": 1,
+                "rm": "1"
+            },
+            {
+                "z": 1.4859942891164242,
+                "heldTicks": 1,
+                "rm": "1"
+            },
+            {
+                "z": 1.6406707119869501,
+                "heldTicks": 1,
+                "rm": "1"
+            },
+            {
+                "z": 1.8114473284902843,
+                "heldTicks": 1,
+                "rm": "1"
+            },
+            {
+                "z": 1.9999999999516587,
+                "heldTicks": 1,
+                "rm": "1"
+            },
+            {
+                "z": 2.2081790272866266,
+                "heldTicks": 1,
+                "rm": "1"
+            },
+            {
+                "z": 2.438027308333185,
+                "heldTicks": 1,
+                "rm": "1"
+            },
+            {
+                "z": 2.691800385171766,
+                "heldTicks": 1,
+                "rm": "1"
+            },
+            {
+                "z": 3,
+                "heldTicks": 451,
+                "rm": "1"
+            },
+            {
+                "z": 2.691800385171766,
+                "heldTicks": 9,
+                "rm": "1"
+            },
+            {
+                "z": 2.438027308333185,
+                "heldTicks": 67,
+                "rm": "1"
+            },
+            {
+                "z": 2.2081790272866266,
+                "heldTicks": 9,
+                "rm": "1"
+            },
+            {
+                "z": 1.9999999999516587,
+                "heldTicks": 10,
+                "rm": "1"
+            },
+            {
+                "z": 1.8114473284902843,
+                "heldTicks": 71,
+                "rm": "1"
+            },
+            {
+                "z": 1.6406707119869501,
+                "heldTicks": 9,
+                "rm": "1"
+            },
+            {
+                "z": 1.4859942891164242,
+                "heldTicks": 10,
+                "rm": "1"
+            },
+            {
+                "z": 1.3459001926184142,
+                "heldTicks": 70,
+                "rm": "1"
+            },
+            {
+                "z": 1.219013654196057,
+                "heldTicks": 9,
+                "rm": "1"
+            },
+            {
+                "z": 1.10408951367,
+                "heldTicks": 82,
+                "rm": "1"
+            },
+            {
+                "z": 1,
+                "heldTicks": 9,
+                "rm": "1"
+            },
+            {
+                "z": 0.9057236642670341,
+                "heldTicks": 10,
+                "rm": "1"
+            },
+            {
+                "z": 0.8203353560133031,
+                "heldTicks": 69,
+                "rm": "1"
+            },
+            {
+                "z": 0.7429971445761708,
+                "heldTicks": 9,
+                "rm": "1"
+            },
+            {
+                "z": 0.6729500963254726,
+                "heldTicks": 10,
+                "rm": "1"
+            },
+            {
+                "z": 0.6095068271127607,
+                "heldTicks": 71,
+                "rm": "1"
+            },
+            {
+                "z": 0.5520447568483433,
+                "heldTicks": 9,
+                "rm": "1"
+            },
+            {
+                "z": 0.5000000000120853,
+                "heldTicks": 59,
+                "rm": "1"
+            },
+            {
+                "z": 0.45286183214446296,
+                "heldTicks": 11,
+                "rm": "1"
+            },
+            {
+                "z": 0.4101676780165656,
+                "heldTicks": 9,
+                "rm": "1"
+            },
+            {
+                "z": 0.37149857229706473,
+                "heldTicks": 71,
+                "rm": "1"
+            },
+            {
+                "z": 0.33647504817086915,
+                "heldTicks": 9,
+                "rm": "1"
+            },
+            {
+                "z": 0.30475341356374647,
+                "heldTicks": 10,
+                "rm": "1"
+            },
+            {
+                "z": 0.2838888888888889,
+                "heldTicks": 0,
+                "rm": "1"
+            },
+            {
+                "z": 1,
+                "heldTicks": 713,
+                "rm": "1"
+            },
+            {
+                "z": 1.10408951367,
+                "heldTicks": 9,
+                "rm": "1"
+            },
+            {
+                "z": 1.219013654196057,
+                "heldTicks": 107,
+                "rm": "1"
+            },
+            {
+                "z": 1.10408951367,
+                "heldTicks": 9,
+                "rm": "1"
+            },
+            {
+                "z": 1,
+                "heldTicks": 0,
+                "rm": "1"
+            },
+            {
+                "z": 1,
+                "heldTicks": 1279,
+                "rm": "1"
+            },
+            {
+                "z": 0.9057236642670341,
+                "heldTicks": 8,
+                "rm": "1"
+            },
+            {
+                "z": 1,
+                "heldTicks": 61,
+                "rm": "1"
+            },
+            {
+                "z": 0.9057236642670341,
+                "heldTicks": 9,
+                "rm": "1"
+            },
+            {
+                "z": 0.8203353560133031,
+                "heldTicks": 0,
+                "rm": "1"
+            },
+            {
+                "z": 1,
+                "heldTicks": 4083,
+                "rm": "1"
+            },
+            {
+                "z": 0.9057236642670341,
+                "heldTicks": 9,
+                "rm": "1"
+            },
+            {
+                "z": 1,
+                "heldTicks": 527,
+                "rm": "1"
+            },
+            {
+                "z": 0.7429971445761708,
+                "heldTicks": 9,
+                "rm": "1"
+            },
+            {
+                "z": 0.6729500963254726,
+                "heldTicks": 0,
+                "rm": "1"
+            }
+        ]
+    },
+    "offLadderNotches": [
+        {
+            "start": 0.8299999999999998,
+            "direction": "in",
+            "landed": 0.9057236642670341,
+            "predictions": {
+                "relative": 0.916394296349264,
+                "nearestThenStep": 0.9057236642639066,
+                "directional": 0.9057236642639067
+            },
+            "fits": ["nearestThenStep", "directional"]
+        },
+        {
+            "start": 0.8299999999999998,
+            "direction": "in",
+            "landed": 0.9057236642670341,
+            "predictions": {
+                "relative": 0.916394296349264,
+                "nearestThenStep": 0.9057236642639066,
+                "directional": 0.9057236642639067
+            },
+            "fits": ["nearestThenStep", "directional"]
+        },
+        {
+            "start": 0.8299999999999998,
+            "direction": "out",
+            "landed": 0.7429971445761708,
+            "predictions": {
+                "relative": 0.7517506413390425,
+                "nearestThenStep": 0.7429971445684743,
+                "directional": 0.820335356007638
+            },
+            "fits": ["nearestThenStep"]
+        }
+    ],
+    "samplesByController": {
+        "1": {
+            "count": 57,
+            "min": 0.2838888888888889,
+            "max": 3
+        }
+    },
+    "otherControllers": [
+        {
+            "controller": "god",
+            "limits": {
+                "closest": {
+                    "zoom": 3
+                },
+                "furthest": {
+                    "zoom": 0.015625
+                },
+                "furthest_game_view": {
+                    "distance": 200,
+                    "max_distance": 500
+                }
+            },
+            "readback_closest_same_tick": 3,
+            "readback_furthest_same_tick": 0.015625
+        },
+        {
+            "controller": "spectator",
+            "limits": {
+                "closest": {
+                    "zoom": 3
+                },
+                "furthest": {
+                    "zoom": 0.00390625
+                },
+                "furthest_game_view": {
+                    "distance": 200,
+                    "max_distance": 500
+                }
+            },
+            "readback_closest_same_tick": 3,
+            "readback_furthest_same_tick": 0.00390625
+        }
+    ],
+    "controls": {
+        "sessions": 4,
+        "sessionsAgreeOnLimits": true,
+        "ceilingInstrumentsAgree": true,
+        "floorInstrumentsAgree": true,
+        "distinctScrolledValues": 25,
+        "everyValueIsAnExactRung": true,
+        "scrolledEndpointsEqualLimits": true
+    }
+}

--- a/tools/oracle/probe-zoom-limits.mjs
+++ b/tools/oracle/probe-zoom-limits.mjs
@@ -1,0 +1,899 @@
+/*
+    Issue #206. The editor's wheel zoom has no floor, a soft ceiling and an
+    asymmetric step; the design (docs/superpowers/specs/2026-08-10-zoom-levels-design.md)
+    settles a fixed ladder whose endpoints come from the game rather than from
+    reasoning. This is the probe that measures them.
+
+    Unlike every other probe here, this one **needs a LuaPlayer**. Zoom is a
+    property of a player's controller, not of a prototype or a surface, so
+    `--create` cannot reach it: a created map has nobody in it. That forces two
+    departures from the established shape, and both are the point rather than
+    an inconvenience:
+
+      - it runs the **graphics client** with `--load-scenario base/freeplay`,
+        so a player exists and a real controller is active
+      - it does not `error("DUMPED-OK")` its way out. The automated half writes
+        its dump and then **stays running**, because the second half needs a
+        human at the wheel.
+
+    What it asks:
+
+      1. The character controller's `zoom_limits`, read directly. Three fields,
+         not two: `closest`, `furthest`, and `furthest_game_view` - the last
+         being the zoom past which the engine renders **chart (map) view**
+         instead of the world. The editor has no map view, so the limit that
+         corresponds to its floor is `furthest_game_view`, not `furthest`. The
+         design was written before this field was known and says the range has
+         two ends; it has three.
+
+      2. The same range measured a second, independent way: write a zoom far
+         outside the limits and read it back. The docs say writes outside the
+         limits are always valid while reads are clamped, so the readback is
+         the true bound. **The two must agree.** A disagreement is the finding,
+         not a number to average.
+
+      3. Where the game view actually gives way to chart view, swept
+         empirically over ~100 geometric steps while reading `render_mode`.
+         That is a third instrument, and it checks (1)'s `furthest_game_view`
+         against observed rendering rather than against the same table it came
+         from.
+
+      4. **The ladder itself**, by sampling `player.zoom` every tick while a
+         human scrolls from one end of the range to the other. This is the part
+         no headless run can do, and it is what makes the shipped ratio a
+         measurement instead of a taste. #211 exists because the design assumed
+         this was out of reach without a logging mod; this is that logging mod.
+
+      5. `god` and `spectator` limits on demand (`/zoomcontrollers`), because
+         limits are per controller type and "like the game" means the character
+         controller. Recording the others says whether the number chosen is the
+         one a player actually experiences.
+
+    Controls, in the README's sense - each can fail while the hypothesis holds:
+
+      - **Instrument**: the direct read (1) and the write-readback (2) are two
+        independent routes to one quantity. Agreement is not guaranteed by
+        construction; the readback goes through the engine's clamp while the
+        read goes through the limits table.
+      - **Instrument**: the scroll capture must find more than one distinct
+        zoom. A single value looks exactly like a correct single value, and is
+        what a wheel that never reached the game (window unfocused, cursor over
+        a GUI) produces.
+      - **Cross-instrument**: the endpoints of the hand-scrolled ladder must
+        equal the limits measured headlessly. This is the control the design
+        named for #211 - two instruments, neither derived from the other,
+        checking each other.
+      - **Coordinate**: `display_scale` and `display_resolution` are recorded,
+        because the design's claim that the units already agree (32 px per tile
+        at zoom 1, both here and in the editor) is only exact at scale 1, and a
+        `distance`-form limit is defined against the window's aspect ratio
+        rather than being a zoom number at all.
+      - **Voiding**: if no player with a character controller is ever obtained,
+        the run says so and records nothing. Zeros from a missing player read
+        exactly like a measured zero, which is the elevated-rail lesson.
+
+    In the game, once it says it is ready:
+
+           /zoomoffladder [value]   set a zoom that is on no rung, then scroll ONE notch
+           /zoomcontrollers         record god and spectator limits
+           /zoomdone                flush and report; then quit however you like
+
+    Usage:
+           # one command: sets up, launches the game, waits, then analyses
+           FACTORIO_BIN="$HOME/Downloads/factorio_space_age_mac_2_0_77.app/Contents/MacOS/factorio" \
+             node tools/oracle/probe-zoom-limits.mjs --work /tmp/zoom-1
+
+           # re-read one session's dumps without relaunching
+           node tools/oracle/probe-zoom-limits.mjs --work /tmp/zoom-1 --analyze
+
+           # several sessions as one capture, which is how the fixture was taken.
+           # Use a FRESH dir per launch - the sample log is appended to, so reusing
+           # one silently interleaves two sittings into a single tick timeline.
+           node tools/oracle/probe-zoom-limits.mjs --analyze --write-fixture \
+             --sessions /tmp/zoom-1,/tmp/zoom-2,/tmp/zoom-3 && vp check --fix
+
+    The --fix is not optional if you recapture: vp's formatter collapses short
+    arrays onto one line and JSON.stringify does not.
+*/
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const BIN =
+    process.env.FACTORIO_BIN ??
+    `${process.env.HOME}/Library/Application Support/Steam/steamapps/common/Factorio/factorio.app/Contents/MacOS/factorio`
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const FIXTURE = join(HERE, 'fixtures', 'zoom-limits.json')
+
+const flag = name => {
+    const i = process.argv.indexOf(name)
+    return i === -1 ? undefined : process.argv[i + 1]
+}
+const WRITE_FIXTURE = process.argv.includes('--write-fixture')
+const ANALYZE_ONLY = process.argv.includes('--analyze')
+const RAW_OUT = flag('--raw-out')
+
+const MOD = 'bp_zoom_limits'
+const DUMP_HEADLESS = 'zoom-headless.json'
+const DUMP_SAMPLES = 'zoom-samples.jsonl'
+const DUMP_CONTROLLERS = 'zoom-controllers.jsonl'
+
+const version = spawnSync(BIN, ['--version'], { encoding: 'utf8' }).stdout ?? ''
+const binaryLine = version.split('\n')[0].trim()
+const binaryVersion = (binaryLine.match(/(\d+)\.(\d+)\.(\d+)/) ?? []).slice(1)
+if (binaryVersion.length !== 3) {
+    console.error(`Could not read a version out of ${BIN}: ${JSON.stringify(binaryLine)}`)
+    process.exit(1)
+}
+/*
+    Derived, not hardcoded. A mod declaring 2.1 against a 2.0.x binary is
+    skipped in silence and the run ends with no dump and nothing naming why.
+*/
+const MOD_FACTORIO_VERSION = `${binaryVersion[0]}.${binaryVersion[1]}`
+
+const work = flag('--work') ?? mkdtempSync(join(tmpdir(), 'fbe-zoom-'))
+const writeData = join(work, 'write-data')
+const modDir = join(work, 'mods')
+const modPath = join(modDir, `${MOD}_0.0.1`)
+const outDir = join(writeData, 'script-output')
+
+if (!ANALYZE_ONLY) {
+    mkdirSync(outDir, { recursive: true })
+    mkdirSync(modPath, { recursive: true })
+
+    writeFileSync(
+        join(modPath, 'info.json'),
+        JSON.stringify({
+            name: MOD,
+            version: '0.0.1',
+            title: 'What zoom range and what per-notch step does the game use',
+            author: 'oracle',
+            factorio_version: MOD_FACTORIO_VERSION,
+            dependencies: ['base'],
+        })
+    )
+
+    /*
+        State lives in file-local Lua rather than in `storage` on purpose: a
+        probe session is one uninterrupted play session, nothing is loaded from
+        a save, and every measurement is appended to disk the moment it is
+        taken. So a hard quit at any point loses nothing, which is what makes
+        it safe to let a human end the session however they like.
+    */
+    writeFileSync(
+        join(modPath, 'control.lua'),
+        `
+local SWEEP_POINTS = 100
+local SWEEP_TICKS = 2      -- render_mode follows a rendered frame, not a set
+
+local phase = "wait"
+local player = nil
+local headless = {controls = {}, sweep = {}, notes = {}}
+local sweepValues, sweepIdx, sweepWait = {}, 1, 0
+local lastZoom = nil
+local sampleCount = 0
+local savedCharacter = nil
+
+local function spec(s)
+  if s == nil then return nil end
+  return {zoom = s.zoom, distance = s.distance, max_distance = s.max_distance}
+end
+
+local function limitsOf(p)
+  local zl = p.zoom_limits
+  if zl == nil then return nil end
+  return {
+    closest = spec(zl.closest),
+    furthest = spec(zl.furthest),
+    furthest_game_view = spec(zl.furthest_game_view),
+  }
+end
+
+local function appendSample(tag)
+  local line = helpers.table_to_json({
+    t = game.tick,
+    z = player.zoom,
+    rm = tostring(player.render_mode),
+    ct = tostring(player.controller_type),
+    tag = tag,
+  })
+  helpers.write_file("${DUMP_SAMPLES}", line .. "\\n", true)
+  sampleCount = sampleCount + 1
+end
+
+local function say(msg)
+  player.print(msg)
+  log("[zoom-probe] " .. msg)
+end
+
+script.on_event(defines.events.on_tick, function()
+  if phase == "done" then return end
+
+  if player == nil then
+    player = game.players[1]
+    if player == nil then return end
+  end
+
+  -- A cutscene is its own controller with its own zoom. Freeplay opens in one.
+  if player.controller_type == defines.controllers.cutscene then
+    player.exit_cutscene()
+    return
+  end
+
+  if phase == "wait" then
+    if player.controller_type ~= defines.controllers.character then
+      -- Not voided yet: freeplay takes a few ticks to hand over the character.
+      if game.tick > 600 then
+        headless.voided = "no character controller after 600 ticks; controller_type was "
+          .. tostring(player.controller_type)
+        helpers.write_file("${DUMP_HEADLESS}", helpers.table_to_json(headless))
+        phase = "done"
+      end
+      return
+    end
+
+    headless.binary_mods = {}
+    for name, v in pairs(script.active_mods) do headless.binary_mods[name] = v end
+    headless.controller_type = tostring(player.controller_type)
+    headless.display_resolution = {
+      width = player.display_resolution.width,
+      height = player.display_resolution.height,
+    }
+    headless.display_scale = player.display_scale
+    headless.zoom_at_start = player.zoom
+    -- (1) direct read
+    headless.limits_read = limitsOf(player)
+
+    -- (2) write far outside, read back: the engine clamps reads.
+    player.zoom = 1000000
+    phase = "readback_closest"
+    return
+  end
+
+  if phase == "readback_closest" then
+    headless.readback_closest = player.zoom
+    player.zoom = 0.000001
+    phase = "readback_furthest"
+    return
+  end
+
+  if phase == "readback_furthest" then
+    headless.readback_furthest = player.zoom
+
+    -- (3) geometric sweep, reading render_mode, to find the game/chart edge.
+    local lo, hi = headless.readback_furthest, headless.readback_closest
+    if lo > 0 and hi > lo then
+      local ratio = (hi / lo) ^ (1 / (SWEEP_POINTS - 1))
+      for i = 1, SWEEP_POINTS do
+        sweepValues[i] = lo * ratio ^ (i - 1)
+      end
+    else
+      headless.notes[#headless.notes + 1] =
+        "sweep skipped: readback range was not positive and increasing"
+    end
+    sweepIdx = 1
+    sweepWait = 0
+    phase = "sweep"
+    player.zoom = sweepValues[1] or 1
+    return
+  end
+
+  if phase == "sweep" then
+    if sweepIdx > #sweepValues then
+      player.zoom = 1
+      helpers.write_file("${DUMP_HEADLESS}", helpers.table_to_json(headless))
+      phase = "live"
+      lastZoom = nil
+      say("--------------------------------------------------")
+      say("Zoom probe ready. The headless half is written.")
+      say("Now SCROLL: all the way IN to the stop, then all the")
+      say("way OUT to the stop, one notch at a time if you can.")
+      say("Then type /zoomdone   (and /zoomcontrollers if asked).")
+      say("--------------------------------------------------")
+      return
+    end
+    sweepWait = sweepWait + 1
+    if sweepWait >= SWEEP_TICKS then
+      sweepWait = 0
+      headless.sweep[#headless.sweep + 1] = {
+        requested = sweepValues[sweepIdx],
+        actual = player.zoom,
+        rm = tostring(player.render_mode),
+      }
+      sweepIdx = sweepIdx + 1
+      if sweepValues[sweepIdx] then player.zoom = sweepValues[sweepIdx] end
+    end
+    return
+  end
+
+  if phase == "live" then
+    local z = player.zoom
+    if z ~= lastZoom then
+      lastZoom = z
+      appendSample("live")
+    end
+  end
+end)
+
+commands.add_command("zoomoffladder", "Start a notch from between two rungs", function(cmd)
+  if player == nil then return end
+  --[[
+      The one thing a plain scroll capture cannot show. The game always sits on
+      a rung, so an ordinary capture is consistent with every rule that agrees
+      on rungs. The editor is on no rung most of the time, because
+      centerViewPort computes a continuous fit from the blueprint's bounds on
+      every load, so this is the case it lives in.
+
+      Three rules survive that far, and which pair a start value separates
+      depends on where in the gap it sits. Between the rungs 0.820335 and
+      0.905724:
+
+        relative      multiply where you are by 2^(1/7)
+        nearest+step  snap to the NEAREST rung, then move one index
+        directional   move to the next rung in the direction of travel
+
+      From 0.83 (below the gap's midpoint of 0.863) a notch IN separates only
+      relative (0.9164) from the other two (0.9057, agreeing). To separate the
+      remaining pair the start has to be ABOVE the midpoint, or the notch has
+      to go the other way:
+
+        0.89 IN  : nearest+step 1.0      directional 0.905724
+        0.83 OUT : nearest+step 0.742997 directional 0.820335
+
+      Hence the parameter. A value is not a neutral instrument here - it decides
+      which hypotheses the run can tell apart at all.
+  ]]
+  local v = tonumber(cmd.parameter) or 0.83
+  player.zoom = v
+  appendSample("offladder-set")
+  say("Zoom set to " .. v .. ". Now scroll exactly ONE notch, then say which way.")
+end)
+
+commands.add_command("zoomdone", "Flush the zoom capture and report", function()
+  if player == nil then return end
+  helpers.write_file(
+    "zoom-done.json",
+    helpers.table_to_json({samples = sampleCount, tick = game.tick, zoom = player.zoom})
+  )
+  say("Captured " .. sampleCount .. " zoom samples. Safe to quit the game now.")
+  say("Optional: /zoomcontrollers records god and spectator limits too.")
+end)
+
+commands.add_command("zoomcontrollers", "Record limits for other controllers", function()
+  if player == nil then return end
+  savedCharacter = player.character
+  for _, name in pairs({"god", "spectator"}) do
+    local ok, err = pcall(function()
+      player.set_controller({type = defines.controllers[name]})
+      local rec = {controller = name, limits = limitsOf(player)}
+      player.zoom = 1000000
+      rec.readback_closest_same_tick = player.zoom
+      player.zoom = 0.000001
+      rec.readback_furthest_same_tick = player.zoom
+      player.zoom = 1
+      helpers.write_file("${DUMP_CONTROLLERS}", helpers.table_to_json(rec) .. "\\n", true)
+    end)
+    if not ok then
+      helpers.write_file(
+        "${DUMP_CONTROLLERS}",
+        helpers.table_to_json({controller = name, error = tostring(err)}) .. "\\n",
+        true
+      )
+    end
+  end
+  if savedCharacter and savedCharacter.valid then
+    player.set_controller({type = defines.controllers.character, character = savedCharacter})
+  end
+  say("Recorded god and spectator limits; back on the character controller.")
+end)
+`
+    )
+
+    writeFileSync(
+        join(work, 'config.ini'),
+        `[path]\nread-data=__PATH__executable__/../data\nwrite-data=${writeData}\n[general]\n[other]\n`
+    )
+
+    console.log(`=== binary: ${binaryLine} (mod declared factorio_version ${MOD_FACTORIO_VERSION})`)
+    console.log(`=== work dir: ${work}`)
+    console.log('=== launching the graphics client; this probe needs a real player.\n')
+
+    spawnSync(
+        BIN,
+        [
+            '--load-scenario',
+            'base/freeplay',
+            '--mod-directory',
+            modDir,
+            '--config',
+            join(work, 'config.ini'),
+        ],
+        { encoding: 'utf8', stdio: 'inherit', maxBuffer: 64 * 1024 * 1024 }
+    )
+}
+
+/* ------------------------------------------------------------------ *
+ * Analysis                                                            *
+ * ------------------------------------------------------------------ */
+
+/*
+    A human at the wheel cannot do everything in one sitting, and asking them to
+    is how a run ends with the interesting half missing. So the analysis reads
+    **several** session directories and treats them as one capture.
+
+    That is not only a convenience: four independent launches reporting the same
+    limits is a control the single-session shape cannot express, and it is the
+    one that would catch a limit that moved because of the window rather than
+    because of the game.
+*/
+const jsonl = p =>
+    existsSync(p)
+        ? readFileSync(p, 'utf8')
+              .split('\n')
+              .filter(l => l.trim())
+              .map(l => JSON.parse(l))
+        : []
+
+const readSession = dir => {
+    const so = join(dir, 'write-data', 'script-output')
+    const hp = join(so, DUMP_HEADLESS)
+    if (!existsSync(hp)) return { dir, missing: true }
+    return {
+        dir,
+        headless: JSON.parse(readFileSync(hp, 'utf8')),
+        samples: jsonl(join(so, DUMP_SAMPLES)),
+        controllers: jsonl(join(so, DUMP_CONTROLLERS)),
+    }
+}
+
+const sessionDirs = (flag('--sessions') ?? '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+const sessions = (sessionDirs.length ? sessionDirs : [work]).map(readSession)
+
+const missing = sessions.filter(s => s.missing)
+if (missing.length === sessions.length) {
+    console.error(
+        `No headless dump in any of: ${sessions.map(s => s.dir).join(', ')}\n` +
+            `Mod declared factorio_version ${MOD_FACTORIO_VERSION} against ${binaryLine}.\n` +
+            'If the game never reached a character controller, the run is voided rather than zero.'
+    )
+    process.exit(1)
+}
+for (const m of missing) console.log(`! session skipped, no dump: ${m.dir}`)
+
+const good = sessions.filter(s => !s.missing)
+const voided = good.filter(s => s.headless.voided)
+for (const v of voided) console.log(`! session VOIDED: ${v.dir} - ${v.headless.voided}`)
+const usable = good.filter(s => !s.headless.voided)
+if (!usable.length) {
+    console.error('\n!!! every session voided. Recording nothing; zeros are not a finding.')
+    process.exit(1)
+}
+
+const H = usable[0].headless
+const list = v => (v === undefined || v === null ? [] : Object.values(v))
+const samples = usable.flatMap((s, i) => s.samples.map(x => ({ ...x, session: i })))
+const controllers = usable.flatMap(s => s.controllers)
+
+console.log(`\n=== binary: ${binaryLine}`)
+console.log(
+    `=== sessions: ${usable.length} (${usable.map(s => s.dir.split('/').pop()).join(', ')})`
+)
+console.log(
+    `=== mods: ${Object.entries(H.binary_mods ?? {})
+        .map(([n, v]) => `${n} ${v}`)
+        .join(', ')}`
+)
+console.log(
+    `=== display: ${H.display_resolution?.width}x${H.display_resolution?.height} at scale ${H.display_scale}`
+)
+for (const n of list(H.notes)) console.log(`! ${n}`)
+
+/*
+    Cross-session control. Each session measured the limits independently, on
+    its own launch. They must agree - and this can genuinely fail, since the
+    floor is computed from the window, so a resized window between runs makes
+    it fail for a reason that is about the instrument rather than the game.
+*/
+if (usable.length > 1) {
+    const key = h => `${h.readback_closest}/${h.readback_furthest}`
+    const disagreeing = usable.filter(s => key(s.headless) !== key(H))
+    console.log(
+        `=== control: ${usable.length} independent sessions ${disagreeing.length === 0 ? 'ALL AGREE on the limits' : 'DISAGREE'}`
+    )
+    for (const d of disagreeing) {
+        console.log(
+            `    ${d.dir}: ${key(d.headless)} against ${key(H)} - check whether the window was resized`
+        )
+    }
+}
+
+const fmt = n => (n === undefined || n === null ? '-' : Number(n.toPrecision(8)).toString())
+const specStr = s =>
+    s === undefined || s === null
+        ? '-'
+        : s.zoom !== undefined && s.zoom !== null
+          ? `zoom ${fmt(s.zoom)}`
+          : `distance ${fmt(s.distance)} (max ${fmt(s.max_distance)})`
+
+console.log('\n--- (1) zoom_limits, read directly off the character controller')
+console.log(`    closest            : ${specStr(H.limits_read?.closest)}`)
+console.log(`    furthest           : ${specStr(H.limits_read?.furthest)}`)
+console.log(`    furthest_game_view : ${specStr(H.limits_read?.furthest_game_view)}`)
+
+console.log('\n--- (2) write far outside the limits, read back (the engine clamps reads)')
+console.log(`    ceiling : ${fmt(H.readback_closest)}`)
+console.log(`    floor   : ${fmt(H.readback_furthest)}`)
+
+/*
+    Control: (1) and (2) are independent routes to one quantity - but only when
+    the limit is given as a `zoom`. A `distance` limit is not a zoom number at
+    all; it is a rule computed against the window, so comparing it to a readback
+    directly answers "DISAGREE" for a limit that is perfectly correct.
+
+    So the rule is transcribed here and evaluated against the window this run
+    actually had, which is the README's "transcribe the proposed rule into the
+    probe" applied to a rule the docs state rather than one we propose. That
+    turns an incomparable field into a third instrument: docs-formula against
+    engine-readback, neither derived from the other.
+*/
+const PX_PER_TILE = 32
+const zoomFromSpec = spec => {
+    if (!spec) return undefined
+    if (spec.zoom !== undefined && spec.zoom !== null) return spec.zoom
+    if (spec.distance === undefined || spec.distance === null) return undefined
+    /*
+        display_resolution is physical pixels; display_scale is the UI scaling
+        factor, so the window in the 32-px-per-tile unit the zoom number is
+        against is resolution/scale. Getting this wrong is invisible - it
+        rescales both ends together and still looks plausible.
+    */
+    const w = H.display_resolution.width / H.display_scale
+    const h = H.display_resolution.height / H.display_scale
+    const aspect = w / h
+    const WIDE = 16 / 9
+    const TALL = 9 / 16
+    let z
+    if (aspect > WIDE || aspect < TALL) {
+        /*
+            Docs: "distance * 9/16 tiles visible along the window's shorter
+            axis". Note the docs then give the shorter axis as the height for
+            BOTH the wide and the tall case, which cannot be true of a window
+            taller than it is wide; the stated rule is followed rather than the
+            second example. Only the wide branch has been measured.
+        */
+        z = Math.min(w, h) / (PX_PER_TILE * spec.distance * (9 / 16))
+    } else {
+        z = Math.max(w, h) / (PX_PER_TILE * spec.distance)
+    }
+    if (spec.max_distance !== undefined && spec.max_distance !== null) {
+        /* "The closest zoom level calculated from distance and max_distance is always used." */
+        z = Math.max(z, Math.max(w, h) / (PX_PER_TILE * spec.max_distance))
+    }
+    return z
+}
+
+const near = (a, b) =>
+    a !== undefined && b !== undefined && Math.abs(a - b) < 1e-6 * Math.max(1, Math.abs(a))
+const predictedClosest = zoomFromSpec(H.limits_read?.closest)
+const predictedFurthest = zoomFromSpec(H.limits_read?.furthest)
+const agreeTop = near(predictedClosest, H.readback_closest)
+const agreeBottom = near(predictedFurthest, H.readback_furthest)
+console.log('\n--- control: do the two instruments agree?')
+console.log(
+    `    ceiling ${agreeTop ? 'AGREE' : 'DISAGREE'}  (limits table ${fmt(predictedClosest)} vs readback ${fmt(H.readback_closest)})`
+)
+console.log(
+    `    floor   ${agreeBottom ? 'AGREE' : 'DISAGREE'}  (limits table ${fmt(predictedFurthest)} vs readback ${fmt(H.readback_furthest)})`
+)
+console.log(
+    `    The floor is a rule, not a number: at most ${fmt(H.limits_read?.furthest?.distance)} tiles across\n` +
+        `    (hard cap ${fmt(H.limits_read?.furthest?.max_distance)}), which on this ${H.display_resolution?.width}x${H.display_resolution?.height} at scale ${H.display_scale} window is ${fmt(predictedFurthest)}.\n` +
+        '    It moves with the viewport. The ceiling does not.'
+)
+if (!agreeTop || !agreeBottom) {
+    console.log('    A disagreement is the finding, not a number to average.')
+}
+
+/* (3) where the world view gives way to chart view, observed rather than declared. */
+const sweep = list(H.sweep)
+let gameViewEdge
+for (const s of sweep) {
+    if (s.rm && s.rm.indexOf('chart') === -1) {
+        if (gameViewEdge === undefined || s.actual < gameViewEdge) gameViewEdge = s.actual
+    }
+}
+const modes = [...new Set(sweep.map(s => s.rm))]
+console.log('\n--- (3) render_mode swept over the range')
+console.log(`    modes seen  : ${modes.join(', ') || '(none)'}`)
+console.log(`    lowest zoom still rendering the world: ${fmt(gameViewEdge)}`)
+console.log(
+    `    declared furthest_game_view          : ${specStr(H.limits_read?.furthest_game_view)}`
+)
+console.log(
+    '    The editor has no chart view, so this - not `furthest` - is the limit its floor\n' +
+        '    corresponds to.'
+)
+
+/* (4) the hand-scrolled ladder. */
+console.log(`\n--- (4) hand-scrolled capture: ${samples.length} samples`)
+/*
+    Split by controller before anything else. `/editor` puts the player on the
+    editor controller, which has its own limits - the wiki puts its floor at 0.1
+    against freeplay's 0.3 - so folding those samples into the character ladder
+    would report a range no single controller has and a bottom rung that is not
+    a rung of anything.
+*/
+const byController = {}
+for (const s of samples) (byController[s.ct] ??= []).push(s)
+if (Object.keys(byController).length > 1) {
+    console.log('    samples span more than one controller:')
+    for (const [ct, ss] of Object.entries(byController)) {
+        const zs = ss.map(s => s.z)
+        console.log(
+            `      controller ${ct}: ${ss.length} samples, ${fmt(Math.min(...zs))} .. ${fmt(Math.max(...zs))}`
+        )
+    }
+    console.log(`    The ladder below is the character controller (${H.controller_type}) only.`)
+}
+/*
+    A script-set zoom is not a scrolled one. `/zoomoffladder` writes its own
+    tagged sample AND trips the live watcher on the same tick, so 0.83 arrives
+    looking exactly like a rung the wheel stopped on - it would enter the
+    distinct set, sit between two real rungs and break the constant-ratio check
+    for a reason that has nothing to do with the game.
+*/
+const scripted = new Set(
+    samples.filter(s => s.tag === 'offladder-set').map(s => `${s.session}:${s.t}`)
+)
+const live = samples.filter(
+    s => s.tag === 'live' && s.ct === H.controller_type && !scripted.has(`${s.session}:${s.t}`)
+)
+
+/*
+    The off-ladder case, which is the one the editor lives in: centerViewPort
+    computes a continuous fit on every load, so a notch almost never starts on a
+    rung.
+
+    Three rules agree on every sample taken from a rung and disagree away from
+    one, and **which pair a given start separates depends on where in the gap it
+    sits**, which is why every probe is evaluated rather than the first. From
+    0.83 a notch in cannot tell `nearest+step` from `directional` at all - both
+    say 0.905724 - and reading that one probe as a verdict would have adopted
+    the wrong rule with a number that matched perfectly.
+*/
+const RATIO = 2 ** (1 / 7)
+const rungAt = n => 2 ** (n / 7)
+const offLadder = []
+for (let i = 0; i < samples.length; i++) {
+    if (samples[i].tag !== 'offladder-set') continue
+    const start = samples[i].z
+    const next = samples.slice(i + 1).find(s => s.ct === samples[i].ct && s.z !== start)
+    if (!next) continue
+    const landed = next.z
+    const n = Math.log2(start) * 7
+    const below = rungAt(Math.floor(n))
+    const above = rungAt(Math.ceil(n))
+    const nearest = rungAt(Math.round(n))
+    /* Which way the notch went is read off the answer, not assumed. */
+    const inward = landed > start
+    const predictions = {
+        relative: inward ? start * RATIO : start / RATIO,
+        nearestThenStep: inward ? nearest * RATIO : nearest / RATIO,
+        directional: inward ? above : below,
+    }
+    const fits = Object.entries(predictions)
+        .filter(([, v]) => near(v, landed))
+        .map(([k]) => k)
+    offLadder.push({ start, direction: inward ? 'in' : 'out', landed, predictions, fits })
+}
+if (offLadder.length) {
+    console.log('\n--- (4b) notches taken from between two rungs')
+    for (const o of offLadder) {
+        console.log(
+            `    from ${fmt(o.start)} one notch ${o.direction} landed on ${fmt(o.landed)}` +
+                `   [relative ${fmt(o.predictions.relative)}, nearest+step ${fmt(o.predictions.nearestThenStep)}, directional ${fmt(o.predictions.directional)}]`
+        )
+        console.log(
+            `      consistent with: ${o.fits.length ? o.fits.join(' and ') : 'NOTHING - that is the finding, do not pick the closest'}`
+        )
+    }
+    /* The verdict is the rule that survives EVERY probe, not the one that fits the last. */
+    const survivors = ['relative', 'nearestThenStep', 'directional'].filter(r =>
+        offLadder.every(o => o.fits.includes(r))
+    )
+    console.log(
+        `    => surviving rule${survivors.length === 1 ? '' : 's'}: ${survivors.join(', ') || 'none'}`
+    )
+    if (survivors.length > 1) {
+        console.log(
+            '    More than one survives, so the probes taken do not separate them. A start\n' +
+                '    ABOVE its gap midpoint, or a notch in the other direction, would.'
+        )
+    }
+}
+/*
+    Plateaus are per session. Ticks restart at every launch, so a plateau
+    spanning a session boundary computes a hold time out of two unrelated clocks
+    - which lands in the settled-rung filter below and quietly decides which
+    values count as rungs.
+*/
+const plateaus = []
+for (const s of live) {
+    const last = plateaus[plateaus.length - 1]
+    if (last && last.z === s.z && last.session === s.session) {
+        last.until = s.t
+        continue
+    }
+    plateaus.push({ z: s.z, from: s.t, until: s.t, rm: s.rm, session: s.session })
+}
+for (let i = 0; i < plateaus.length; i++) {
+    const next = plateaus[i + 1]
+    const contiguous = next && next.session === plateaus[i].session
+    plateaus[i].heldTicks = (contiguous ? next.from : plateaus[i].until) - plateaus[i].from
+}
+const distinct = [...new Set(live.map(s => s.z))].sort((a, b) => a - b)
+
+/*
+    Every rung must be an exact 2^(n/7) off a baseline of 1.0. This is the
+    headline claim and it is checked rather than eyeballed off the ratio spread:
+    a mean ratio can sit at 1.10409 while individual rungs drift, and a ladder
+    anchored at 1.03 instead of 1.0 would give an identical ratio series. The
+    two clamp values are excluded because they are limits rather than rungs -
+    the game steps onto its limit exactly, which is the behaviour, not an error.
+*/
+const RUNG_TOL = 1e-6
+const clamps = new Set([H.readback_closest, H.readback_furthest])
+const rungCheck = distinct
+    .filter(z => !clamps.has(z))
+    .map(z => ({ z, n: Math.log2(z) * 7 }))
+    .map(r => ({ ...r, off: Math.abs(r.n - Math.round(r.n)) }))
+const worstRung = rungCheck.length ? Math.max(...rungCheck.map(r => r.off)) : undefined
+if (rungCheck.length) {
+    console.log(
+        `    every non-clamp value is 2^(n/7): ${worstRung < RUNG_TOL ? 'YES' : 'NO'}` +
+            ` over ${rungCheck.length} values, worst deviation in n = ${worstRung.toExponential(2)}`
+    )
+    const ns = rungCheck.map(r => Math.round(r.n)).sort((a, b) => a - b)
+    console.log(`    n runs ${ns[0]} .. ${ns[ns.length - 1]}, baseline 2^0 = 1.0`)
+}
+console.log(`    distinct zoom values : ${distinct.length}`)
+console.log(`    plateaus (visits)    : ${plateaus.length}`)
+
+if (distinct.length < 2) {
+    console.log(
+        '    !!! INSTRUMENT CONTROL FAILED: fewer than two distinct values. A wheel that\n' +
+            '    never reached the game (window unfocused, cursor over a GUI) looks like this.'
+    )
+} else {
+    /*
+        A rung is a value the zoom settled on. Anything held for a single tick
+        is a frame of an animated transition, not a level the wheel stops at.
+    */
+    const SETTLE_TICKS = 3
+    const settled = [
+        ...new Set(plateaus.filter(p => p.heldTicks >= SETTLE_TICKS).map(p => p.z)),
+    ].sort((a, b) => a - b)
+    console.log(`    settled rungs (held >= ${SETTLE_TICKS} ticks): ${settled.length}`)
+    console.log(`    range walked : ${fmt(distinct[0])} .. ${fmt(distinct[distinct.length - 1])}`)
+
+    const ratios = []
+    for (let i = 1; i < settled.length; i++) ratios.push(settled[i] / settled[i - 1])
+    if (ratios.length) {
+        const min = Math.min(...ratios)
+        const max = Math.max(...ratios)
+        const mean = ratios.reduce((a, b) => a + b, 0) / ratios.length
+        console.log(
+            `    consecutive ratios: min ${fmt(min)}  mean ${fmt(mean)}  max ${fmt(max)}` +
+                `  ${max - min < 0.02 ? '(constant - a geometric ladder)' : '(not constant)'}`
+        )
+        console.log(`    rungs: ${settled.map(fmt).join(', ')}`)
+    }
+
+    /* Cross-instrument control, the one #211 was blocked on. */
+    const walkedTop = distinct[distinct.length - 1]
+    const walkedBottom = distinct[0]
+    const topOk = near(walkedTop, H.readback_closest)
+    const bottomOk = near(walkedBottom, H.readback_furthest)
+    console.log('\n--- control: do the scrolled endpoints equal the measured limits?')
+    console.log(
+        `    top    ${topOk ? 'AGREE' : 'DIFFER'} (scrolled ${fmt(walkedTop)} vs limit ${fmt(H.readback_closest)})`
+    )
+    console.log(
+        `    bottom ${bottomOk ? 'AGREE' : 'DIFFER'} (scrolled ${fmt(walkedBottom)} vs limit ${fmt(H.readback_furthest)})`
+    )
+    if (!topOk || !bottomOk) {
+        console.log(
+            '    DIFFER usually means the scroll simply did not reach that stop, which makes it\n' +
+                '    a control on the session rather than on the game. Scroll to both stops and rerun.'
+        )
+    }
+}
+
+/* (5) other controllers. */
+if (controllers.length) {
+    console.log('\n--- (5) other controller types')
+    for (const c of controllers) {
+        if (c.error) {
+            console.log(`    ${c.controller}: ERROR ${c.error}`)
+            continue
+        }
+        console.log(
+            `    ${c.controller}: closest ${specStr(c.limits?.closest)}, furthest ${specStr(c.limits?.furthest)}, game view ${specStr(c.limits?.furthest_game_view)}`
+        )
+    }
+} else {
+    console.log('\n--- (5) other controller types: not recorded (/zoomcontrollers was not run)')
+}
+
+const captured = {
+    provenance: {
+        issue: 206,
+        binary: binaryLine,
+        modFactorioVersion: MOD_FACTORIO_VERSION,
+        capturedBy: 'tools/oracle/probe-zoom-limits.mjs',
+        mods: H.binary_mods,
+        display: { resolution: H.display_resolution, scale: H.display_scale },
+        note:
+            'Zoom is a property of a player controller, so this ran against the graphics ' +
+            'client with a human at the wheel for the ladder half. The editor targets ' +
+            '2.0.45 to 2.0.73 and the corpus spans 2.0.32 to 2.1.12.',
+    },
+    characterController: {
+        limitsRead: H.limits_read,
+        readbackClosest: H.readback_closest,
+        readbackFurthest: H.readback_furthest,
+        observedGameViewFloor: gameViewEdge,
+        renderModesSeen: modes,
+    },
+    scrolledLadder: {
+        sampleCount: live.length,
+        /* The ladder as a formula, and the values it was read off. */
+        rungFormula: '2^(n/7), baseline 2^0 = 1.0',
+        notchesPerDoubling: 7,
+        ratio: RATIO,
+        distinct,
+        worstRungDeviationInN: worstRung,
+        plateaus: plateaus.map(p => ({ z: p.z, heldTicks: p.heldTicks, rm: p.rm })),
+    },
+    offLadderNotches: offLadder,
+    samplesByController: Object.fromEntries(
+        Object.entries(byController).map(([ct, ss]) => {
+            const zs = ss.map(s => s.z)
+            return [ct, { count: ss.length, min: Math.min(...zs), max: Math.max(...zs) }]
+        })
+    ),
+    otherControllers: controllers,
+    controls: {
+        sessions: usable.length,
+        sessionsAgreeOnLimits: usable.every(
+            s =>
+                s.headless.readback_closest === H.readback_closest &&
+                s.headless.readback_furthest === H.readback_furthest
+        ),
+        ceilingInstrumentsAgree: agreeTop,
+        floorInstrumentsAgree: agreeBottom,
+        distinctScrolledValues: distinct.length,
+        everyValueIsAnExactRung: worstRung !== undefined && worstRung < RUNG_TOL,
+        scrolledEndpointsEqualLimits:
+            near(distinct[distinct.length - 1], H.readback_closest) &&
+            near(distinct[0], H.readback_furthest),
+    },
+}
+
+if (RAW_OUT) {
+    writeFileSync(RAW_OUT, JSON.stringify({ headless: H, samples, controllers }, null, 2))
+    console.log(`\nRaw dump written to ${RAW_OUT}`)
+}
+
+if (WRITE_FIXTURE) {
+    writeFileSync(FIXTURE, JSON.stringify(captured, null, 4) + '\n')
+    console.log(`\nFixture written to ${FIXTURE} - run \`vp check --fix\` to format it.`)
+} else {
+    console.log('\n(no fixture written; pass --write-fixture to capture)')
+}


### PR DESCRIPTION
PR 1 of the two the [zoom design](docs/superpowers/specs/2026-08-10-zoom-levels-design.md) sequences: pure measurement, no behaviour change. Its result picks the ladder the implementation PR ships.

## What it found

| | |
|---|---|
| **step** | `2^(1/7)` - seven notches per doubling, ladder anchored at exactly 1.0 |
| **off-rung notch** | snaps to the **nearest** rung, then moves one index |
| **ceiling** | 3 - already what `BlueprintContainer.ts:87` passes as `maxZoom` |
| **overshoot** | lands on the limit **exactly**, so the clamp value is reachable and is not a rung |
| **floor** | a rule, not a number: at most 200 tiles across the window, capped at 500 |

All 23 non-clamp values scrolled through are exact `2^(n/7)`, worst deviation in `n` of **4.2e-10** across four sessions.

## Two things the design got wrong, and one it did not know about

- **The ratio did not need choosing.** The design called it "the one number that is pure feel" and handed it to a driving session; #211 wrote the per-notch step off as unreachable without a manual scrolling session against a logging mod. Both were cost estimates standing in for findings. This is that logging mod and it took one sitting. The guessed starting point, 1.33, is three real notches wide - shipping it would have felt wrong in exactly the way #206 complains about, and no test could have said so.
- **The floor cannot be taken from the game.** #206's stated goal is the game's range, but 30 of the 367 corpus blueprints are wider than 200 tiles - the widest is 397, needing zoom 0.151 to fit at 1920px against a floor of 0.300 - so adopting the game's own floor makes 8% of real blueprints impossible to view whole. The 200-tile limit exists to stop a player seeing ungenerated chunks, which an editor does not do. The game's **map editor** floor, 0.1, is the number that transfers, and is what the implementation PR will use. Third measurement here to refuse the change it was capturing evidence for.
- **`zoom_limits` has three fields, not two.** `furthest_game_view` is `distance 200` for the character, god and spectator controllers alike: the game never draws the world further out than 200 tiles across. God and spectator may zoom out further (0.015625 and 0.00390625) but that range renders as chart view, which the editor has none of.

The floor formula reproduces the measured 0.283889 to 1e-9 only at **32 px per tile against the window in logical pixels** (`display_resolution / display_scale`), which confirms the design's units claim exactly rather than by assertion.

## Why this probe is shaped differently

It is the first here that needs a `LuaPlayer`, so `--create` cannot reach it - a created map has nobody in it. It runs the **graphics client** with `--load-scenario base/freeplay`, and it does not `error("DUMPED-OK")` out: the automated half writes its dump and the mod keeps sampling `player.zoom` every tick while a human scrolls, appending to disk as it goes, so a quit at any moment loses nothing.

## Controls

Every one passes, and each can fail while the hypothesis holds:

- `zoom_limits` read directly vs. write-far-outside-and-read-back - two independent routes, **AGREE** at both ends
- four independent sessions **agree** on the limits (this one can fail on a resized window, which is about the instrument rather than the game)
- hand-scrolled endpoints equal the headlessly measured limits at both ends - the cross-instrument control #211 named
- `render_mode` swept over the whole range, checking `furthest_game_view` against observed rendering rather than against the table it came from
- voiding: no character controller means the run records nothing, rather than zeros that read like a measurement

## Method notes added to the oracle README

- **"No headless probe can reach it" is not the same claim as "not worth measuring."**
- **Which hypotheses a probe value can separate is part of the question.** Three rules agree on every sample taken from a rung. 0.83 sits below its gap's midpoint, so a notch *in* cannot tell "nearest then step" from "next rung in the direction of travel" - both say 0.905724, exactly. A notch *out* separates them. Reading the first probe as a verdict would have adopted the wrong rule with a number matching to nine digits, so the analysis reports the rules surviving **every** probe rather than the one fitting the last.
- **A script-set value is not a measured one, and it enters the same stream.** The off-ladder command trips the live sampler on the same tick, so 0.83 arrives looking exactly like a rung the wheel stopped on. Excluded by tag, not by value.
- **Ask what a limit *is* before comparing it to a number.** `furthest` is a rule, so comparing it to a readback answers DISAGREE for a limit that is perfectly correct. Transcribing the documented formula turned an incomparable field into a third instrument.

Closes #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShHVPRNjjWzQyJFQfirX9Y