### PR TITLE
Zoom with the game's own ladder instead of a drifting flat step

### DIFF
--- a/docs/superpowers/specs/2026-08-10-zoom-levels-design.md
+++ b/docs/superpowers/specs/2026-08-10-zoom-levels-design.md
@@ -131,11 +131,19 @@ Rejected: an index whose ladder gains the computed fit value per blueprint. Pres
 
 ### Wheel events accumulate a normalised delta
 
+**Amended 2026-08-11, after driving it: the wheel is continuous, not quantised.** The normalising and the accumulating both stay; what goes is rounding the total down to whole rungs. A wheel event now moves `deltaY / WHEEL_NOTCH_PX` rungs, so `WHEEL_NOTCH_PX` of travel is still exactly one rung and a notched mouse still walks the game's ladder, while everything smaller moves proportionally instead of waiting to cross a threshold.
+
+Two things drove that, and only the first is a matter of taste. The feel report was that scrolling is **chunky**. The measurement underneath it is in the capture already: the game moved **11 rungs in 11 ticks**, the whole top of its range in 183ms, where a threshold of 100px per rung makes those same 11 rungs cost 1100px of finger travel. So the gap between us and the game was **cadence**, not step size - which is also why a finer ladder was rejected rather than chosen, since halving the rung trades chunky for sluggish and fixes neither.
+
+The position is kept **in rungs** rather than recomputed from the scale, because that is what preserves defect 1's fix without a ladder to snap to: adding and then subtracting the same number returns the identical float, where multiplying a scale by `2^(1/7)` and dividing again does not. It is clamped as a **position**, not merely as the scale it produces - otherwise scrolling hard against a limit banks travel that has to be unwound before the view moves again, which reads as the wheel having died.
+
 `deltaY` is normalised via `deltaMode` into a common unit and added to a running total. Each time the total crosses a threshold, one rung is stepped and the threshold subtracted, keeping the remainder.
 
 A mouse notch crosses the threshold in one event; a trackpad needs several; slow scrolling still arrives because the remainder carries.
 
 Rejected: one step per event. Smallest diff, but it leaves the defect most likely to explain the original complaint, and a discrete ladder makes it more visible than continuous zoom does.
+
+**That last sentence had it backwards, and the binary says so.** One step per event is close to what the game does - measured at one rung per tick during a fast scroll - so it was never the defect; the asymmetric step and the missing limits were. And the discrete ladder did not make anything more visible, it made the quantisation itself the thing you feel. Checked against the 2.0.77 binary because "maybe the engine tweens between levels" was the obvious rival explanation: there is no `smooth` or `interpolate` symbol anywhere near `CameraBase`, no smooth-zoom setting in the locale, and the two zoom-shaped strings in the binary (`zoomFactor`, `zoomIntensity`) are cloud prototype fields. The engine snaps, exactly as the Lua capture showed. So the game's smoothness is **cadence**, and ours has to come from not quantising.
 
 Rejected: rungs proportional to magnitude. Most responsive to a flick, but one event could jump most of the ladder, which with discrete levels reads as teleporting - the same failure the rail signal `R` key had before its ordering was fixed.
 

