### PR TITLE
Move vite-plus 0.2.6 -> 0.2.8, and let Renovate track it on a 24-hour cooldown

### DIFF
--- a/.github/actions/setup-vp/action.yml
+++ b/.github/actions/setup-vp/action.yml
@@ -11,7 +11,7 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ~/.vite-plus
-        key: vite-plus-${{ runner.os }}-0.2.6
+        key: vite-plus-${{ runner.os }}-0.2.8
 
     - name: Cache npm downloads
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -31,6 +31,6 @@ runs:
         # when intentionally upgrading the toolchain.
         curl -fsSL https://vite.plus -o vp-install.sh
         echo "58bb052c6a007e662e99667d65686251b16d6b39aa21155487da6d51280b3d54  vp-install.sh" | sha256sum -c -
-        VP_VERSION=0.2.6 VP_NODE_MANAGER=yes bash vp-install.sh
+        VP_VERSION=0.2.8 VP_NODE_MANAGER=yes bash vp-install.sh
         echo "$HOME/.vite-plus/bin" >> "$GITHUB_PATH"
         rm -f vp-install.sh

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -227,25 +227,57 @@
         {
             // vite-plus is the ENTIRE toolchain - there is no `vite` package in this
             // tree at all, the root `overrides` aliases it to
-            // `npm:@voidzero-dev/vite-plus-core@0.2.6`. So Vite, Rolldown, oxlint,
+            // `npm:@voidzero-dev/vite-plus-core@0.2.8`. So Vite, Rolldown, oxlint,
             // oxfmt and Vitest are not independently upgradable, and "bump vitest" has
             // no answer except "bump vite-plus".
             //
-            // Disabled rather than merely noted, because a Renovate PR here would be
-            // WRONG BY CONSTRUCTION rather than merely risky. The pin appears in five
-            // places that must move as one: root, editor and website package.json; the
-            // root `overrides` alias; and .github/actions/setup-vp/action.yml, which
-            // carries VP_VERSION, a cache key, AND A SHA256 OF THE INSTALLER SCRIPT.
-            // Renovate cannot compute that checksum, so a PR touching only the
-            // manifests would leave CI installing a different toolchain version than
-            // the lockfile pins - green, and wrong.
+            // ENABLED, on a 24-hour cooldown. This rule used to be `enabled: false`,
+            // and leaving it that way cost three releases: the pin sat at 0.2.6 from
+            // 2026-07-29 to 2026-08-11 while 0.2.7 and 0.2.8 shipped, under a comment
+            // here and in CLAUDE.md both asserting 0.2.6 was `latest`. Nothing
+            // re-measured, because nothing was watching. A hold whose only enforcement
+            // is a sentence in a config file is not a hold, it is a wish.
             //
-            // Note 0.2.6 is `latest`, not a lagging pin, so there is nothing to propose
-            // today anyway. Revisit by hand, changing all five places in one commit.
+            // The old reason for disabling was that a PR touching only the manifests
+            // would leave .github/actions/setup-vp/action.yml behind, so CI would
+            // install a different vp than the lockfile pins - "green, and wrong". That
+            // failure is real, and the customManager at the bottom of this file closes
+            // it: VP_VERSION and the cache key now move in the same PR.
+            //
+            // The old reason ALSO said Renovate cannot compute the installer sha256, so
+            // the checksum would go stale. Two corrections, both measured on
+            // 2026-08-11. First, that hash pins the mutable bootstrap script at
+            // https://vite.plus, which is versioned INDEPENDENTLY of the toolchain - it
+            // did not change across 0.2.6 -> 0.2.8, so most bumps do not touch it at
+            // all. Second, and this is the part that was backwards: a stale checksum
+            // cannot be "green and wrong", because the action VERIFIES it
+            // (`sha256sum -c -`) and a mismatch FAILS THE STEP. It is the one part of
+            // this that is self-guarding. The unguarded part was VP_VERSION, which is
+            // what the customManager now covers.
+            //
+            // 24 hours rather than the 3-day default, by explicit decision: this is
+            // developer tooling that never ships to users, the whole gate
+            // (vp check + vp test + build + 192 Playwright specs) runs against it
+            // locally before merge, and .npmrc already sets `min-release-age=1` so npm
+            // itself will not resolve anything younger.
+            //
             // The `@voidzero-dev/vite-plus-core` name is here because that is what
             // Renovate sees behind the `overrides` alias, not a second dependency.
+            //
+            // STILL TRUE AND STILL THE REVIEWER'S JOB: all five sites must move as one,
+            // and CI cannot see a mismatch between the vp CLI and the local vite-plus.
+            // Read the diff before merging, and if the installer script itself changed,
+            // re-fetch and re-hash by hand.
             matchPackageNames: ['vite-plus', '@voidzero-dev/vite-plus-core'],
-            enabled: false,
+            enabled: true,
+            minimumReleaseAge: '24 hours',
+            groupName: 'vite-plus toolchain',
+            addLabels: ['toolchain'],
+            prBodyNotes: [
+                'This is the ENTIRE toolchain (Vite, Rolldown, oxlint, oxfmt, Vitest). Nothing under it is independently upgradable.',
+                'Check `.github/actions/setup-vp/action.yml` moved too - `VP_VERSION` and the cache key are updated by a customManager, but **the installer sha256 is not**. Re-fetch https://vite.plus and re-hash if that script changed; a mismatch fails CI rather than passing silently.',
+                'CI does not run Playwright. Run `npm run localpreview` then `npx playwright test` locally before merging.',
+            ],
         },
         {
             // Enabled - this one is a "needs care", not a refusal. The bundled browser
@@ -318,6 +350,48 @@
             prBodyNotes: [
                 'Nothing reads this file - no workflow or script references it, and CI installs Node through `vp` (`VP_NODE_MANAGER=yes` in `.github/actions/setup-vp`). This is a local development hint, so the bump changes nothing about CI.',
             ],
+        },
+    ],
+
+    // The vite-plus pin does not live only in package.json. Two of its six
+    // occurrences are inside a composite action - a `VP_VERSION=` assignment in a
+    // shell `run:` block and an actions/cache key - and no built-in manager reads
+    // either. That is the specific hole that made this dependency worth disabling
+    // before: Renovate would bump the three manifests and the `overrides` alias,
+    // CI would still install the OLD vp, and the check would pass, because `vp
+    // install` reads the lockfile while the vp CLI itself comes from VP_VERSION.
+    // A CLI and a toolchain one release apart is exactly the kind of mismatch a
+    // green run does not surface.
+    //
+    // These two entries close it, so all six occurrences move in one PR. The
+    // `datasourceTemplate` is npm and the `depNameTemplate` is vite-plus, so
+    // Renovate treats them as the same dependency as the manifests and the
+    // packageRule above (cooldown, grouping, labels, prBodyNotes) applies to them
+    // too - that grouping is the point, not a nicety. Without it they would arrive
+    // as a separate PR and could merge apart from the manifests.
+    //
+    // NOT covered, deliberately: the installer sha256 on the line below
+    // VP_VERSION. It pins the bootstrap script at https://vite.plus, which is
+    // versioned separately from the toolchain and did not move across
+    // 0.2.6 -> 0.2.8. Renovate has no way to compute it, and it does not need one:
+    // the action runs `sha256sum -c -`, so a genuinely changed script fails the
+    // step loudly. Left to the human, and said so in prBodyNotes.
+    customManagers: [
+        {
+            customType: 'regex',
+            managerFilePatterns: ['/^\\.github/actions/setup-vp/action\\.yml$/'],
+            matchStrings: ['VP_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)'],
+            depNameTemplate: 'vite-plus',
+            datasourceTemplate: 'npm',
+        },
+        {
+            customType: 'regex',
+            managerFilePatterns: ['/^\\.github/actions/setup-vp/action\\.yml$/'],
+            matchStrings: [
+                'key: vite-plus-\\$\\{\\{ runner\\.os \\}\\}-(?<currentValue>\\d+\\.\\d+\\.\\d+)',
+            ],
+            depNameTemplate: 'vite-plus',
+            datasourceTemplate: 'npm',
         },
     ],
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,12 +530,25 @@ justifies a hold expires without anyone editing this file.
   the tree at all, the root `overrides` aliases it
   (`"vite": "npm:@voidzero-dev/vite-plus-core@0.2.8"`). So "bump vitest" has no
   answer except "bump vite-plus". 0.2.8 is `latest`, measured 2026-08-11.
-  **Nothing tracks this pin, so it goes stale without anyone touching the
-  file** - Renovate does not propose it, because it is an exact version rather
-  than a range and the CI half lives in a workflow `run:` line no manager reads.
-  It sat at 0.2.6 through 0.2.7 and 0.2.8 for that reason, under a note in this
-  file asserting it was `latest`. Re-measure with `npm view vite-plus dist-tags`
+  **Renovate tracks it now, on a 24-hour cooldown** - it did not until
+  2026-08-11, and the thirteen days it did not are the reason this entry is
+  worth reading. `renovate.json5` had it `enabled: false`, so the pin sat at
+  0.2.6 while 0.2.7 and 0.2.8 shipped, under a note in this file and a comment
+  in that one both asserting 0.2.6 was `latest`. Both were true when written and
+  neither could notice it had stopped being true. **A hold enforced only by a
+  sentence is not a hold.** Re-measure with `npm view vite-plus dist-tags`
   rather than trusting the number above.
+- **What made the disable look justified was half right, and the wrong half was
+  backwards.** The stated fear was that Renovate would bump the manifests and
+  leave `.github/actions/setup-vp/action.yml` behind - green, and wrong. The
+  `VP_VERSION` half of that is real: CI's `vp` CLI comes from that line while
+  `vp install` reads the lockfile, so the two can end up a release apart with
+  every check passing. Two `customManagers` in `renovate.json5` now move
+  `VP_VERSION` and the cache key in the same PR. The **checksum** half was the
+  backwards part: a stale installer sha256 cannot pass silently, because the
+  action runs `sha256sum -c -` and a mismatch **fails the step**. It is the one
+  self-guarding piece, and it was the one cited as unguardable. Ask whether a
+  thing is checked before citing it as a reason to automate nothing.
 - The pin appears in **five** places that must move as one: root, editor and
   website `package.json`; the root `overrides`; and
   `.github/actions/setup-vp/action.yml`, which carries both `VP_VERSION`, a cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ cd packages/website && npm run build:analyze
 
 ## Vite+ Toolchain
 
-`vp` is the unified CLI for this project (check, lint, format, test, build). Configuration lives in the root `vite.config.ts` (`lint`, `fmt`, and `test` blocks); `lint.options.typeCheck` is true, which is what makes `vp check` a type check as well as a lint. The commands `npm run lint` and `npm run format` delegate to `vp` and require it on PATH - install with `VP_VERSION=0.2.6 VP_NODE_MANAGER=yes curl -fsSL https://vite.plus | bash` and add `~/.vite-plus/bin` to PATH.
+`vp` is the unified CLI for this project (check, lint, format, test, build). Configuration lives in the root `vite.config.ts` (`lint`, `fmt`, and `test` blocks); `lint.options.typeCheck` is true, which is what makes `vp check` a type check as well as a lint. The commands `npm run lint` and `npm run format` delegate to `vp` and require it on PATH - install with `VP_VERSION=0.2.8 VP_NODE_MANAGER=yes curl -fsSL https://vite.plus | bash` and add `~/.vite-plus/bin` to PATH.
 
 ## Git and PR Conventions
 
@@ -525,15 +525,26 @@ justifies a hold expires without anyone editing this file.
 
 ### Coupled - these move together or not at all
 
-- **`vite-plus` 0.2.6 pins the whole toolchain.** Vite, Rolldown, oxlint, oxfmt
+- **`vite-plus` 0.2.8 pins the whole toolchain.** Vite, Rolldown, oxlint, oxfmt
   and Vitest are **not independently upgradable** - there is no `vite` package in
   the tree at all, the root `overrides` aliases it
-  (`"vite": "npm:@voidzero-dev/vite-plus-core@0.2.6"`). So "bump vitest" has no
-  answer except "bump vite-plus". **0.2.6 is `latest`, not a lagging pin.**
+  (`"vite": "npm:@voidzero-dev/vite-plus-core@0.2.8"`). So "bump vitest" has no
+  answer except "bump vite-plus". 0.2.8 is `latest`, measured 2026-08-11.
+  **Nothing tracks this pin, so it goes stale without anyone touching the
+  file** - Renovate does not propose it, because it is an exact version rather
+  than a range and the CI half lives in a workflow `run:` line no manager reads.
+  It sat at 0.2.6 through 0.2.7 and 0.2.8 for that reason, under a note in this
+  file asserting it was `latest`. Re-measure with `npm view vite-plus dist-tags`
+  rather than trusting the number above.
 - The pin appears in **five** places that must move as one: root, editor and
   website `package.json`; the root `overrides`; and
   `.github/actions/setup-vp/action.yml`, which carries both `VP_VERSION`, a cache
   key, **and a sha256 of the installer script** - the part people forget.
+  Measured across 0.2.6 -> 0.2.8, the installer checksum did **not** move: it
+  pins the mutable bootstrap script at `https://vite.plus`, which is versioned
+  independently of the toolchain, so a bump usually touches `VP_VERSION` and the
+  cache key and leaves the hash alone. Re-fetch and re-hash anyway rather than
+  assuming - the whole point of the pin is that the script can change silently.
 - **`@playwright/test`** needs `npx playwright install` in the same commit as any
   bump, or every spec fails on a missing `chrome-headless-shell` and reads as a
   suite-wide regression.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@types/node": "^26.1.2",
                 "typed-factorio": "^3.36.0",
                 "typescript": "^7.0.2",