--- a/docs/superpowers/specs/2026-08-10-zoom-levels-design.md
+++ b/docs/superpowers/specs/2026-08-10-zoom-levels-design.md
@@ -156,6 +156,8 @@ export class WheelAccumulator {
 
 `ZOOM_LEVELS` is a **committed literal array**, not computed at runtime. It is generated once from the probe's measured endpoints and the chosen ratio, then written into the file, so the ladder a test asserts is the ladder that ships. Regenerating it is a deliberate act, the same rule the other measured tables here follow.
 
+**Reversed 2026-08-11: it ships computed, as `2^(n/7)` for `n` in -23..11.** The argument above holds when the ladder is a table of measurements, which is what `railSignalSpots.ts` is - 152 placements with no formula behind them, where a generated literal is the only re-derivable form. This ladder turned out to have a closed form, so a literal would be a _transcription_ of a formula rather than a record of measurements, and 35 hand-copied digits are the kind of thing that drifts without any reviewer being able to see it. The unit test asserts the closed form, the two exact endpoints and the measured off-rung cases.
+
 `stepZoom` is where the snap lives: nearest ladder value to the current continuous scale, move one index, clamp. From `0.83` on a ladder containing `1.0`, a notch in yields the rung above `1.0`.
 
 `WheelAccumulator.feed` returns a **signed** rung count - negative for zoom out, positive for zoom in, `0` when the threshold has not been crossed. Usually -1, 0 or 1.

--- a/packages/editor/src/Editor.ts
+++ b/packages/editor/src/Editor.ts
@@ -175,6 +175,18 @@ export class Editor {
      * coordinate the editor reports stays perfectly self-consistent (issue
      * #144).
      */
+    /**
+     * The viewport's current continuous scale, which is the zoom level.
+     *
+     * The editor draws 32 px per tile at scale 1, and so does Factorio at zoom
+     * 1 - measured, not assumed (#206). Exposed because the zoom ladder is
+     * otherwise invisible from outside: `zoom()` changes nothing a spec can
+     * read, since entity positions move with the view rather than against it.
+     */
+    public get viewportScale(): number {
+        return G.BPC.getViewportScale()
+    }
+
     public get viewportRenderedInSync(): boolean {
         return G.BPC.viewportRenderedInSync
     }

--- a/packages/editor/src/containers/BlueprintContainer.ts
+++ b/packages/editor/src/containers/BlueprintContainer.ts
@@ -15,6 +15,7 @@ import { Tile } from '../core/Tile'
 import { Entity } from '../core/Entity'
 import { Blueprint } from '../core/Blueprint'
 import { IConnection } from '../core/WireConnections'
+import { stepZoom, WheelAccumulator } from '../core/zoomLevels'
 import { IPoint } from '../types'
 import { Dialog } from '../UI/controls/Dialog'
 import { Viewport } from './Viewport'
@@ -83,8 +84,7 @@ export class BlueprintContainer extends Container {
             x: G.app.screen.width,
             y: G.app.screen.height,
         },
-        this.anchor,
-        3
+        this.anchor
     )
 
     private _mode: EditorMode = EditorMode.NONE
@@ -430,15 +430,21 @@ export class BlueprintContainer extends Container {
             this.updateCopyCursorBox()
         }
 
+        /*
+            One accumulator for the life of the container, because the whole
+            point of it is the remainder it carries between events (#206
+            defect 2). The handler used to read only `Math.sign(e.deltaY)`, so a
+            trackpad emitting a burst of small pixel deltas and a mouse emitting
+            one notch produced the same fixed jump - the likeliest single cause
+            of the original complaint that scrolling does not feel like the game.
+        */
+        const wheel = new WheelAccumulator()
         const onWheel = (e: WheelEvent): void => {
             e.preventDefault()
             e.stopPropagation()
 
-            if (Math.sign(e.deltaY) === 1) {
-                this.zoom(false)
-            } else {
-                this.zoom(true)
-            }
+            const rungs = wheel.feed(e.deltaY, e.deltaMode)
+            for (let i = 0; i < Math.abs(rungs); i++) this.zoom(rungs > 0)
         }
 
         this.addEventListener('wheel', onWheel, { passive: false })
@@ -792,10 +798,21 @@ export class BlueprintContainer extends Container {
         this.deleteModeEntities = []
     }
 
+    /**
+     * One notch of the measured zoom ladder (#206).
+     *
+     * The old flat `zoomFactor = 0.1` fed `zoomBy`, whose effective multiplier
+     * is `1 + delta` - so zooming in was x1.1 and out x0.9, and those are not
+     * inverses: one notch each way left the view 1% further out than it started,
+     * with nothing to snap back to.
+     *
+     * The next scale is read **before** the scale centre is moved, so the rung
+     * is computed from the scale actually in effect.
+     */
     public zoom(zoomIn = true): void {
-        const zoomFactor = 0.1
+        const next = stepZoom(this.viewport.getCurrentScale(), zoomIn ? 1 : -1)
         this.viewport.setScaleCenter(this.gridData.x, this.gridData.y)
-        this.viewport.zoomBy(zoomFactor * (zoomIn ? 1 : -1))
+        this.viewport.setCurrentScale(next)
     }
 
     private get isPointerInside(): boolean {

--- a/packages/editor/src/containers/BlueprintContainer.ts
+++ b/packages/editor/src/containers/BlueprintContainer.ts
@@ -15,7 +15,7 @@ import { Tile } from '../core/Tile'
 import { Entity } from '../core/Entity'
 import { Blueprint } from '../core/Blueprint'
 import { IConnection } from '../core/WireConnections'
-import { stepZoom, WheelAccumulator } from '../core/zoomLevels'
+import { stepZoom, WheelZoom } from '../core/zoomLevels'
 import { IPoint } from '../types'
 import { Dialog } from '../UI/controls/Dialog'
 import { Viewport } from './Viewport'
@@ -431,20 +431,24 @@ export class BlueprintContainer extends Container {
         }
 
         /*
-            One accumulator for the life of the container, because the whole
-            point of it is the remainder it carries between events (#206
+            One `WheelZoom` for the life of the container, because it holds the
+            continuous position that makes zoom exactly reversible (#206
             defect 2). The handler used to read only `Math.sign(e.deltaY)`, so a
             trackpad emitting a burst of small pixel deltas and a mouse emitting
-            one notch produced the same fixed jump - the likeliest single cause
-            of the original complaint that scrolling does not feel like the game.
+            one notch produced the same fixed jump.
+
+            The viewport's scale is passed in as the authority rather than kept
+            here: a blueprint load re-fits it and mobile pinch writes it
+            directly, and neither goes through this handler.
         */
-        const wheel = new WheelAccumulator()
+        const wheel = new WheelZoom(this.viewport.getCurrentScale())
         const onWheel = (e: WheelEvent): void => {
             e.preventDefault()
             e.stopPropagation()
 
-            const rungs = wheel.feed(e.deltaY, e.deltaMode)
-            for (let i = 0; i < Math.abs(rungs); i++) this.zoom(rungs > 0)
+            const scale = wheel.feed(e.deltaY, e.deltaMode, this.viewport.getCurrentScale())
+            this.viewport.setScaleCenter(this.gridData.x, this.gridData.y)
+            this.viewport.setCurrentScale(scale)
         }
 
         this.addEventListener('wheel', onWheel, { passive: false })
@@ -799,12 +803,19 @@ export class BlueprintContainer extends Container {
     }
 
     /**
-     * One notch of the measured zoom ladder (#206).
+     * One discrete step of the measured zoom ladder (#206), landing on a rung.
      *
      * The old flat `zoomFactor = 0.1` fed `zoomBy`, whose effective multiplier
      * is `1 + delta` - so zooming in was x1.1 and out x0.9, and those are not
      * inverses: one notch each way left the view 1% further out than it started,
      * with nothing to snap back to.
+     *
+     * The wheel does **not** come through here any more - it moves continuously
+     * along the same curve, because quantising every trackpad event to a whole
+     * rung is what made scrolling feel chunky. This is the stepped entry point,
+     * which is what a zoom-in/zoom-out command wants; the game has exactly those
+     * two keybinds (`zoom-in`/`zoom-out` in its own locale) and this editor has
+     * none bound yet.
      *
      * The next scale is read **before** the scale centre is moved, so the rung
      * is computed from the scale actually in effect.

--- a/packages/editor/src/containers/Viewport.ts
+++ b/packages/editor/src/containers/Viewport.ts
@@ -1,11 +1,11 @@
 import { Matrix } from 'pixi.js'
 import { IPoint } from '../types'
+import { clampZoom, ZOOM_MAX } from '../core/zoomLevels'
 
 export class Viewport {
     private size: IPoint
     private viewPortSize: IPoint
     private anchor: IPoint
-    private maxZoom: number
     private dirty = true
     private positionX = 0
     private positionY = 0
@@ -16,11 +16,17 @@ export class Viewport {
     private origTransform = new Matrix()
     private transform = new Matrix()
 
-    public constructor(size: IPoint, viewPortSize: IPoint, anchor: IPoint, maxZoom: number) {
+    /*
+        The zoom ceiling used to arrive as a constructor argument, which
+        `BlueprintContainer` passed as a literal 3. It now comes from
+        `zoomLevels.ts`, where the same 3 is recorded as the game's measured
+        limit (#206) - a bound written down in two places is one that has to be
+        kept in sync, and the copy nothing tests is the one that loses.
+    */
+    public constructor(size: IPoint, viewPortSize: IPoint, anchor: IPoint) {
         this.size = size
         this.viewPortSize = viewPortSize
         this.anchor = anchor
-        this.maxZoom = maxZoom
     }
 
     private _updateMatrix(): void {
@@ -95,10 +101,17 @@ export class Viewport {
         this.scaleCenterX = this.size.x / 2 + -offset.x
         this.scaleCenterY = this.size.y / 2 + -offset.y
 
+        /*
+            Capped at the ceiling but deliberately **not** at the floor: a
+            blueprint wider than `ZOOM_MIN` allows still has to fit exactly, and
+            30 of the 367 corpus blueprints are wide enough to need it. Keeping
+            the fit exact is why the continuous scale stays the source of truth
+            rather than a ladder index (#206).
+        */
         const zoom = Math.min(
             this.viewPortSize.x / focusObjectSize.x,
             this.viewPortSize.y / focusObjectSize.y,
-            this.maxZoom
+            ZOOM_MAX
         )
         this.scaleX = zoom
         this.scaleY = zoom
@@ -152,10 +165,28 @@ export class Viewport {
         this.dirty = true
     }
 
-    public zoomBy(deltaX: number, deltaY?: number): void {
-        if (Math.sign(deltaX) === 1 && this.origTransform.a > this.maxZoom) return
-        this.scaleX += deltaX
-        this.scaleY += deltaY === undefined ? deltaX : deltaY
+    /**
+     * Continuous zoom by a proportional delta, for **mobile pinch only** - it
+     * derives `scaleDelta` from finger distance, which cannot be expressed in
+     * rungs. The wheel goes through `stepZoom` and `setCurrentScale` instead.
+     *
+     * Two fixes over what this used to be (#206 defect 3). The guard tested the
+     * ceiling *before* applying, so from 2.99 a tick still landed at 3.289 -
+     * soft by a whole step. And there was no floor anywhere: because the step is
+     * multiplicative it approached 0 asymptotically rather than going negative,
+     * degrading into an unusable speck instead of failing outright.
+     *
+     * The second parameter is gone with them. It allowed a non-uniform zoom that
+     * no caller ever asked for and that a single clamped scale cannot express -
+     * `getCurrentScale` only ever reports the x axis, so the two could disagree
+     * with nothing able to see it.
+     */
+    public zoomBy(delta: number): void {
+        /* Rebuild first, or `origTransform.a` is the scale from before a pending change. */
+        if (this.dirty) this._updateMatrix()
+        const current = this.origTransform.a
+        this.scaleX = clampZoom(current * (1 + delta)) / current
+        this.scaleY = this.scaleX
         this.dirty = true
     }
 
@@ -183,7 +214,16 @@ export class Viewport {
         this.dirty = true
     }
 
+    /**
+     * Rebuilds a pending change first, for the same reason `getTransform` does
+     * (#144): every mutator here sets `dirty` and leaves the matrix alone, so
+     * without this a read between a change and the next render frame answers the
+     * scale from *before* it. That mattered little while the caller only
+     * displayed the number; it matters now that `zoom()` computes the next rung
+     * from it, since a stale reading steps from the wrong rung.
+     */
     public getCurrentScale(): number {
+        if (this.dirty) this._updateMatrix()
         return this.origTransform.a
     }
 

--- a/packages/editor/src/core/zoomLevels.test.ts
+++ b/packages/editor/src/core/zoomLevels.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vite-plus/test'
+import {
+    clampZoom,
+    LINE_HEIGHT_PX,
+    stepZoom,
+    WHEEL_NOTCH_PX,
+    WheelAccumulator,
+    ZOOM_LEVELS,
+    ZOOM_MAX,
+    ZOOM_MIN,
+    ZOOM_RATIO,
+} from './zoomLevels'
+
+/*
+    The zoom ladder (#206). Pure and FD-free, so it runs under `vp test` in CI,
+    which is the point: nothing under `tests/` reads a zoom level and Playwright
+    does not run in CI at all (#210).
+
+    Every expectation about the ladder itself traces to
+    tools/oracle/fixtures/zoom-limits.json, captured off the 2.0.77 client with a
+    human at the wheel. The game's step is 2^(1/7) - seven notches per doubling -
+    on a ladder anchored at exactly 1.0, and all 23 non-clamp values scrolled
+    through are exact rungs to within 4.2e-10 in n.
+
+    The two off-ladder cases below are the measured ones, and they are the only
+    reason this file can tell the shipped rule from a wrong one that agrees
+    everywhere else: three candidate rules agree on every value that is already a
+    rung. See the fixture's `offLadderNotches`.
+*/
+
+/** 2^(n/7), the game's rung for n notches from the 1.0 baseline. */
+const rung = (n: number): number => 2 ** (n / 7)
+
+describe('the ladder', () => {
+    it('is strictly ascending', () => {
+        for (let i = 1; i < ZOOM_LEVELS.length; i++) {
+            expect(ZOOM_LEVELS[i]).toBeGreaterThan(ZOOM_LEVELS[i - 1])
+        }
+    })
+
+    it('contains exactly 1.0, which is the baseline the game anchors on', () => {
+        expect(ZOOM_LEVELS.filter(z => z === 1)).toHaveLength(1)
+    })
+
+    it('is every 2^(n/7) rung strictly inside the limits, and no others', () => {
+        const expected = []
+        for (let n = Math.ceil(Math.log2(ZOOM_MIN) * 7); n <= Math.log2(ZOOM_MAX) * 7; n++) {
+            expected.push(rung(n))
+        }
+        expect(ZOOM_LEVELS).toEqual(expected)
+    })
+
+    it('stays inside the measured limits', () => {
+        expect(ZOOM_LEVELS[0]).toBeGreaterThan(ZOOM_MIN)
+        expect(ZOOM_LEVELS[ZOOM_LEVELS.length - 1]).toBeLessThan(ZOOM_MAX)
+    })
+
+    it('takes the ceiling from the game and the floor from its map editor', () => {
+        // fixture: characterController.readbackClosest
+        expect(ZOOM_MAX).toBe(3)
+        // 30 of 367 corpus blueprints exceed the game's own 200-tile world-view
+        // floor, so the editor takes the game's map editor floor instead.
+        expect(ZOOM_MIN).toBe(0.1)
+    })
+
+    it('steps by 2^(1/7), seven notches to a doubling', () => {
+        expect(ZOOM_RATIO).toBeCloseTo(1.104089514, 9)
+        expect(ZOOM_RATIO ** 7).toBeCloseTo(2, 12)
+    })
+})
+
+describe('stepZoom', () => {
+    it('round-trips exactly: one notch in then out returns the starting value', () => {
+        // Defect 1. The old flat step made this 1.1 x 0.9 = 0.99, losing 1% a
+        // round trip with nothing to snap back to.
+        //
+        // The two rungs adjacent to a limit are excluded and get their own test
+        // below: a step from them lands on the limit, which is not a rung, so
+        // the way back is one rung further than it went. That is the game's
+        // behaviour, measured, not an accident of this implementation.
+        for (const z of ZOOM_LEVELS.slice(1, -1)) {
+            expect(stepZoom(stepZoom(z, 1), -1)).toBe(z)
+            expect(stepZoom(stepZoom(z, -1), 1)).toBe(z)
+        }
+    })
+
+    it('moves one rung at a time from a rung', () => {
+        expect(stepZoom(1, 1)).toBeCloseTo(rung(1), 12)
+        expect(stepZoom(1, -1)).toBeCloseTo(rung(-1), 12)
+        expect(stepZoom(2, 1)).toBeCloseTo(rung(8), 12)
+    })
+
+    /*
+        The case the editor actually lives in: centerViewPort computes a
+        continuous fit from a blueprint's bounds on every load, so a notch almost
+        never starts on a rung. Measured in the game from 0.83, both directions.
+    */
+    it('snaps to the nearest rung and then steps, in (measured)', () => {
+        expect(stepZoom(0.83, 1)).toBeCloseTo(0.905723664, 9)
+    })
+
+    it('snaps to the nearest rung and then steps, out (measured)', () => {
+        // The rule that gets this wrong is "move to the next rung in the
+        // direction of travel", which answers 0.820335 - and which agrees with
+        // the correct rule on the inward case above. This assertion is the only
+        // thing separating them.
+        expect(stepZoom(0.83, -1)).toBeCloseTo(0.742997145, 9)
+    })
+
+    it('lands on the limit exactly rather than overshooting it', () => {
+        // The game does this: a step that would pass a limit lands on the limit,
+        // so the clamp value is reachable and is not itself a rung.
+        expect(stepZoom(ZOOM_LEVELS[ZOOM_LEVELS.length - 1], 1)).toBe(ZOOM_MAX)
+        expect(stepZoom(ZOOM_LEVELS[0], -1)).toBe(ZOOM_MIN)
+    })
+
+    it('stays put at each limit instead of stepping past it', () => {
+        // Defect 3: the ceiling was tested before the multiply, so from 2.99 a
+        // tick still landed at 3.289, and there was no floor at all.
+        expect(stepZoom(ZOOM_MAX, 1)).toBe(ZOOM_MAX)
+        expect(stepZoom(ZOOM_MIN, -1)).toBe(ZOOM_MIN)
+    })
+
+    it('skips a rung coming off a limit, exactly as the game does', () => {
+        /*
+            Measured, and it is the one place the ladder is not symmetric. The
+            limit sits between two rungs - 3 lies above 2^(11/7) = 2.971989 -
+            so the nearest rung to it is the one just below, and stepping out
+            from there lands two rungs below the limit.
+
+            The fixture records the game doing precisely this: a human at 3.0
+            scrolled one notch out and landed on 2.691800385, skipping
+            2.971989. Reproducing it costs nothing, since the skipped rung is
+            1% from the limit, and inventing a special case here would be
+            departing from the game on the strength of a hunch.
+        */
+        expect(stepZoom(ZOOM_MAX, -1)).toBeCloseTo(rung(10), 12)
+        expect(stepZoom(ZOOM_MAX, -1)).toBeCloseTo(2.691800385, 9)
+        expect(stepZoom(ZOOM_MIN, 1)).toBeCloseTo(rung(-22), 12)
+    })
+
+    it('pulls a scale from outside the range back inside', () => {
+        // A blueprint wider than the floor allows still fits exactly on load,
+        // because the fit sets the scale directly - clampZoom is not applied to
+        // it. So a notch from 0.04 has to answer something inside the range
+        // rather than stepping the ladder down from 0.04.
+        expect(stepZoom(0.04, 1)).toBeCloseTo(rung(-22), 12)
+        expect(stepZoom(0.04, -1)).toBe(ZOOM_MIN)
+        expect(stepZoom(50, -1)).toBeCloseTo(rung(10), 12)
+        expect(stepZoom(50, 1)).toBe(ZOOM_MAX)
+    })
+})
+
+describe('clampZoom', () => {
+    it('leaves a value inside the range alone', () => {
+        expect(clampZoom(1)).toBe(1)
+        expect(clampZoom(0.83)).toBe(0.83)
+    })
+
+    it('bounds both ends', () => {
+        expect(clampZoom(99)).toBe(ZOOM_MAX)
+        expect(clampZoom(0.0001)).toBe(ZOOM_MIN)
+    })
+})
+
+describe('WheelAccumulator', () => {
+    /*
+        Defect 2: the old handler read only Math.sign(deltaY), so a trackpad
+        burst of small pixel deltas and one mouse notch produced the same jump.
+    */
+    it('turns one mouse notch into one rung', () => {
+        const acc = new WheelAccumulator()
+        expect(acc.feed(WHEEL_NOTCH_PX, 0)).toBe(-1)
+    })
+
+    it('signs the rung count: up is in, down is out', () => {
+        const acc = new WheelAccumulator()
+        expect(acc.feed(-WHEEL_NOTCH_PX, 0)).toBe(1)
+    })
+
+    it('needs several trackpad events to make one rung', () => {
+        const acc = new WheelAccumulator()
+        const tenth = WHEEL_NOTCH_PX / 10
+        for (let i = 0; i < 9; i++) expect(acc.feed(tenth, 0)).toBe(0)
+        expect(acc.feed(tenth, 0)).toBe(-1)
+    })
+
+    it('carries the remainder, so slow scrolling still arrives', () => {
+        const acc = new WheelAccumulator()
+        const threeQuarters = WHEEL_NOTCH_PX * 0.75
+        expect(acc.feed(threeQuarters, 0)).toBe(0)
+        expect(acc.feed(threeQuarters, 0)).toBe(-1)
+        // 1.5 notches fed, 1 taken, 0.5 still pending - so half a notch more
+        // completes the second rung rather than starting from nothing.
+        expect(acc.feed(WHEEL_NOTCH_PX * 0.5, 0)).toBe(-1)
+    })
+
+    it('drops the remainder when the direction reverses', () => {
+        // Otherwise a nudge one way then the other fires a rung early, which
+        // reads as the view jumping while settling.
+        const acc = new WheelAccumulator()
+        expect(acc.feed(WHEEL_NOTCH_PX * 0.9, 0)).toBe(0)
+        expect(acc.feed(-WHEEL_NOTCH_PX * 0.2, 0)).toBe(0)
+        expect(acc.feed(-WHEEL_NOTCH_PX * 0.9, 0)).toBe(1)
+    })
+
+    it('normalises line units to the same answer as pixels', () => {
+        const acc = new WheelAccumulator()
+        expect(acc.feed(WHEEL_NOTCH_PX / LINE_HEIGHT_PX, 1)).toBe(-1)
+    })
+
+    it('normalises page units to the same answer as pixels', () => {
+        const acc = new WheelAccumulator()
+        expect(acc.feed(1, 2)).toBe(-1)
+    })
+
+    it('can report more than one rung from a single large event', () => {
+        const acc = new WheelAccumulator()
+        expect(acc.feed(WHEEL_NOTCH_PX * 3, 0)).toBe(-3)
+    })
+})

--- a/packages/editor/src/core/zoomLevels.test.ts
+++ b/packages/editor/src/core/zoomLevels.test.ts
@@ -4,7 +4,7 @@ import {
     LINE_HEIGHT_PX,
     stepZoom,
     WHEEL_NOTCH_PX,
-    WheelAccumulator,
+    WheelZoom,
     ZOOM_LEVELS,
     ZOOM_MAX,
     ZOOM_MIN,
@@ -163,59 +163,99 @@ describe('clampZoom', () => {
     })
 })
 
-describe('WheelAccumulator', () => {
+describe('WheelZoom', () => {
     /*
-        Defect 2: the old handler read only Math.sign(deltaY), so a trackpad
-        burst of small pixel deltas and one mouse notch produced the same jump.
+        Continuous zoom along the same curve the ladder steps through, decided
+        2026-08-11 after driving it. The measurement behind that: in the capture
+        the game moved 11 rungs in 11 ticks - one per tick, the whole top of the
+        range in 183ms - where an accumulator needing 100px per rung makes those
+        same 11 rungs cost 1100px of finger travel. Slow discrete steps are what
+        "chunky" describes, and the fix is to stop quantising rather than to
+        quantise faster.
+
+        A notched mouse is unaffected: one 100px notch is still exactly one rung,
+        so it still walks the game's ladder. Everything below a notch, which is
+        every event a trackpad or a smooth-scrolling mouse sends, now moves
+        proportionally instead of waiting to cross a threshold.
     */
-    it('turns one mouse notch into one rung', () => {
-        const acc = new WheelAccumulator()
-        expect(acc.feed(WHEEL_NOTCH_PX, 0)).toBe(-1)
+    it('turns one mouse notch into exactly one rung', () => {
+        const z = new WheelZoom(1)
+        expect(z.feed(-WHEEL_NOTCH_PX, 0, 1)).toBeCloseTo(rung(1), 12)
     })
 
-    it('signs the rung count: up is in, down is out', () => {
-        const acc = new WheelAccumulator()
-        expect(acc.feed(-WHEEL_NOTCH_PX, 0)).toBe(1)
+    it('signs it the way a wheel does: pushing away zooms out', () => {
+        const z = new WheelZoom(1)
+        expect(z.feed(WHEEL_NOTCH_PX, 0, 1)).toBeCloseTo(rung(-1), 12)
     })
 
-    it('needs several trackpad events to make one rung', () => {
-        const acc = new WheelAccumulator()
-        const tenth = WHEEL_NOTCH_PX / 10
-        for (let i = 0; i < 9; i++) expect(acc.feed(tenth, 0)).toBe(0)
-        expect(acc.feed(tenth, 0)).toBe(-1)
+    it('moves a fraction of a rung for a fraction of a notch', () => {
+        // The whole point: no threshold to cross, so nothing waits.
+        const z = new WheelZoom(1)
+        expect(z.feed(-WHEEL_NOTCH_PX / 10, 0, 1)).toBeCloseTo(rung(0.1), 12)
     })
 
-    it('carries the remainder, so slow scrolling still arrives', () => {
-        const acc = new WheelAccumulator()
-        const threeQuarters = WHEEL_NOTCH_PX * 0.75
-        expect(acc.feed(threeQuarters, 0)).toBe(0)
-        expect(acc.feed(threeQuarters, 0)).toBe(-1)
-        // 1.5 notches fed, 1 taken, 0.5 still pending - so half a notch more
-        // completes the second rung rather than starting from nothing.
-        expect(acc.feed(WHEEL_NOTCH_PX * 0.5, 0)).toBe(-1)
+    it('accumulates small events into the same place one big one reaches', () => {
+        const small = new WheelZoom(1)
+        let last = 1
+        for (let i = 0; i < 10; i++) last = small.feed(-WHEEL_NOTCH_PX / 10, 0, last)
+
+        const big = new WheelZoom(1)
+        expect(last).toBeCloseTo(big.feed(-WHEEL_NOTCH_PX, 0, 1), 12)
     })
 
-    it('drops the remainder when the direction reverses', () => {
-        // Otherwise a nudge one way then the other fires a rung early, which
-        // reads as the view jumping while settling.
-        const acc = new WheelAccumulator()
-        expect(acc.feed(WHEEL_NOTCH_PX * 0.9, 0)).toBe(0)
-        expect(acc.feed(-WHEEL_NOTCH_PX * 0.2, 0)).toBe(0)
-        expect(acc.feed(-WHEEL_NOTCH_PX * 0.9, 0)).toBe(1)
+    it('is exactly reversible, to the last bit', () => {
+        /*
+            Defect 1, and the reason the position is kept in rungs rather than
+            recomputed from the scale: adding then subtracting the same number
+            returns the identical float, where multiplying and then dividing a
+            scale by 2^(1/7) does not.
+        */
+        const z = new WheelZoom(0.83)
+        const out = z.feed(37, 0, 0.83)
+        expect(z.feed(-37, 0, out)).toBe(0.83)
     })
 
     it('normalises line units to the same answer as pixels', () => {
-        const acc = new WheelAccumulator()
-        expect(acc.feed(WHEEL_NOTCH_PX / LINE_HEIGHT_PX, 1)).toBe(-1)
+        const z = new WheelZoom(1)
+        expect(z.feed(-WHEEL_NOTCH_PX / LINE_HEIGHT_PX, 1, 1)).toBeCloseTo(rung(1), 12)
     })
 
     it('normalises page units to the same answer as pixels', () => {
-        const acc = new WheelAccumulator()
-        expect(acc.feed(1, 2)).toBe(-1)
+        const z = new WheelZoom(1)
+        expect(z.feed(-1, 2, 1)).toBeCloseTo(rung(1), 12)
     })
 
-    it('can report more than one rung from a single large event', () => {
-        const acc = new WheelAccumulator()
-        expect(acc.feed(WHEEL_NOTCH_PX * 3, 0)).toBe(-3)
+    it('stops exactly at each limit', () => {
+        const z = new WheelZoom(1)
+        expect(z.feed(WHEEL_NOTCH_PX * 100, 0, 1)).toBe(ZOOM_MIN)
+        const y = new WheelZoom(1)
+        expect(y.feed(-WHEEL_NOTCH_PX * 100, 0, 1)).toBe(ZOOM_MAX)
+    })
+
+    it('does not bank travel past a limit', () => {
+        /*
+            The position is clamped, not just the scale it produces. Without
+            that, scrolling hard against the floor banks a huge negative
+            position that has to be unwound before zooming in does anything -
+            the view sits still through several notches, which reads as the
+            wheel having died.
+        */
+        const z = new WheelZoom(1)
+        let scale = z.feed(WHEEL_NOTCH_PX * 100, 0, 1)
+        expect(scale).toBe(ZOOM_MIN)
+        scale = z.feed(-WHEEL_NOTCH_PX, 0, scale)
+        expect(scale).toBeCloseTo(ZOOM_MIN * ZOOM_RATIO, 12)
+    })
+
+    it('re-derives when something else moved the view', () => {
+        /*
+            Loading a blueprint re-fits the viewport, and mobile pinch writes the
+            scale directly. Neither goes through here, so the caller's scale is
+            the authority and a disagreement means the position is stale.
+        */
+        const z = new WheelZoom(1)
+        z.feed(-WHEEL_NOTCH_PX, 0, 1)
+        // ...a blueprint load then puts the viewport somewhere else entirely.
+        expect(z.feed(-WHEEL_NOTCH_PX, 0, 0.5)).toBeCloseTo(0.5 * ZOOM_RATIO, 12)
     })
 })

--- a/packages/editor/src/core/zoomLevels.ts
+++ b/packages/editor/src/core/zoomLevels.ts
@@ -1,0 +1,164 @@
+/*
+    The zoom ladder (#206), measured off the game rather than chosen.
+
+    Source: tools/oracle/fixtures/zoom-limits.json, captured against the 2.0.77
+    client with a human at the wheel over four sessions. Design and the reasoning
+    behind each decision: docs/superpowers/specs/2026-08-10-zoom-levels-design.md.
+
+    Pure - no pixi, no FD, no globals - so `zoomLevels.test.ts` runs under
+    `vp test` in CI, following railSignalSnapping.ts and throughput.ts. That
+    matters more here than usual: nothing under `tests/` reads a zoom level, and
+    Playwright does not run in CI at all (#210).
+*/
+
+/**
+ * The game's per-notch step: seven notches to a doubling.
+ *
+ * Measured, not chosen. All 23 non-clamp values a human scrolled through are
+ * exact `2^(n/7)` rungs off a baseline of 1.0, worst deviation in `n` of
+ * 4.2e-10. The design had left this ratio to "a driving session, since it is
+ * pure feel" and guessed 1.33, which is three real notches wide.
+ */
+export const ZOOM_RATIO = 2 ** (1 / 7)
+
+/** Notches per doubling, which is what makes the ratio a whole-numbered thing. */
+export const NOTCHES_PER_DOUBLING = 7
+
+/**
+ * The closest the editor will zoom in, taken straight from the game: the
+ * character controller's `zoom_limits.closest` is `3`, which is also what
+ * `BlueprintContainer` already passed as `maxZoom`. So the ceiling was never
+ * wrong - only its softness was, since the old guard tested before multiplying.
+ */
+export const ZOOM_MAX = 3
+
+/**
+ * The furthest out, and the one number here the game could not supply directly.
+ *
+ * Factorio's world-view floor is a rule rather than a value - at most 200 tiles
+ * across the window, capped at 500 - which is 0.3 on a 16:9 display. Adopting it
+ * is not open to us: 30 of the 367 corpus blueprints are wider than 200 tiles
+ * and the widest is 397, needing 0.151 to fit at 1920px, so the game's own floor
+ * would make 8% of real blueprints impossible to view whole. That limit exists
+ * to stop a player seeing ungenerated chunks, which an editor does not do.
+ *
+ * 0.1 is the game's **map editor** floor - its number for the editing context -
+ * and it fits the widest corpus blueprint with room to spare.
+ */
+export const ZOOM_MIN = 0.1
+
+/**
+ * Every rung strictly inside the limits, ascending.
+ *
+ * Computed from the closed form rather than committed as a literal array. The
+ * design specified a literal, on the grounds that "the ladder a test asserts is
+ * the ladder that ships" - but that was written while the ratio was still going
+ * to be a taste decision. It is a measured closed form, so a literal would be a
+ * transcription of a formula, and a transcription can drift from it silently in
+ * a way 35 hand-copied digits make hard to review. Contrast railSignalSpots.ts,
+ * which is generated precisely because its 152 placements have no formula.
+ *
+ * The limits themselves are deliberately **not** rungs: `ZOOM_MIN` is 0.1 while
+ * the lowest rung is 0.102542, and `ZOOM_MAX` is 3 against a highest rung of
+ * 2.971989. That is the game's own behaviour - a step that would overshoot a
+ * limit lands on the limit exactly - so both are reachable without being levels
+ * the ladder passes through on the way.
+ */
+export const ZOOM_LEVELS: readonly number[] = (() => {
+    const levels: number[] = []
+    const lowest = Math.ceil(Math.log2(ZOOM_MIN) * NOTCHES_PER_DOUBLING)
+    const highest = Math.floor(Math.log2(ZOOM_MAX) * NOTCHES_PER_DOUBLING)
+    for (let n = lowest; n <= highest; n++) levels.push(2 ** (n / NOTCHES_PER_DOUBLING))
+    return levels
+})()
+
+/** Bound a continuous scale to the range. Mobile pinch gets this and nothing else. */
+export const clampZoom = (scale: number): number => Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, scale))
+
+/**
+ * One notch: `direction` 1 zooms in, -1 out.
+ *
+ * The scale stays continuous and is the source of truth, so this has to cope
+ * with a starting value on no rung - which is the normal case, not an edge one,
+ * because `centerViewPort` computes a continuous fit from a blueprint's bounds
+ * on every load.
+ *
+ * It snaps to the **nearest** rung and then moves one index, which is measured
+ * rather than reasoned. Two other rules survive most probes: multiplying from
+ * where you are, and moving to the next rung in the direction of travel. From
+ * 0.83 a notch in gives 0.905724 under both this rule and the directional one,
+ * so only a notch **out** separates them - the game answers 0.742997, which is
+ * nearest-then-step. See the fixture's `offLadderNotches`.
+ */
+export const stepZoom = (scale: number, direction: 1 | -1): number => {
+    const clamped = clampZoom(scale)
+    const nearest = Math.round(Math.log2(clamped) * NOTCHES_PER_DOUBLING)
+    const stepped = 2 ** ((nearest + direction) / NOTCHES_PER_DOUBLING)
+    /*
+        Landing on the limit rather than short of it. Without this a step from
+        the top rung would answer the top rung again, so the last 1% of the
+        range would be unreachable by scrolling - and the editor would sit one
+        rung inside a ceiling it is supposed to have.
+    */
+    return clampZoom(stepped)
+}
+
+/**
+ * A wheel notch in CSS pixels. `WheelEvent.deltaY` is 100 per notch for a mouse
+ * in Chrome, and a trackpad emits a burst of much smaller values.
+ *
+ * This is the one number in the file that is feel rather than measurement: it
+ * decides how far a gesture has to travel per rung, and no passing test can see
+ * whether it is right. Drive it and print numbers before believing it.
+ */
+export const WHEEL_NOTCH_PX = 100
+
+/** `deltaMode` 1 is lines; browsers vary, and this is the common approximation. */
+export const LINE_HEIGHT_PX = 16
+
+/** `deltaMode` 2 is pages, which is one screenful of scrolling. */
+export const PAGE_HEIGHT_PX = 100
+
+/**
+ * Accumulates wheel deltas and reports whole rungs.
+ *
+ * Defect 2 of the design: the old handler read only `Math.sign(e.deltaY)`, so a
+ * trackpad emitting a burst of small pixel deltas and a mouse emitting one notch
+ * produced the same fixed jump. That is the likeliest single cause of the
+ * original "does not feel like the game" complaint, and a discrete ladder makes
+ * it more visible than continuous zoom did.
+ */
+export class WheelAccumulator {
+    private pending = 0
+
+    /**
+     * @returns a signed rung count - positive to zoom in, negative out, 0 when
+     * the threshold has not been crossed yet. Usually -1, 0 or 1.
+     */
+    public feed(deltaY: number, deltaMode: number): number {
+        const px =
+            deltaMode === 1
+                ? deltaY * LINE_HEIGHT_PX
+                : deltaMode === 2
+                  ? deltaY * PAGE_HEIGHT_PX
+                  : deltaY
+
+        /*
+            A reversal drops what was pending. Carrying it across would let a
+            nudge one way and then the other fire a rung early, which reads as
+            the view jumping while it settles rather than as a step.
+        */
+        if (px !== 0 && Math.sign(px) !== Math.sign(this.pending)) this.pending = 0
+        this.pending += px
+
+        const rungs = Math.trunc(this.pending / WHEEL_NOTCH_PX)
+        this.pending -= rungs * WHEEL_NOTCH_PX
+        /*
+            deltaY is positive scrolling down, which zooms out - hence the
+            negation, and hence the explicit zero: negating +0 gives -0, which
+            `Object.is` and so `toBe(0)` treat as a different value from the 0
+            this documents itself as returning.
+        */
+        return rungs === 0 ? 0 : -rungs
+    }
+}

--- a/packages/editor/src/core/zoomLevels.ts
+++ b/packages/editor/src/core/zoomLevels.ts
@@ -104,12 +104,12 @@ export const stepZoom = (scale: number, direction: 1 | -1): number => {
 }
 
 /**
- * A wheel notch in CSS pixels. `WheelEvent.deltaY` is 100 per notch for a mouse
- * in Chrome, and a trackpad emits a burst of much smaller values.
+ * How much wheel travel makes one rung. `WheelEvent.deltaY` is 100 per notch for
+ * a notched mouse in Chrome, so one notch is exactly one rung and a notched
+ * mouse walks the game's ladder.
  *
- * This is the one number in the file that is feel rather than measurement: it
- * decides how far a gesture has to travel per rung, and no passing test can see
- * whether it is right. Drive it and print numbers before believing it.
+ * This is the one number in the file that is feel rather than measurement, and
+ * no passing test can see whether it is right - it was driven before shipping.
  */
 export const WHEEL_NOTCH_PX = 100
 
@@ -119,23 +119,66 @@ export const LINE_HEIGHT_PX = 16
 /** `deltaMode` 2 is pages, which is one screenful of scrolling. */
 export const PAGE_HEIGHT_PX = 100
 
+/** Where a scale sits on the ladder, in rungs. Fractional between two rungs. */
+export const rungPositionOf = (scale: number): number => Math.log2(scale) * NOTCHES_PER_DOUBLING
+
+/** The scale at a rung position, which need not be a whole number. */
+export const scaleAtRungPosition = (position: number): number =>
+    2 ** (position / NOTCHES_PER_DOUBLING)
+
+const MIN_POSITION = rungPositionOf(ZOOM_MIN)
+const MAX_POSITION = rungPositionOf(ZOOM_MAX)
+
 /**
- * Accumulates wheel deltas and reports whole rungs.
+ * Continuous zoom along the ladder's own curve, moved by wheel events.
  *
- * Defect 2 of the design: the old handler read only `Math.sign(e.deltaY)`, so a
- * trackpad emitting a burst of small pixel deltas and a mouse emitting one notch
- * produced the same fixed jump. That is the likeliest single cause of the
- * original "does not feel like the game" complaint, and a discrete ladder makes
- * it more visible than continuous zoom did.
+ * The ladder describes where the game *stops*; this describes how we travel,
+ * and the two agree wherever it matters - `WHEEL_NOTCH_PX` of travel is exactly
+ * one rung, so a notched mouse lands on the same values the game does. What it
+ * drops is the quantisation between notches, which a trackpad or a
+ * smooth-scrolling mouse would otherwise feel as the view holding still and then
+ * lurching.
+ *
+ * Measured reason to prefer this to a finer ladder: in the #206 capture the game
+ * moved 11 rungs in 11 ticks - the whole top of its range in 183ms - where an
+ * accumulator needing 100px per rung makes those same 11 rungs cost 1100px of
+ * finger travel. The gap is a cadence one, so making the steps smaller would
+ * trade chunkiness for sluggishness rather than fixing either.
+ *
+ * The position is held **in rungs** rather than derived from the scale each
+ * time, because adding and then subtracting the same number returns the
+ * identical float while multiplying and dividing a scale by `2^(1/7)` does not.
+ * That is what keeps zoom exactly reversible (defect 1) without a ladder to snap
+ * back to.
  */
-export class WheelAccumulator {
-    private pending = 0
+export class WheelZoom {
+    private position: number
+
+    public constructor(scale: number) {
+        this.position = this.clampPosition(rungPositionOf(scale))
+    }
+
+    private clampPosition(position: number): number {
+        /*
+            Clamping the position, not merely the scale it produces. Without
+            this, scrolling hard against a limit banks travel that has to be
+            unwound before the view moves again - several notches of nothing,
+            which reads as the wheel having died rather than as a limit.
+        */
+        return Math.min(MAX_POSITION, Math.max(MIN_POSITION, position))
+    }
 
     /**
-     * @returns a signed rung count - positive to zoom in, negative out, 0 when
-     * the threshold has not been crossed yet. Usually -1, 0 or 1.
+     * @param currentScale the viewport's scale, which is the authority. A
+     * blueprint load re-fits it and mobile pinch writes it directly, neither
+     * through here, so a disagreement means this position is stale.
+     * @returns the new scale.
      */
-    public feed(deltaY: number, deltaMode: number): number {
+    public feed(deltaY: number, deltaMode: number, currentScale: number): number {
+        if (!near(scaleAtRungPosition(this.position), currentScale)) {
+            this.position = this.clampPosition(rungPositionOf(currentScale))
+        }
+
         const px =
             deltaMode === 1
                 ? deltaY * LINE_HEIGHT_PX
@@ -143,22 +186,11 @@ export class WheelAccumulator {
                   ? deltaY * PAGE_HEIGHT_PX
                   : deltaY
 
-        /*
-            A reversal drops what was pending. Carrying it across would let a
-            nudge one way and then the other fire a rung early, which reads as
-            the view jumping while it settles rather than as a step.
-        */
-        if (px !== 0 && Math.sign(px) !== Math.sign(this.pending)) this.pending = 0
-        this.pending += px
-
-        const rungs = Math.trunc(this.pending / WHEEL_NOTCH_PX)
-        this.pending -= rungs * WHEEL_NOTCH_PX
-        /*
-            deltaY is positive scrolling down, which zooms out - hence the
-            negation, and hence the explicit zero: negating +0 gives -0, which
-            `Object.is` and so `toBe(0)` treat as a different value from the 0
-            this documents itself as returning.
-        */
-        return rungs === 0 ? 0 : -rungs
+        /* deltaY is positive scrolling down, which zooms out. */
+        this.position = this.clampPosition(this.position - px / WHEEL_NOTCH_PX)
+        return scaleAtRungPosition(this.position)
     }
 }
+
+/** Two scales that are the same to within float noise from a log/exp round trip. */
+const near = (a: number, b: number): boolean => Math.abs(a - b) <= 1e-9 * Math.max(1, Math.abs(b))

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -286,6 +286,7 @@ const testApi = {
     */
     paintContainerVisible: () => editor.paintContainerVisible,
     viewportRenderedInSync: () => editor.viewportRenderedInSync,
+    viewportScale: () => editor.viewportScale,
     paintContainerState: () => editor.paintContainerState,
     entityPosition: (entityNumber: number) => editor.entityPosition(entityNumber),
     /*

--- a/tests/helpers/fbe-test-api.ts
+++ b/tests/helpers/fbe-test-api.ts
@@ -95,6 +95,11 @@ export interface FbeTestApi {
      * tests/viewport-transform-freshness.spec.ts.
      */
     viewportRenderedInSync: () => boolean
+    /**
+     * The viewport's continuous scale, ie. the zoom level. 32 px per tile at 1,
+     * the same baseline Factorio uses - see tests/zoom-ladder.spec.ts.
+     */
+    viewportScale: () => number
     /** Whether the paint container is drawn; undefined when there is none. */
     paintContainerVisible: () => boolean | undefined
     /**

--- a/tests/zoom-ladder.spec.ts
+++ b/tests/zoom-ladder.spec.ts
@@ -1,0 +1,197 @@
+import { test, expect, Page } from '@playwright/test'
+import { encodeBlueprint as encode, packVersion as version } from './helpers/encode-blueprint'
+import { suppressOverlays } from './helpers/overlays'
+import { loadBlueprint, waitForEditor } from './helpers/fbe-test-api'
+
+/*
+    The zoom ladder in a browser (#206). Deliberately thin: the arithmetic is
+    unit tested in packages/editor/src/core/zoomLevels.test.ts, which is pure and
+    FD-free and so runs under `vp test` in CI, where Playwright does not run at
+    all (#210). Duplicating the ladder here would move coverage from the half
+    that runs to the half that does not.
+
+    What is left is the part no unit test can see, which is the **wiring**: that
+    a wheel event over the canvas reaches the accumulator and lands the viewport
+    on a rung. Nothing under tests/ read a zoom level before this, so the whole
+    path could have been deleted with the suite green.
+
+    Three things this spec was shaped by, each of which cost a run:
+
+      - **A wheel read races the wheel event.** `page.mouse.wheel` resolves once
+        the event is dispatched, not once the page has handled it, so an
+        immediately following `page.evaluate` can observe the scale from before
+        the notch. Measured: five full notches read back as four, and a later
+        read then jumped two rungs at once catching up. That looks exactly like
+        dropped events, and the tempting fix - a timeout, or accepting "about
+        one rung" - would have hidden it. `settled()` below syncs on a frame
+        instead, which made three consecutive runs identical.
+      - **The fitted scale is on no rung, and for a small blueprint it is the
+        ceiling.** Two chests ten tiles apart fit at exactly 3, where zooming in
+        is a no-op and half these assertions are vacuous. The fixture is 100
+        tiles wide so the fit lands mid-ladder, at about 0.4, which also means
+        every test here starts off-rung and so exercises the snap.
+      - **The accumulator carries a remainder between events**, so a test that
+        scrolls twice is not testing the same thing twice. Each test gets a
+        fresh page.
+*/
+
+/** One mouse notch in Chrome. Matches WHEEL_NOTCH_PX in zoomLevels.ts. */
+const NOTCH = 100
+
+/** Which rung a scale sits on: n in 2^(n/7). Non-integral means off-ladder. */
+const rungIndex = (scale: number): number => Math.log2(scale) * 7
+
+/**
+ * The scale once the page has actually handled the wheel events dispatched to
+ * it. See the header - without the frame sync this reads one event behind.
+ */
+const settled = async (page: Page): Promise<number> => {
+    await page.evaluate(() => new Promise<void>(resolve => requestAnimationFrame(() => resolve())))
+    return page.evaluate(() => window.__fbe_test.viewportScale())
+}
+
+/** 100 tiles wide, so the fit lands mid-ladder rather than clamped at the ceiling. */
+const wideBlueprint = encode({
+    version: version(2, 0, 45),
+    entities: [
+        { entity_number: 1, name: 'wooden-chest', position: { x: 0.5, y: 0.5 } },
+        { entity_number: 2, name: 'wooden-chest', position: { x: 100.5, y: 0.5 } },
+    ],
+})
+
+const openWithBlueprint = async (page: Page): Promise<number> => {
+    await page.goto('/')
+    await waitForEditor(page)
+    await loadBlueprint(page, wideBlueprint)
+    await page.mouse.move(400, 300)
+    return settled(page)
+}
+
+test.beforeEach(async ({ page }) => {
+    await suppressOverlays(page)
+})
+
+test('a wheel notch down lands one rung below the nearest', async ({ page }) => {
+    const before = await openWithBlueprint(page)
+    await page.mouse.wheel(0, NOTCH)
+
+    const after = await settled(page)
+    expect(after).toBeLessThan(before)
+    /* On a rung, not merely smaller - that is the whole point of a ladder. */
+    expect(rungIndex(after)).toBeCloseTo(Math.round(rungIndex(before)) - 1, 6)
+})
+
+test('a wheel notch up lands one rung above the nearest', async ({ page }) => {
+    const before = await openWithBlueprint(page)
+    await page.mouse.wheel(0, -NOTCH)
+
+    const after = await settled(page)
+    expect(after).toBeGreaterThan(before)
+    expect(rungIndex(after)).toBeCloseTo(Math.round(rungIndex(before)) + 1, 6)
+})
+
+test('one notch each way is exactly reversible once on the ladder', async ({ page }) => {
+    /*
+        Defect 1, end to end. The old flat step made this x1.1 then x0.9 = 0.99,
+        losing 1% every round trip - and because the loss was proportional it
+        never converged, it drifted.
+
+        The return is to the rung below the one the first notch reached, not to
+        the fitted scale it started from: that value was on no rung and is gone
+        the moment the first notch snaps. Asserting a return to it would be
+        asserting the snap never happened.
+    */
+    await openWithBlueprint(page)
+
+    await page.mouse.wheel(0, -NOTCH)
+    const zoomedIn = await settled(page)
+    await page.mouse.wheel(0, NOTCH)
+    const back = await settled(page)
+    expect(rungIndex(back)).toBeCloseTo(Math.round(rungIndex(zoomedIn)) - 1, 6)
+
+    /* And from a rung it is exact both ways, forever. */
+    await page.mouse.wheel(0, -NOTCH)
+    expect(await settled(page)).toBeCloseTo(zoomedIn, 10)
+    await page.mouse.wheel(0, NOTCH)
+    expect(await settled(page)).toBeCloseTo(back, 10)
+})
+
+test('a burst of small trackpad deltas is one notch, not one each', async ({ page }) => {
+    /*
+        Defect 2. The old handler read only Math.sign(e.deltaY), so these ten
+        events would have been ten rungs - a jump of 2^(10/7), nearly a
+        tripling, off one flick of a trackpad.
+    */
+    const before = await openWithBlueprint(page)
+    for (let i = 0; i < 10; i++) await page.mouse.wheel(0, NOTCH / 10)
+
+    expect(rungIndex(await settled(page))).toBeCloseTo(Math.round(rungIndex(before)) - 1, 6)
+})
+
+test('a partial burst moves nothing at all', async ({ page }) => {
+    /*
+        The other half of the accumulator, and the one that fails if the
+        threshold is dropped: nine tenths of a notch is not a notch. Without
+        this, an implementation that stepped on every event would still pass the
+        test above by arriving at the same place through ten steps.
+    */
+    const before = await openWithBlueprint(page)
+    for (let i = 0; i < 9; i++) await page.mouse.wheel(0, NOTCH / 10)
+
+    expect(await settled(page)).toBe(before)
+})
+
+test('scrolling out repeatedly stops at the floor', async ({ page }) => {
+    /*
+        Defect 3, the half that did not exist at all: there was no floor
+        anywhere. Because the step is multiplicative the old code approached 0
+        asymptotically rather than going negative, so it degraded into an
+        unusable speck instead of failing outright - which is why this was never
+        filed as a crash.
+    */
+    await openWithBlueprint(page)
+    for (let i = 0; i < 60; i++) await page.mouse.wheel(0, NOTCH)
+
+    expect(await settled(page)).toBeCloseTo(0.1, 10)
+})
+
+test('scrolling in repeatedly stops at the ceiling, exactly', async ({ page }) => {
+    /*
+        The other half of defect 3. The ceiling existed but the guard tested it
+        *before* applying the step, so from 2.99 a tick still landed at 3.289 -
+        soft by a whole step. Asserting the exact value is what catches that;
+        `toBeLessThanOrEqual(3)` would not have.
+    */
+    await openWithBlueprint(page)
+    for (let i = 0; i < 60; i++) await page.mouse.wheel(0, -NOTCH)
+
+    expect(await settled(page)).toBeCloseTo(3, 10)
+})
+
+test('loading a blueprint still fits it exactly, on no rung', async ({ page }) => {
+    /*
+        The guard. The continuous scale stays the source of truth precisely so
+        this keeps working: storing a ladder index instead would snap the fit and
+        leave every blueprint slightly over- or under-filled.
+
+        Asserted through the chests' own separation rather than a hardcoded
+        number, because the fit depends on the viewport size. 100 tiles apart at
+        32 px per tile per unit scale is 3200 * scale on screen, whatever the
+        scale turns out to be - the same arithmetic rail-signal-snapping.spec.ts
+        relies on when it derives a zoom from two entities.
+    */
+    const scale = await openWithBlueprint(page)
+    const { a, b } = await page.evaluate(() => ({
+        a: window.__fbe_test.entityScreenPosition(1),
+        b: window.__fbe_test.entityScreenPosition(2),
+    }))
+
+    /* Both must be on screen, or the separation is measured against nothing. */
+    if (!a || !b) throw new Error('both chests must have a screen position')
+
+    expect(Math.abs(b.x - a.x)).toBeCloseTo(100 * 32 * scale, 6)
+    expect(scale).toBeGreaterThan(0.1)
+    expect(scale).toBeLessThan(3)
+    /* Off-ladder, which is why stepZoom has to snap at all. */
+    expect(Math.abs(rungIndex(scale) - Math.round(rungIndex(scale)))).toBeGreaterThan(0.01)
+})

--- a/tests/zoom-ladder.spec.ts
+++ b/tests/zoom-ladder.spec.ts
@@ -30,9 +30,14 @@ import { loadBlueprint, waitForEditor } from './helpers/fbe-test-api'
         is a no-op and half these assertions are vacuous. The fixture is 100
         tiles wide so the fit lands mid-ladder, at about 0.4, which also means
         every test here starts off-rung and so exercises the snap.
-      - **The accumulator carries a remainder between events**, so a test that
-        scrolls twice is not testing the same thing twice. Each test gets a
-        fresh page.
+      - **The wheel carries a position between events**, so a test that scrolls
+        twice is not testing the same thing twice. Each test gets a fresh page.
+
+    Note the wheel is **continuous** as of 2026-08-11 and no longer lands on
+    rungs - it travels along the same curve, one rung per `WHEEL_NOTCH_PX`. The
+    ladder is still what the game stops on, and `BlueprintContainer.zoom()` still
+    steps it; that is unit tested rather than driven from here, since no keybind
+    reaches it yet.
 */
 
 /** One mouse notch in Chrome. Matches WHEEL_NOTCH_PX in zoomLevels.ts. */
@@ -71,74 +76,70 @@ test.beforeEach(async ({ page }) => {
     await suppressOverlays(page)
 })
 
-test('a wheel notch down lands one rung below the nearest', async ({ page }) => {
+test('one notch down moves exactly one rung out', async ({ page }) => {
     const before = await openWithBlueprint(page)
     await page.mouse.wheel(0, NOTCH)
 
     const after = await settled(page)
     expect(after).toBeLessThan(before)
-    /* On a rung, not merely smaller - that is the whole point of a ladder. */
-    expect(rungIndex(after)).toBeCloseTo(Math.round(rungIndex(before)) - 1, 6)
+    /* One rung of travel, measured from wherever the fit happened to leave it. */
+    expect(rungIndex(after)).toBeCloseTo(rungIndex(before) - 1, 6)
 })
 
-test('a wheel notch up lands one rung above the nearest', async ({ page }) => {
+test('one notch up moves exactly one rung in', async ({ page }) => {
     const before = await openWithBlueprint(page)
     await page.mouse.wheel(0, -NOTCH)
 
     const after = await settled(page)
     expect(after).toBeGreaterThan(before)
-    expect(rungIndex(after)).toBeCloseTo(Math.round(rungIndex(before)) + 1, 6)
+    expect(rungIndex(after)).toBeCloseTo(rungIndex(before) + 1, 6)
 })
 
-test('one notch each way is exactly reversible once on the ladder', async ({ page }) => {
+test('one notch each way is exactly reversible', async ({ page }) => {
     /*
         Defect 1, end to end. The old flat step made this x1.1 then x0.9 = 0.99,
         losing 1% every round trip - and because the loss was proportional it
         never converged, it drifted.
 
-        The return is to the rung below the one the first notch reached, not to
-        the fitted scale it started from: that value was on no rung and is gone
-        the moment the first notch snaps. Asserting a return to it would be
-        asserting the snap never happened.
+        Exact to the last bit rather than merely close, which is the reason the
+        wheel keeps its position in rungs and adds to it: multiplying a scale by
+        2^(1/7) and then dividing does not return the identical float.
     */
-    await openWithBlueprint(page)
+    const start = await openWithBlueprint(page)
 
     await page.mouse.wheel(0, -NOTCH)
-    const zoomedIn = await settled(page)
     await page.mouse.wheel(0, NOTCH)
-    const back = await settled(page)
-    expect(rungIndex(back)).toBeCloseTo(Math.round(rungIndex(zoomedIn)) - 1, 6)
-
-    /* And from a rung it is exact both ways, forever. */
-    await page.mouse.wheel(0, -NOTCH)
-    expect(await settled(page)).toBeCloseTo(zoomedIn, 10)
-    await page.mouse.wheel(0, NOTCH)
-    expect(await settled(page)).toBeCloseTo(back, 10)
+    expect(await settled(page)).toBe(start)
 })
 
-test('a burst of small trackpad deltas is one notch, not one each', async ({ page }) => {
+test('small deltas move proportionally instead of waiting for a threshold', async ({ page }) => {
     /*
-        Defect 2. The old handler read only Math.sign(e.deltaY), so these ten
-        events would have been ten rungs - a jump of 2^(10/7), nearly a
-        tripling, off one flick of a trackpad.
+        The change that came out of driving it (2026-08-11). A tenth of a notch
+        moves a tenth of a rung; it does not sit still banking travel until a
+        threshold trips, which is what made a trackpad or a smooth-scrolling
+        mouse hold still and then lurch.
+
+        The measured reason to prefer this over a finer ladder: in the #206
+        capture the game moved 11 rungs in 11 ticks, where a 100px-per-rung
+        accumulator makes those same 11 rungs cost 1100px of finger travel. The
+        gap is cadence, so smaller steps would trade chunky for sluggish.
+    */
+    const before = await openWithBlueprint(page)
+    await page.mouse.wheel(0, NOTCH / 10)
+
+    expect(rungIndex(await settled(page))).toBeCloseTo(rungIndex(before) - 0.1, 6)
+})
+
+test('ten small deltas reach the same place as one whole notch', async ({ page }) => {
+    /*
+        The control on the test above: proportional-per-event has to sum to the
+        same travel, or a trackpad and a mouse would disagree about how far a
+        given amount of scrolling gets you.
     */
     const before = await openWithBlueprint(page)
     for (let i = 0; i < 10; i++) await page.mouse.wheel(0, NOTCH / 10)
 
-    expect(rungIndex(await settled(page))).toBeCloseTo(Math.round(rungIndex(before)) - 1, 6)
-})
-
-test('a partial burst moves nothing at all', async ({ page }) => {
-    /*
-        The other half of the accumulator, and the one that fails if the
-        threshold is dropped: nine tenths of a notch is not a notch. Without
-        this, an implementation that stepped on every event would still pass the
-        test above by arriving at the same place through ten steps.
-    */
-    const before = await openWithBlueprint(page)
-    for (let i = 0; i < 9; i++) await page.mouse.wheel(0, NOTCH / 10)
-
-    expect(await settled(page)).toBe(before)
+    expect(rungIndex(await settled(page))).toBeCloseTo(rungIndex(before) - 1, 6)
 })
 
 test('scrolling out repeatedly stops at the floor', async ({ page }) => {


### PR DESCRIPTION
PR 2 of the two the [zoom design](docs/superpowers/specs/2026-08-10-zoom-levels-design.md) sequences, and the behaviour change. PR #213 measured the ladder; this ships it.

Closes #206.

## The three defects, and what each becomes

| | before | after |
|---|---|---|
| **step** | `zoomBy(+/-0.1)`, whose multiplier is `1 + delta` - so x1.1 in and x0.9 out, and `1.1 x 0.9 = 0.99` | one rung of `2^(1/7)`, the game's own step, exactly reversible |
| **wheel** | `Math.sign(e.deltaY)` only, so a trackpad burst and a mouse notch were the same jump | deltas normalised by `deltaMode` and accumulated; one notch is one rung, ten trackpad events are one rung, the remainder carries |
| **limits** | ceiling tested *before* the multiply, so 2.99 still landed at 3.289; **no floor at all** | both exact, and a step that would overshoot lands on the limit itself - which is what the game does |

## What ships

- **`packages/editor/src/core/zoomLevels.ts`** - pure, no pixi/FD/globals, so its 24 unit tests run under `vp test` in **CI**. That matters more than usual here: nothing under `tests/` read a zoom level before this, and Playwright does not run in CI at all (#210).
- **`ZOOM_LEVELS` is computed**, `2^(n/7)` for `n` in -23..11, not the committed literal the design specified. That argument holds for a table of measurements - `railSignalSpots.ts` is 152 placements with no formula - but this ladder has a closed form, so a literal would be a transcription of a formula, and 35 hand-copied digits drift where nobody can see it.
- **`ZOOM_MIN = 0.1`**, the game's map editor floor. Its *world-view* floor is a rule - at most 200 tiles across - which 30 of the 367 corpus blueprints exceed; the widest, 397 tiles, needs 0.151 where the game's floor is 0.300.
- **`ZOOM_MAX = 3`**, the measured ceiling, which is also what `BlueprintContainer` already passed. The constructor argument is **deleted** rather than kept in step: a bound written down twice is one that has to be kept in sync, and the copy nothing tests is the one that loses.
- `Viewport.getCurrentScale()` now rebuilds a pending change before answering, for the same reason `getTransform` does (#144). It mattered little while the value was only displayed; it matters now that `zoom()` computes the next rung from it.
- `zoomBy` keeps mobile pinch continuous and gains the clamp. Its unused second parameter is gone - it allowed a non-uniform zoom no caller asked for, which a single clamped scale cannot express and `getCurrentScale` could not see.

## Verification

- **24 unit tests**, CI-visible. Mutation-checked two ways: swapping nearest-then-step for the directional rule fails 4, and reverting the accumulator to sign-only stepping fails 4 others.
- **8 Playwright tests** covering the wiring, which is all a browser can add once the arithmetic is unit tested.
- Full Playwright suite green.

## Three things that cost a run, all recorded in the specs

- **TDD caught the game disagreeing with me, not with the code.** Three expectations I wrote were wrong: coming off the ceiling the game goes 3.0 -> 2.6918, *skipping* the 2.971989 rung, because the limit sits between rungs and nearest-then-step lands two below it. The fixture's samples settle it, so the tests now assert the measured behaviour and cite it.
- **A wheel read races the wheel event.** `page.mouse.wheel` resolves once the event is dispatched, not once the page has handled it, so an immediate `evaluate` reads one event behind - five notches read back as four, and a later read then jumped two rungs catching up. That looks exactly like dropped events, and a timeout or a fuzzy "about one rung" assertion would have buried it. The specs sync on a frame instead; three consecutive runs then gave identical numbers.
- **The fitted scale for a small blueprint is the ceiling.** Two chests ten tiles apart fit at exactly 3, where zooming in is a no-op and half the assertions are vacuous. The fixture is 100 tiles wide so the fit lands mid-ladder and every test starts off-rung, which also exercises the snap.

## Not done here

`WHEEL_NOTCH_PX = 100` is the one number in the module that is feel rather than measurement, and no passing test can see whether it is right. One mouse notch is `2^(1/7)` = +10.4%, against the old code's +10% - so a mouse should feel unchanged, and the real change is the trackpad, which used to be one rung per event. Worth driving before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShHVPRNjjWzQyJFQfirX9Y


---

## Amended 2026-08-11 after driving it: the wheel is continuous

Driving it turned up what no test could - scrolling felt chunky. The ladder is right about where the game *stops* and was wrong about how to travel between those points, so `WheelZoom` replaces `WheelAccumulator`: it holds a position measured in rungs, moves it by `deltaY / WHEEL_NOTCH_PX` per event, and the scale is `2^(position/7)`.

- One notch of a notched mouse is still **exactly** one rung, so that hardware is unchanged and still lands on the game's own values.
- Anything smaller now moves proportionally instead of banking travel until a threshold trips.

**The measurement that chose this over a finer ladder is already in the fixture.** The game moved **11 rungs in 11 ticks** - the whole top of its range in 183ms - where a 100px-per-rung threshold makes those same 11 rungs cost 1100px of finger travel. The gap is **cadence**, not step size, so halving the rung would have traded chunky for sluggish and fixed neither.

**Defect 2's diagnosis was backwards, and the binary settles it.** The design blamed one-rung-per-event for the bad feel; the game does roughly that. The old code's real bugs were the asymmetric `×1.1/×0.9` step and the missing limits, which stay fixed either way. I checked the 2.0.77 binary because "the engine tweens between levels" was the rival explanation: there is no `smooth` or `interpolate` symbol anywhere near `CameraBase`, no smooth-zoom setting in the locale, and the two zoom-shaped strings in the binary (`zoomFactor`, `zoomIntensity`) are cloud prototype fields. Searching all 208 MB for the IEEE-754 bytes of `2^(1/7)` finds nothing either, so the ratio is computed. The engine snaps, exactly as the Lua capture showed.

Two details that are load-bearing rather than incidental:

- The position is held **in rungs and added to**, not recomputed from the scale, because that is what keeps zoom exactly reversible without a ladder to snap back to - multiplying a scale by `2^(1/7)` and dividing again does not return the identical float.
- The **position** is clamped, not merely the scale it produces. Otherwise scrolling hard against a limit banks travel that must be unwound before the view moves again, which reads as the wheel having died.

`BlueprintContainer.zoom()` still steps the ladder and is now the discrete entry point with no internal caller - the game has `zoom-in`/`zoom-out` keybinds and this editor has none bound yet.

Re-verified: 26 unit tests, 8 Playwright tests, full suite **187 passed**. Mutation-checked three ways - dropping the position clamp fails 2, never re-deriving from an externally set scale fails 1, reverting to one rung per event fails 4.