-                "vite-plus": "0.2.6"
+                "vite-plus": "0.2.8"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1249,9 +1249,9 @@
             }
         },
         "node_modules/@oxc-project/runtime": {
-            "version": "0.141.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.141.0.tgz",
-            "integrity": "sha512-Z/6jQ0dyvE2fVjMUO7GoD4h+3q0G4lI4BWQNjaPhC4RPxaS4hF1b7/QYKB/Tl+KAQwqqKgMF54ukR/VvV5FILg==",
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.142.0.tgz",
+            "integrity": "sha512-Dv3jRrcXFdvUBUEljUu9kusrEo9G0iiqZFZNg3yCg+mkET4DD4S2Ow6Q6shFWDJwPidSa980d6YVXBlErUGADw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1259,9 +1259,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.141.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.141.0.tgz",
-            "integrity": "sha512-S4as7z0j0xQkXcJlyY5ehntwK8/wRkQb9Cyqw+J/N2rkWGQGK0SxD6X6DhQTc7qsxVTBxXbxZtBJh3mr3PtIzQ==",
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+            "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1269,9 +1269,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm-eabi": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.60.0.tgz",
-            "integrity": "sha512-1q4q4Jc8FlOMVojEisyFAVyl8h1yawNv6phjgmhGVEDeyeOdsSnSr9x0+D4mOnEKvpO5L4mxKZ/DP9X6U3A/Mw==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.61.0.tgz",
+            "integrity": "sha512-BaS+1OVvg9sr+Xav0+KdWedQRcAzrdoEcwMZeqoc2F6ieC1s/t5eM35YQoRPQ7vAqkZ+p3tbQb1r9I9mrV5oGA==",
             "cpu": [
                 "arm"
             ],
@@ -1286,9 +1286,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm64": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.60.0.tgz",
-            "integrity": "sha512-tD41I6nCt9k8SQXft0CSjjU9jg6SwG7uMu7PxodSEHXl+GDW0868oy6tTtoJkyUze8YKFgTpz/k5LuPUnFiGLw==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.61.0.tgz",
+            "integrity": "sha512-of8atAV0M1egGcVOMbgZCvc10sFOP3ayQBNQV5h5G3fNq8gACdEswfFk9bzGrdbM23rtg0Coxi7np7oPLcueNw==",
             "cpu": [
                 "arm64"
             ],
@@ -1303,9 +1303,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-arm64": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.60.0.tgz",
-            "integrity": "sha512-TTpzPug96Zxdyb46KvTyIUQDdsqbumXh2TKG9C23PCT0kF7JkW56Z/quPuG9rqOFKQIi1gpRNZ7DX18LwxXPnw==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.61.0.tgz",
+            "integrity": "sha512-7l8+5ov4BGwtAcmpzvEik/TG3bciwyw/S3e6j5GKH7pcQqcgCVxD3AuJeP6upto+SOTBKQ4wrrdbMt0gq8fHSQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1320,9 +1320,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-x64": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.60.0.tgz",
-            "integrity": "sha512-CnOoWgQ7L+JL/YQaRJ+NyATciSfcftncm7y3kqyte1cGtFEGnStaCd1TAyrinkfQ7nRBfHrTs1/vTwUJr3WF2Q==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.61.0.tgz",
+            "integrity": "sha512-Fnz4dDDXBb7udk+DmwelNjxbD6yptyxwCqwCH2ebo4RVLxVsRfFsn/AHJC49KIltPrVokamGv4SSOsiV50DTxQ==",
             "cpu": [
                 "x64"
             ],
@@ -1337,9 +1337,9 @@
             }
         },
         "node_modules/@oxfmt/binding-freebsd-x64": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.60.0.tgz",
-            "integrity": "sha512-ychJo7S3hZxdO6eDZ9zM6F2lM9fpJS3EKS5CAUSWyprdLYxTu4gbaUKV/VBPTcMJwQa2Bpo+643y3OJ537pihA==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.61.0.tgz",
+            "integrity": "sha512-mddOebKNCP+AucmzfNsk3jgbr681qAUvgMqi865GW5gWLJ/AnzXbvjQRrny0e++NAN8aphav/aRSrfFxNsNjpA==",
             "cpu": [
                 "x64"
             ],
@@ -1354,9 +1354,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.60.0.tgz",
-            "integrity": "sha512-36IH5o55T2Fx7E0feDttt+mifxN6yk9pWv4KfhAIsP0dFnUq27331OwbpOsZdoXF9soOLWm7mQUz5+UUmyec4g==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.61.0.tgz",
+            "integrity": "sha512-svx59iYL+DbaZGZUIoice4W0CjRXGExnbz7Re+awIb60rVxBS2KrU7Hnlx+nZYanLGLpjneUEgo/VFEKkSZAyQ==",
             "cpu": [
                 "arm"
             ],
@@ -1371,9 +1371,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.60.0.tgz",
-            "integrity": "sha512-G1Ve7lAa6sFBolVI2LWHfEAqy0YKh4vnioH8uYO9kAEdgM7mR40IksIx9/Zk4+vbYew/sGa4J9Q4tZ3n9gXDHA==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.61.0.tgz",
+            "integrity": "sha512-BYK9MPJPCf6d+fLKMTruThmEyCtHzQ1zLcsrTlUVkmnoXIaHAbfpeLYQwX1tkjs7W11dyzoi6HFvKcdnvX1zNg==",
             "cpu": [
                 "arm"
             ],
@@ -1388,9 +1388,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.60.0.tgz",
-            "integrity": "sha512-LTQdRBf6uzj/h7Xk6lKzbGD2hrF/fK4YI9LIN1c0509tPUn8wRa3mCmrFQpEWJPLYGFrLFFMTYW1Ljj6VqW2Hw==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.61.0.tgz",
+            "integrity": "sha512-QUaCNLq2/EC6G5ljOuFanl9Lgw6ZWp4co7rs4+KOMUzbGfA4Lq58FHRjjF9sVIG+93XSbo343MxFATrOU1qctA==",
             "cpu": [
                 "arm64"
             ],
@@ -1408,9 +1408,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-musl": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.60.0.tgz",
-            "integrity": "sha512-2JMo3XPxMPx3hiqddSZYyaH+fKJm6cz0u8n1naYjP/CdOQOZW34i8lKBUfmbWiuFvd6KoYXLmhAyBuvojsYS7Q==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.61.0.tgz",
+            "integrity": "sha512-S6uvJ6MXnRXl+zTs0CARNDvkE+cymj0EVWEKKsyKnlLlqTyQJBjw5s4D2pSIOZc+S46cy4STefzcr/sm0VzVPA==",
             "cpu": [
                 "arm64"
             ],
@@ -1428,9 +1428,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.60.0.tgz",
-            "integrity": "sha512-L3C+nBD13lr306tr/PjM3RMll+BVqgFrIgUyoeHuai5oueJrRLgO3j+GO5/Cbhtkf5PSlHYTI1JY7iqBd1qa6A==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.61.0.tgz",
+            "integrity": "sha512-6VDlRcytvZG6UlSIdAFKDLbppo9tvPxrWzle6vHldYFMeuDPQEfMKrkwezp7FaBq1wik9ra554ZZeRPsyIkFpg==",
             "cpu": [
                 "ppc64"
             ],
@@ -1448,9 +1448,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.60.0.tgz",
-            "integrity": "sha512-M4MsmvqlxFiPtSRGyBYQSZxchEf463AOyd+Dh4/9xDpjWBsRtDUTDMFN5EdHinjVK1/eDJQ8MLpcYjpYayaCnA==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.61.0.tgz",
+            "integrity": "sha512-KkBTYbzExpbmn15XjKPLu2fRV2PVlq+KWt+brad5rwIa03vdYoaDRWiS7raHII/dCTR6Ro4UpYUCH4t6lif4WQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -1468,9 +1468,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.60.0.tgz",
-            "integrity": "sha512-OH+9UskYuxRB+GxqdGkVN8f5UpwhqG8YscNo1wl8+KJ62cd7wZdGga6iGLJIf8kibF1WBwvlfDUx3cez/VXwFg==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.61.0.tgz",
+            "integrity": "sha512-69tzIq7sJLVB9dxYYtvMzcSSsnZHSO+U2U19O2RqDqgj6+Q4O7HjSXdaszbcgqzhsUwzSH7z5kWvk8nmf6BHTg==",
             "cpu": [
                 "riscv64"
             ],
@@ -1488,9 +1488,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.60.0.tgz",
-            "integrity": "sha512-y7AAFutt9wFWBFOAn6+BHaV39usZmcr3YYH2385f+NHgPNpIF9HpqKp0jgUxPaUOCyG3oaX5VhJduL1Nw164rw==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.61.0.tgz",
+            "integrity": "sha512-Oqi/N0OvtOVXsPKAOOhKgGH3msRYF8BLJaNBbWiupRiKoKVyc8JRKPCfarkQJC+RgP9U8raUKLe+bNwd0HUMiA==",
             "cpu": [
                 "s390x"
             ],
@@ -1508,9 +1508,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-gnu": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.60.0.tgz",
-            "integrity": "sha512-yKZ9+CXAI+1RO5nH/4Z/9M6DAsfOzd5bw/gtWk81KB4mpalMaRRSXfouc5/tHxazDmBek55HNPepNYBgaCew0Q==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.61.0.tgz",
+            "integrity": "sha512-3TKwv/ed4uwJSemAA8P9XcoqETpjQI4waquF9UilhA9Mn/dhr1PdUEXWlL74mtc6ZNfmKPA9+NEJm01nRF8CVA==",
             "cpu": [
                 "x64"
             ],
@@ -1528,9 +1528,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-musl": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.60.0.tgz",
-            "integrity": "sha512-bCUGaF6hJOYnQzLJdHLZbvGsOd5oSvGAyJhPAKum2uyLYUuXmP8vqg690DWi2hqcnIoYpqSqCrjzE5aiUAgwQg==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.61.0.tgz",
+            "integrity": "sha512-uFso4u4nLkVSlMCpgjyvWV60Gt7GvDQHnk1mmRxHIkZTMB0ljpUKwCD9FYGgN9H97x2wYl0UwEjgRZaPIuhEhw==",
             "cpu": [
                 "x64"
             ],
@@ -1548,9 +1548,9 @@
             }
         },
         "node_modules/@oxfmt/binding-openharmony-arm64": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.60.0.tgz",
-            "integrity": "sha512-GrUeZOvzP30ExxfCuQiyofuUGI+OmvAgFwOO5w5p9mGPlxcyuqI+6Sy9fAKFFfLQrqKYWFgc5sYA2Unj/29nPg==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.61.0.tgz",
+            "integrity": "sha512-keGLkzeOvkMpNmPp4hffXWpfoSsY6e1K8++KXD4mSSfxdvM8q9QUDsYY689TB1k6Co832DZn1MnaaVx6cIBMWQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1565,9 +1565,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.60.0.tgz",
-            "integrity": "sha512-WD4Q954kUl2TDJV/6q7UnE2rlKk047kXLJsr4bJ2mXRaAqNXcmV3nwKUsGCc3mz/jYDBnXtJEaBErJEybK8iQQ==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.61.0.tgz",
+            "integrity": "sha512-VzsAISkFxmNhJ5LBDEL9VuH6tJsVJMtqYit2LyIUf/HLnsCe4Pg9SMOjjVQzGWt0bnpyfJ94CrqTqcpNZzK+ug==",
             "cpu": [
                 "arm64"
             ],
@@ -1582,9 +1582,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.60.0.tgz",
-            "integrity": "sha512-HqDekjr8JXzVDUP1YthDZ1Y3CBEcuZT4WX3B+1kaxj8CvZA8Y2YhcEsXqoSop3tVsgjACxjnFQFDkBo0r/jq1Q==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.61.0.tgz",
+            "integrity": "sha512-xv4t7yzwJoYaLB6Zv28B3W+j7brEjsyv50rLTAQgmxJzddce9fAMCxed8dSAkbWES0zz2J29nYK5FaTuD2YBHg==",
             "cpu": [
                 "ia32"
             ],
@@ -1599,9 +1599,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-x64-msvc": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.60.0.tgz",
-            "integrity": "sha512-tz78yhmGPKboTMHCHSaUqXK8JrmoSejgDcWeqAtg2s07ZGKQ3rH5Jn8NuXPGNG33CDbY2e9NoQWXIVEmKO21Rw==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.61.0.tgz",
+            "integrity": "sha512-6EZXFkqOwxdDYjIn3TSNnPk3ST5E5GiYd4FiM6UF/mCL/LZSfr6D6UygTfW3R1PCQP2quCKpCEGRlij8E3VYbg==",
             "cpu": [
                 "x64"
             ],
@@ -1700,9 +1700,9 @@
             ]
         },
         "node_modules/@oxlint/binding-android-arm-eabi": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.75.0.tgz",
-            "integrity": "sha512-lutovtFzJqlRaqpZrCqSSGaHZzl9nIxxpjLzhSRLunN6dCLylj0uzlCyQGaQDIys7rrv8kVXiFO+R4Zpn0bX7g==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.76.0.tgz",
+            "integrity": "sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w==",
             "cpu": [
                 "arm"
             ],
@@ -1717,9 +1717,9 @@
             }
         },
         "node_modules/@oxlint/binding-android-arm64": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.75.0.tgz",
-            "integrity": "sha512-hXI0hDgHkw4w5nfru72aG7y+2iQJmC4waH/KV6H/hbgA6yAP5jYNx0P9yug15Hs0tWl/+mda3Jjn/2gmDT48tw==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.76.0.tgz",
+            "integrity": "sha512-shm/ngQilHK6bs+ElJWa4oHfNj5vL1Gl/iVEJldTQjpr0/67oSgr0KUpbmcnLig5Fo0v/l6j2567A7TOL89ONA==",
             "cpu": [
                 "arm64"
             ],
@@ -1734,9 +1734,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-arm64": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.75.0.tgz",
-            "integrity": "sha512-D91BWbK/dMYfCcrghspPIuKs2D9LF4Z/OabVSQjw1AO6PWxArD7teDA48bm0ySFqWDaPVqmQRl5GMWNglTXyrQ==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.76.0.tgz",
+            "integrity": "sha512-rvJmrAPKSQ9aWJ6wIS6CK2tJjwzfW0ApQH9qokq6sfDvmHwoyIHxHFMq7z7i7GiV6fdE6s8qvBqWKPTu8RmT6Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1751,9 +1751,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-x64": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.75.0.tgz",
-            "integrity": "sha512-02mpwzf12BonZ6PT0TuQoomvEh2kVl2WGBIKWezCyToIS+rYkQZ6GXnARBAl9A4Ovm2V+Xe7M4KretyqmmcnJQ==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.76.0.tgz",
+            "integrity": "sha512-U/zYdb7VYKGY6pA9Vd2rYl9O/HlCylcOlb5PGPvVLtg+oLGsk6H3XGKEMHKyqD3nmmtmlmwb/8SwU2vfSAtvMw==",
             "cpu": [
                 "x64"
             ],
@@ -1768,9 +1768,9 @@
             }
         },
         "node_modules/@oxlint/binding-freebsd-x64": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.75.0.tgz",
-            "integrity": "sha512-qZJgLnDaBsiL5YESx2t/TZ8eXkL9fEkKoXEdzegROhlz9A0lgyGnZ0dAzJrh7LJAHQl2K9RdRueN2s/9N7+odg==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.76.0.tgz",
+            "integrity": "sha512-WvKG9CAriuo0XNiFzpXjDngUZcRGFNpaK2kLyMUsnJlShxkT96u+BpJQ3KqdQwGOrvI14L6V8bAwXwAYNNY6Jg==",
             "cpu": [
                 "x64"
             ],
@@ -1785,9 +1785,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.75.0.tgz",
-            "integrity": "sha512-7XlaWA5BJD3XpCfrEqjEe6Zseeb14S7QGa304XfwKignRaKQ+eIj775BQ7nIslggWickl4IsPUFqJ+/gAyNHVg==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.76.0.tgz",
+            "integrity": "sha512-qJ5+RH99TqFRq3UCDxkW0zJJu9c+OAHFY72vGlxZLEpuO+MpKo3POgqb8sYipL9KYm8XY6ofb0HsOuvY6hQNqQ==",
             "cpu": [
                 "arm"
             ],
@@ -1802,9 +1802,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.75.0.tgz",
-            "integrity": "sha512-av6Tpv8yrcMMMOadOqENBhlsLRcGFXXwoQ0hzHhsmS9FJ4Wioy8we427GbcMe2XTxmL2e60T67H1Dyr3up+tAA==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.76.0.tgz",
+            "integrity": "sha512-PvPCVptkgVARsucgIqFQQcSmJ6xc6GtnVB5bRBekRahTc9eObMtjHfMjy5M+C2tHt5UCMttWM9RuSk/H9NqYeg==",
             "cpu": [
                 "arm"
             ],
@@ -1819,9 +1819,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-gnu": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.75.0.tgz",
-            "integrity": "sha512-WcUhd8fHT5plrA14lANevl+hOl815mVI5t2hU21oFWrZKFXIVV/Sr4rWQV0NzSvzBupbMLNc5ErEA6Ehxh5jMg==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.76.0.tgz",
+            "integrity": "sha512-3KeFDx8Bu4HPAXbuHZOr/oHvN+QT+JQhMw/NYPz7Z071xLSsG27Jfh9PIQVEY7hk1I+jr43ExqRIeJ6VKk2yLw==",
             "cpu": [
                 "arm64"
             ],
@@ -1839,9 +1839,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-musl": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.75.0.tgz",
-            "integrity": "sha512-UWzp5wRHFe/ESO3+eEaxXsTkYTGLYjnTsi/I5neEacXSItQ6WNleapfOAeA4x2b8nyhJ4uQxqvtv9pHv8kWJtQ==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.76.0.tgz",
+            "integrity": "sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw==",
             "cpu": [
                 "arm64"
             ],
@@ -1859,9 +1859,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.75.0.tgz",
-            "integrity": "sha512-XEVRwGMLKCUKrvhLAz4F6AIh8MJrQVdSZtAmPpRZt9tGPsUnamPOcl3dS/ZQzJnar/Ymgc//+xho0L60Emzuxg==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.76.0.tgz",
+            "integrity": "sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw==",
             "cpu": [
                 "ppc64"
             ],
@@ -1879,9 +1879,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.75.0.tgz",
-            "integrity": "sha512-mAG4DUXqfLC8cTjMD2kt3jDmVzFREYtDyeLNdLdsCcBc4Zbl2EMuiFektGBilQwkNjYnMvCqJs55U+Hyb+b+jw==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.76.0.tgz",
+            "integrity": "sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA==",
             "cpu": [
                 "riscv64"
             ],
@@ -1899,9 +1899,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-musl": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.75.0.tgz",
-            "integrity": "sha512-95hrAvriAlI+pekSomTFIn0+bawMDlDwTNVmdjsFusTHyL2JWh7TWvRNG/Lkim72uN8OiCcO9wcaC6omLP5E3w==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.76.0.tgz",
+            "integrity": "sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -1919,9 +1919,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-s390x-gnu": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.75.0.tgz",
-            "integrity": "sha512-4b6f2+FrtruAESrCqIKcrarzfrSx+wk2QNcp+RT91/Prc+pMQMAfyZ1rG1c3tFQNl8Bc616tx40uNXyxNBRPbQ==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.76.0.tgz",
+            "integrity": "sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ==",
             "cpu": [
                 "s390x"
             ],
@@ -1939,9 +1939,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-gnu": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.75.0.tgz",
-            "integrity": "sha512-nshAhrUvXFUWOvqQ2soIw7HFNWvpvEV4o0cYSqPtzLiPF5gKyYTDOOTJ6Rn8g8K/iGvPIrbDA4v8+5MvnjJrrg==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.76.0.tgz",
+            "integrity": "sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg==",
             "cpu": [
                 "x64"
             ],
@@ -1959,9 +1959,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-musl": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.75.0.tgz",
-            "integrity": "sha512-e4jNxLKnxLC6sYBQRxrI2pgIIxnmMtF8U/VwNYcjTT/CLS+spH624cYVnj07bTKwaEWT37/e025isOs6j/0xqA==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.76.0.tgz",
+            "integrity": "sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A==",
             "cpu": [
                 "x64"
             ],
@@ -1979,9 +1979,9 @@
             }
         },
         "node_modules/@oxlint/binding-openharmony-arm64": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.75.0.tgz",
-            "integrity": "sha512-hZ2lH+1qLf/DiEP9UWuQTK2JWj/BgvMB4jhIV4SmNU1wfEiYYX4TynQyAZXx0j9X4qRYizAL042SKaV+8ynh4w==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.76.0.tgz",
+            "integrity": "sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1996,9 +1996,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-arm64-msvc": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.75.0.tgz",
-            "integrity": "sha512-Ilj6PNzGDS3bCU0MSJH7Msh0NhH+T/mRp2shwg+q+GHeVlPwP5LEboW96aW+3kVKFk6zYZy1Xi5pZkqZh6X8KQ==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.76.0.tgz",
+            "integrity": "sha512-pqDWZiwcmByWUEm1NFUBNiT6aentCcaoMWJv0HbXEmuYermJ4sg8ppVrshubYP2MZ6SHccJJcpr6x469PuDFIw==",
             "cpu": [
                 "arm64"
             ],
@@ -2013,9 +2013,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-ia32-msvc": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.75.0.tgz",
-            "integrity": "sha512-QVit2nOEOiPhkmsrksPSkoGCdnZRNkspt8fwoYyP09te1VEbnSj4LAxua4rc8FKTmWkySVe05j8iz9GXYfF1AQ==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.76.0.tgz",
+            "integrity": "sha512-Ba0O659kgMv6pwO3z9PdO+K3aMxQRaw9HnG+e6AtOfgwcKFvYilciQYBoUBmxfQvOCKZe1SwjMkuB542NkuDMQ==",
             "cpu": [
                 "ia32"
             ],
@@ -2030,9 +2030,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-x64-msvc": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.75.0.tgz",
-            "integrity": "sha512-DSxnNkBUAYARPwJtR12Ig3deWr8w0H997xP6jy33i+e0SyYJw8FKuz4+cZtpmPEhQmvlPJE3X/2vNxDmLkd/rA==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.76.0.tgz",
+            "integrity": "sha512-5qcirPHO8nKfkoowEVWtpAoVTcYDy6g0UT0NGic450Qv8J2NrOqg4uQ8QppRP4MDTC7Xx47lbZnmadTH03CGGA==",
             "cpu": [
                 "x64"
             ],
@@ -2742,14 +2742,14 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-core": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.6.tgz",
-            "integrity": "sha512-vqDuuLJWS2JHWkFO7r8Z6AehtKnurpnYtw2XEQtjIfwE2GgSAO3zJdPIeaEZiovS6CqfQa+iOMn3kzVzeTSpTw==",
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.8.tgz",
+            "integrity": "sha512-hqUJyozjE4HtJ3wwf2pOw6LnH/EF9W4+ys2s8arr/3fUdw64vzp/SfPFBVCxsGRv2UfjkIieOeZrQ1FH6Oa5Tw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/runtime": "=0.141.0",
-                "@oxc-project/types": "=0.141.0",
+                "@oxc-project/runtime": "=0.142.0",
+                "@oxc-project/types": "=0.142.0",
                 "lightningcss": "^1.33.0",
                 "postcss": "^8.5.6",
                 "yuku-codegen": "^0.5.44",
@@ -2759,12 +2759,20 @@
                 "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
             },
             "optionalDependencies": {
+                "@voidzero-dev/vite-plus-darwin-arm64": "0.2.8",
+                "@voidzero-dev/vite-plus-darwin-x64": "0.2.8",
+                "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.8",
+                "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.8",
+                "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.8",
+                "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.8",
+                "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.8",
+                "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.8",
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
                 "@arethetypeswrong/core": "^0.18.1",
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.3.0",
+                "@vitejs/devtools": "^0.4.0",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -2850,9 +2858,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-darwin-arm64": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.6.tgz",
-            "integrity": "sha512-QSZWgfqPx5lrIKZ0vwgVRujRqo7gORcc9Oq4fI1UDjKZFgYz9gXVMibSjEqYU3R1webN6FKTOCnzFmrfXchWYw==",
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.8.tgz",
+            "integrity": "sha512-zcGNhemAhux0/sGDZBK5sHvv5bPm9kj+NhDKs8MYfZMjc51kpzMOV3PWhtTOXjJYDiSxv+Ss4AFj2y2wvQDgWg==",
             "cpu": [
                 "arm64"
             ],
@@ -2867,9 +2875,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-darwin-x64": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.6.tgz",
-            "integrity": "sha512-pMQZGCQO0s+akuxbjgh31hOUgrdDndCmfbP7BciJuts436qrBb8KaVzBhNjJQtxD6H8yY21CIOjD8nlrp4eDIw==",
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.8.tgz",
+            "integrity": "sha512-56vcDhYuHg1HSqQlFIEexs9WbDtvT2Z8QXq2pEUYVplmP55ekDGx8+Ibu69jBhk+lNwmLAonCW1alffQxMKirQ==",
             "cpu": [
                 "x64"
             ],
@@ -2884,9 +2892,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-linux-arm64-gnu": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.6.tgz",
-            "integrity": "sha512-0e6nrJgUDN5WwoDRjyh7KV/jbL7WDUhTEWslI64KGpuvD7M6OoPBXYo8Et176O2ENwf52CKVDjXwuvMMNIAzAA==",
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.8.tgz",
+            "integrity": "sha512-EU9zlSieuouJlnLEkVNw9guig5rTQ5hfMeNH0AlRjb1C1xVpUQdf0uRjXg1PHP3os/WspyCPB46Q80lEaeRb0w==",
             "cpu": [
                 "arm64"
             ],
@@ -2904,9 +2912,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-linux-arm64-musl": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.6.tgz",
-            "integrity": "sha512-j2yvyv3r2ZEuJG73rWlXFrYrxA7u5+bFSlWTqhsfHZhdb1FKMkklfYRuLtBBdBRLXJ+YMNt9GZT6VTVPJDZnnQ==",
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.8.tgz",
+            "integrity": "sha512-VbWUwaSAw0Ndql5uYy/Gfqt7duSy1sxTacLngD5M5kF4ZK7yoKKcx8iFiA0il1Gf3J7OGojPonKi5b3NSn3K7A==",
             "cpu": [
                 "arm64"
             ],
@@ -2924,9 +2932,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-linux-x64-gnu": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.6.tgz",
-            "integrity": "sha512-5vqldBBnRjIAUmQ88oKli+wPd5vSQaA2AZ2xs+omRlZfeJhC8chlud6DyJV6fVZCC9GI4otK2zSGpfQZx8Kc3A==",
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.8.tgz",
+            "integrity": "sha512-gZfnd3l9vNiP7QXQIEN9r2M9ZKCh8sg2vhBv04sZjMNAeQ05IXJMkWYkcfTUO7jhf8pdVt3VHQ4x6ULm0OnELg==",
             "cpu": [
                 "x64"
             ],
@@ -2944,9 +2952,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-linux-x64-musl": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.6.tgz",
-            "integrity": "sha512-29ned+euDKAl+BmCigzGrPykQ/kxTjtsPGV6G3hkImwakHNUnmLRayqmsWKHSwXmBk5xo5m+wqjMbo3G0npJQg==",
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.8.tgz",
+            "integrity": "sha512-5NtDUvjzF/HcjQraebpiVUgjX2CMKv2Jdmi5YpzHlt4g86sFA9M5a+OqBlgUctdzTeolnjxRsfurKiefG/hILA==",
             "cpu": [
                 "x64"
             ],
@@ -2964,9 +2972,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-win32-arm64-msvc": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.6.tgz",
-            "integrity": "sha512-4b5ASpQlkxSXDYzuM6MYsOc1GnYkqG9CbSA1QzobXm87V/Q+MGPn57eILyacgfbmNNLrO2HQ5hasoLvd2BXaSg==",
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.8.tgz",
+            "integrity": "sha512-Atjz6KsG42ntfQkM6Ks09Ifxm+ZIca2DnA31tO2FcPlHetBxYEGZwSNCOHAnoNnLrh2qNm+7aOC329a2ijhxLg==",
             "cpu": [
                 "arm64"
             ],
@@ -2981,9 +2989,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-win32-x64-msvc": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.6.tgz",
-            "integrity": "sha512-rvGkm4WmVkCKPhvUbLkRtlVhi7EYb8GU8KaqIGJ0dVfNQHDEqnFboaiUHuPN1npFNwB+80Ulzz9AkQ/Q8MswQA==",
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.8.tgz",
+            "integrity": "sha512-VSpa+gK1MjOH7GeO6H5xtJLqisQOWVeRQIDQs9XKizXFX0R4NCrioYO6Rc31QLXfL0lPCkwsKhp/9M9gllImRg==",
             "cpu": [
                 "x64"
             ],
@@ -4442,9 +4450,9 @@
             }
         },
         "node_modules/oxfmt": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.60.0.tgz",
-            "integrity": "sha512-fViX6i+gJuZWY+jI/fnR6WRbRj70GZ9RlCd30MygJrHTUNc4DxvKHWw8vBjMjffv3PgU5qWDR0AzmojQByqaZA==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.61.0.tgz",
+            "integrity": "sha512-DxdHBEMYpcEnHoUHjjOigUqV2TYKsvxLwUPXnVYBjgFdqrcQ/91OtwubtZ2PUodCs3sStI8R5Qw3fKNGK4e8wQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4460,25 +4468,25 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxfmt/binding-android-arm-eabi": "0.60.0",
-                "@oxfmt/binding-android-arm64": "0.60.0",
-                "@oxfmt/binding-darwin-arm64": "0.60.0",
-                "@oxfmt/binding-darwin-x64": "0.60.0",
-                "@oxfmt/binding-freebsd-x64": "0.60.0",
-                "@oxfmt/binding-linux-arm-gnueabihf": "0.60.0",
-                "@oxfmt/binding-linux-arm-musleabihf": "0.60.0",
-                "@oxfmt/binding-linux-arm64-gnu": "0.60.0",
-                "@oxfmt/binding-linux-arm64-musl": "0.60.0",
-                "@oxfmt/binding-linux-ppc64-gnu": "0.60.0",
-                "@oxfmt/binding-linux-riscv64-gnu": "0.60.0",
-                "@oxfmt/binding-linux-riscv64-musl": "0.60.0",
-                "@oxfmt/binding-linux-s390x-gnu": "0.60.0",
-                "@oxfmt/binding-linux-x64-gnu": "0.60.0",
-                "@oxfmt/binding-linux-x64-musl": "0.60.0",
-                "@oxfmt/binding-openharmony-arm64": "0.60.0",
-                "@oxfmt/binding-win32-arm64-msvc": "0.60.0",
-                "@oxfmt/binding-win32-ia32-msvc": "0.60.0",
-                "@oxfmt/binding-win32-x64-msvc": "0.60.0"
+                "@oxfmt/binding-android-arm-eabi": "0.61.0",
+                "@oxfmt/binding-android-arm64": "0.61.0",
+                "@oxfmt/binding-darwin-arm64": "0.61.0",
+                "@oxfmt/binding-darwin-x64": "0.61.0",
+                "@oxfmt/binding-freebsd-x64": "0.61.0",
+                "@oxfmt/binding-linux-arm-gnueabihf": "0.61.0",
+                "@oxfmt/binding-linux-arm-musleabihf": "0.61.0",
+                "@oxfmt/binding-linux-arm64-gnu": "0.61.0",
+                "@oxfmt/binding-linux-arm64-musl": "0.61.0",
+                "@oxfmt/binding-linux-ppc64-gnu": "0.61.0",
+                "@oxfmt/binding-linux-riscv64-gnu": "0.61.0",
+                "@oxfmt/binding-linux-riscv64-musl": "0.61.0",
+                "@oxfmt/binding-linux-s390x-gnu": "0.61.0",
+                "@oxfmt/binding-linux-x64-gnu": "0.61.0",
+                "@oxfmt/binding-linux-x64-musl": "0.61.0",
+                "@oxfmt/binding-openharmony-arm64": "0.61.0",
+                "@oxfmt/binding-win32-arm64-msvc": "0.61.0",
+                "@oxfmt/binding-win32-ia32-msvc": "0.61.0",
+                "@oxfmt/binding-win32-x64-msvc": "0.61.0"
             },
             "peerDependencies": {
                 "svelte": "^5.0.0",
@@ -4494,9 +4502,9 @@
             }
         },
         "node_modules/oxlint": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.75.0.tgz",
-            "integrity": "sha512-m9WzjRcRYA/uqIZDa9tclrieoPJ/ln1QYTKdFx6NUOs8uY5DiHlIwRQoCrHT6OM6O3ww3l2skY5gO7G7ZphE7g==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.76.0.tgz",
+            "integrity": "sha512-6QoFioEU4fNdiUx/2Eo6TRd6NG7H7njnRCz8rhB66cZmMHDTqcm1Rjvl8Wry+ZTQMBAmyb4Mlf62Mk5X+eHSOw==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -4509,25 +4517,25 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxlint/binding-android-arm-eabi": "1.75.0",
-                "@oxlint/binding-android-arm64": "1.75.0",
-                "@oxlint/binding-darwin-arm64": "1.75.0",
-                "@oxlint/binding-darwin-x64": "1.75.0",
-                "@oxlint/binding-freebsd-x64": "1.75.0",
-                "@oxlint/binding-linux-arm-gnueabihf": "1.75.0",
-                "@oxlint/binding-linux-arm-musleabihf": "1.75.0",
-                "@oxlint/binding-linux-arm64-gnu": "1.75.0",
-                "@oxlint/binding-linux-arm64-musl": "1.75.0",
-                "@oxlint/binding-linux-ppc64-gnu": "1.75.0",
-                "@oxlint/binding-linux-riscv64-gnu": "1.75.0",
-                "@oxlint/binding-linux-riscv64-musl": "1.75.0",
-                "@oxlint/binding-linux-s390x-gnu": "1.75.0",
-                "@oxlint/binding-linux-x64-gnu": "1.75.0",
-                "@oxlint/binding-linux-x64-musl": "1.75.0",
-                "@oxlint/binding-openharmony-arm64": "1.75.0",
-                "@oxlint/binding-win32-arm64-msvc": "1.75.0",
-                "@oxlint/binding-win32-ia32-msvc": "1.75.0",
-                "@oxlint/binding-win32-x64-msvc": "1.75.0"
+                "@oxlint/binding-android-arm-eabi": "1.76.0",
+                "@oxlint/binding-android-arm64": "1.76.0",
+                "@oxlint/binding-darwin-arm64": "1.76.0",
+                "@oxlint/binding-darwin-x64": "1.76.0",
+                "@oxlint/binding-freebsd-x64": "1.76.0",
+                "@oxlint/binding-linux-arm-gnueabihf": "1.76.0",
+                "@oxlint/binding-linux-arm-musleabihf": "1.76.0",
+                "@oxlint/binding-linux-arm64-gnu": "1.76.0",
+                "@oxlint/binding-linux-arm64-musl": "1.76.0",
+                "@oxlint/binding-linux-ppc64-gnu": "1.76.0",
+                "@oxlint/binding-linux-riscv64-gnu": "1.76.0",
+                "@oxlint/binding-linux-riscv64-musl": "1.76.0",
+                "@oxlint/binding-linux-s390x-gnu": "1.76.0",
+                "@oxlint/binding-linux-x64-gnu": "1.76.0",
+                "@oxlint/binding-linux-x64-musl": "1.76.0",
+                "@oxlint/binding-openharmony-arm64": "1.76.0",
+                "@oxlint/binding-win32-arm64-msvc": "1.76.0",
+                "@oxlint/binding-win32-ia32-msvc": "1.76.0",
+                "@oxlint/binding-win32-x64-msvc": "1.76.0"
             },
             "peerDependencies": {
                 "oxlint-tsgolint": ">=7.0.2001",
@@ -5205,14 +5213,14 @@
         },
         "node_modules/vite": {
             "name": "@voidzero-dev/vite-plus-core",
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.6.tgz",
-            "integrity": "sha512-vqDuuLJWS2JHWkFO7r8Z6AehtKnurpnYtw2XEQtjIfwE2GgSAO3zJdPIeaEZiovS6CqfQa+iOMn3kzVzeTSpTw==",
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.8.tgz",
+            "integrity": "sha512-hqUJyozjE4HtJ3wwf2pOw6LnH/EF9W4+ys2s8arr/3fUdw64vzp/SfPFBVCxsGRv2UfjkIieOeZrQ1FH6Oa5Tw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/runtime": "=0.141.0",
-                "@oxc-project/types": "=0.141.0",
+                "@oxc-project/runtime": "=0.142.0",
+                "@oxc-project/types": "=0.142.0",
                 "lightningcss": "^1.33.0",
                 "postcss": "^8.5.6",
                 "yuku-codegen": "^0.5.44",
@@ -5222,12 +5230,20 @@
                 "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
             },
             "optionalDependencies": {
+                "@voidzero-dev/vite-plus-darwin-arm64": "0.2.8",
+                "@voidzero-dev/vite-plus-darwin-x64": "0.2.8",
+                "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.8",
+                "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.8",
+                "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.8",
+                "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.8",
+                "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.8",
+                "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.8",
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
                 "@arethetypeswrong/core": "^0.18.1",
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.3.0",
+                "@vitejs/devtools": "^0.4.0",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -5321,13 +5337,13 @@
             }
         },
         "node_modules/vite-plus": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.6.tgz",
-            "integrity": "sha512-fFX8GLENhtzvnE4NmTPC8INRxjD2kZKcqUW0p7jOdawmHTNZqM5FiieyWOG6WH1a/axu9FCsbUNb918grfzDTw==",
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.8.tgz",
+            "integrity": "sha512-JULDOsy7gxG0o2FuvnsWnzRjzD1x9WM9mya3MNMOJUqTsL2pqiN2nq+dzoQMw+FGCytRw7yG1/p5qNcmYMM5Fw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.141.0",
+                "@oxc-project/types": "=0.142.0",
                 "@oxlint/plugins": "=1.73.0",
                 "@vitest/browser": "4.1.10",
                 "@vitest/browser-preview": "4.1.10",
@@ -5338,9 +5354,9 @@
                 "@vitest/snapshot": "4.1.10",
                 "@vitest/spy": "4.1.10",
                 "@vitest/utils": "4.1.10",
-                "@voidzero-dev/vite-plus-core": "0.2.6",
-                "oxfmt": "=0.60.0",
-                "oxlint": "=1.75.0",
+                "@voidzero-dev/vite-plus-core": "0.2.8",
+                "oxfmt": "=0.61.0",
+                "oxlint": "=1.76.0",
                 "oxlint-tsgolint": "=7.0.2001",
                 "vitest": "4.1.10"
             },
@@ -5354,14 +5370,14 @@
                 "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
             },
             "optionalDependencies": {
-                "@voidzero-dev/vite-plus-darwin-arm64": "0.2.6",
-                "@voidzero-dev/vite-plus-darwin-x64": "0.2.6",
-                "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.6",
-                "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.6",
-                "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.6",
-                "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.6",
-                "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.6",
-                "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.6"
+                "@voidzero-dev/vite-plus-darwin-arm64": "0.2.8",
+                "@voidzero-dev/vite-plus-darwin-x64": "0.2.8",
+                "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.8",
+                "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.8",
+                "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.8",
+                "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.8",
+                "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.8",
+                "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.8"
             },
             "peerDependencies": {
                 "@vitest/browser-playwright": "4.1.10",
@@ -5783,7 +5799,7 @@
             "devDependencies": {
                 "@types/pathfinding": "0.1.0",
                 "typed-factorio": "^3.36.0",
-                "vite-plus": "0.2.6"
+                "vite-plus": "0.2.8"
             }
         },
         "packages/website": {
@@ -5800,7 +5816,7 @@
                 "@types/file-saver": "2.0.7",
                 "rollup-plugin-visualizer": "^7.0.1",
                 "vite-plugin-static-copy": "^4.1.1",
-                "vite-plus": "0.2.6"
+                "vite-plus": "0.2.8"
             }
         },
         "packages/worker": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@types/node": "^26.1.2",
         "typed-factorio": "^3.36.0",
         "typescript": "^7.0.2",
-        "vite-plus": "0.2.6"
+        "vite-plus": "0.2.8"
     },
     "devEngines": {
         "packageManager": {
@@ -36,6 +36,6 @@
         }
     },
     "overrides": {
-        "vite": "npm:@voidzero-dev/vite-plus-core@0.2.6"
+        "vite": "npm:@voidzero-dev/vite-plus-core@0.2.8"
     }
 }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -27,6 +27,6 @@
     "devDependencies": {
         "@types/pathfinding": "0.1.0",
         "typed-factorio": "^3.36.0",
-        "vite-plus": "0.2.6"
+        "vite-plus": "0.2.8"
     }
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -19,6 +19,6 @@
         "@types/file-saver": "2.0.7",
         "rollup-plugin-visualizer": "^7.0.1",
         "vite-plugin-static-copy": "^4.1.1",
-        "vite-plus": "0.2.6"
+        "vite-plus": "0.2.8"
     }
 }


### PR DESCRIPTION
## What

Two commits.

1. Moves the `vite-plus` pin 0.2.6 -> 0.2.8 across all six occurrences in five files.
2. Turns Renovate **on** for it with a 24-hour cooldown, and adds two `customManagers` so the CI half of the pin moves in the same PR.

## Why it drifted, corrected

The first commit message says Renovate could not propose this because the version is exact rather than a range. **That is wrong**, and the second commit corrects it in both places it was written down. Renovate updates exact pins perfectly well. The real reason is `.github/renovate.json5:227` had:

```json5
matchPackageNames: ['vite-plus', '@voidzero-dev/vite-plus-core'],
enabled: false,
```

So the pin sat at 0.2.6 for thirteen days while 0.2.7 and 0.2.8 shipped, under a comment in that file and a note in CLAUDE.md **both asserting 0.2.6 was `latest`**. Both were true when written on 2026-07-29. Neither could notice it had stopped being true. A hold whose only enforcement is a sentence is not a hold.

## The disable's reasoning was half right, and the wrong half was backwards

**Right, and now closed.** A Renovate PR touching only the manifests would leave `.github/actions/setup-vp/action.yml` behind. CI's `vp` CLI comes from that `VP_VERSION=` line while `vp install` reads the lockfile, so the two can end up a release apart with every check green. Two `customManagers` now move `VP_VERSION` and the cache key in the same PR, sharing `depNameTemplate: 'vite-plus'` so the cooldown, grouping, labels and `prBodyNotes` all apply to them. The grouping is load-bearing rather than cosmetic: ungrouped, they could merge apart from the manifests, which is the exact failure being closed.

**Backwards.** The comment also cited the installer sha256 as unguardable, since Renovate cannot compute it. It does not need to. The action runs:

```bash
echo "58bb052c...  vp-install.sh" | sha256sum -c -
```

A mismatch **fails the step**. It is the single self-guarding piece in the whole arrangement, and it was the reason given for automating none of it. Separately measured: that hash pins the mutable bootstrap script at `https://vite.plus`, which is versioned independently of the toolchain and **did not change** across 0.2.6 -> 0.2.8, so most bumps do not touch it at all.

## Cooldown

24 hours rather than the 3-day default, by explicit decision. This is developer tooling that never reaches users, the full gate runs locally before merge, and `.npmrc` already carries `min-release-age=1` so npm will not resolve anything younger regardless.

## The six occurrences

| File | What |
| --- | --- |
| `package.json:29` | devDependency |
| `package.json:39` | `overrides` alias |
| `packages/editor/package.json:30` | devDependency |
| `packages/website/package.json:22` | devDependency |
| `.github/actions/setup-vp/action.yml:14` | cache key (now Renovate-managed) |
| `.github/actions/setup-vp/action.yml:34` | `VP_VERSION` (now Renovate-managed) |

## Validation, and a trap worth knowing

This config's own header warns that an unparseable file makes Renovate skip the repo **silently**, so the change was validated rather than eyeballed.

`npx --yes --package renovate renovate-config-validator` resolved **renovate 37.440.7**, which predates `managerFilePatterns` (it still uses `fileMatch`) and reports the new syntax as invalid. That is a false negative that would have sent me to the wrong syntax. Pin the version:

```bash
npx --yes --package renovate@latest renovate-config-validator
```

Against 44.24.2, the current release: `Config validated successfully`. Both regexes were also tested against the real `action.yml` and each extracts `0.2.8` — the validator checks syntax, not whether a pattern matches anything.

## Gate

Green on 0.2.8:

- `vp check` - 230 files formatted, 0 warnings/lint/type errors in 171 files
- `vp test` - 180 passed
- `npm run type-check:gate` - 0 errors at baseline 0
- `vp build` - succeeds
- `npx playwright test` - **192 passed** (4.3m), against dev servers restarted onto the new toolchain

`npm audit` unchanged at 3 (2 moderate, 1 high), all still `undici` behind the `wrangler` -> `miniflare` exact pins.

## Expect one noisy first run

`helpers:pinGitHubActionDigests` is in `extends` and four actions still use moving tags, so re-enabling proposals here may arrive alongside that re-pin PR. Already documented at `renovate.json5:83-91`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRcjtKKZRVAKkpPeuJZZ1T