### PR TITLE
Ask the game which snapping mode carries the grid position, and pin it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,6 +461,42 @@ Three method notes, all in the probe README:
   matter: four entities move footprint between 2.0.77 and 2.1.12 (`tree-plant`
   and the three demolisher corpses), none of them among the 155.
 
+And which snapping mode carries a blueprint's grid position (PR #222,
+`tools/oracle/fixtures/blueprint-snapping.json`), measured on **2.0.77** rather
+than 2.1.12. The rule is short: the game writes `position-relative-to-grid`
+under **absolute** snapping and omits it under **relative**. Set a position of
+`{3, 5}` in relative mode and the game writes no position key at all; set the
+same one in absolute mode and it writes it. The `{0, 0}` rows say the
+non-default check belongs there too, since the game omits the key at the origin
+in either mode. So the condition is `snapToGrid && absoluteSnapping &&
+!positionIsDefault`, and the editor's existing pass-through is already right.
+
+Three things came out of it, and the first is the one to remember.
+
+- **The corpus could not have answered this, and it looks like it can.** 325 of
+  the 367 blueprints carry snapping and every one is absolute, including the
+  only one carrying a grid position. That is 325 rows agreeing, and it says the
+  two co-occur - never that one requires the other, because no corpus blueprint
+  uses relative snapping at all. Same shape of argument #133 item 5 and #142
+  both got wrong.
+- **Setting `blueprint_position_relative_to_grid` turns
+  `blueprint_absolute_snapping` on.** The first run set snap, then absolute,
+  then position, so the position write flipped absolute back on afterwards and
+  every row exported as absolute. Relative mode was never reached and the
+  relative rows measured nothing, while looking entirely reasonable. The
+  readback control caught that the instrument was broken; only a per-setter
+  trace of `absolute_snapping` said which setter did it. **Set position before
+  absolute, or not at all.**
+- **A grid position with no `snap-to-grid` is a state the GUI cannot reach**,
+  and the game answers it inconsistently - writing keys with no grid beside them
+  and failing to reconstruct them on import. Those rows are in the fixture and
+  deliberately not scored, per #133 item 4.
+
+And one note about the probe file rather than the game: its Lua lives inside a
+JS template literal, so **a backtick in a Lua comment closes the template**. A
+matched pair on one line closes it and reopens it, which a scan for odd backtick
+counts cannot see. Cost a debugging round; there is a comment at that spot now.
+
 ## Cloudflare Deployment
 
 The editor is deployed to Cloudflare Workers at https://fbe.factorygamefan.com (custom

--- a/tests/blueprint-snapping.spec.ts
+++ b/tests/blueprint-snapping.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprint, packVersion } from './helpers/encode-blueprint'
+import { waitForEditor } from './helpers/fbe-test-api'
+
+/*
+    What survives the decode -> model -> serialize path for the three grid
+    snapping fields: `snap-to-grid`, `absolute-snapping` and
+    `position-relative-to-grid`.
+
+    Nothing pinned this before. `blueprint-round-trip.spec.ts` did catch PR
+    #222 dropping `position-relative-to-grid`, but only by accident of the
+    corpus: exactly ONE of its 367 blueprints carries a grid position ("Biolabs
+    750 SPM" in test-blueprints/EARN/pocket-base-space-age-v22.1.2.txt, at
+    {80, 106}). Re-capture that fixture, or swap the corpus the way #186 did,
+    and the coverage leaves with it. What it reports is also a changed hash
+    rather than a named field, so it says something moved without saying what.
+
+    The rule these assert is measured, not reasoned - the game itself, on
+    2.0.77, in tools/oracle/fixtures/blueprint-snapping.json:
+
+        position-relative-to-grid is written under ABSOLUTE snapping and
+        omitted under RELATIVE.
+
+    Set a grid position of {3, 5} in relative mode and the game writes no
+    position key at all; set the same one in absolute mode and it writes it.
+    That is the opposite of what #222 implemented, and the first test below is
+    the one that fails under its rule.
+
+    Synthetic, and it has to be: the corpus cannot reach relative snapping at
+    all. All 325 of its blueprints that carry snapping are absolute, so a test
+    built from real exports could not tell the two modes apart - which is
+    exactly why the corpus could not have answered the question and the binary
+    had to.
+
+    Mutation-checked against the real thing rather than an invented one: with
+    PR #222's own condition pasted into Blueprint.serialize, two of the five
+    fail - "an absolute grid position survives the round trip" and "a grid
+    position at the origin is carried as it arrived" - and the other three
+    pass. So the first test is not decoration, and the origin test is doing
+    work of its own rather than restating it.
+
+    Fixed point, not a snapshot to refresh. A diff here means the serialization
+    of a blueprint's own grid settings changed; check it against the fixture
+    before touching the numbers.
+*/
+
+/** Current, so no name migration applies - see nameMigrations.ts. */
+const VERSION = packVersion(2, 0, 55)
+
+/** One entity, so the blueprint is non-empty and serialize() has something to do. */
+const ENTITIES = [{ entity_number: 1, name: 'wooden-chest', position: { x: 0.5, y: 0.5 } }]
+
+interface Snapping {
+    'snap-to-grid'?: { x: number; y: number }
+    'absolute-snapping'?: boolean
+    'position-relative-to-grid'?: { x: number; y: number }
+}
+
+/** Decode a synthetic blueprint and hand back only the three keys, as serialized. */
+async function serializedSnapping(
+    page: import('@playwright/test').Page,
+    snapping: Snapping
+): Promise<Snapping> {
+    const source = encodeBlueprint({
+        item: 'blueprint',
+        version: VERSION,
+        entities: ENTITIES,
+        ...snapping,
+    })
+
+    return page.evaluate(async (src: string) => {
+        const bp = (await window.__fbe_test.getBlueprintOrBookFromSource(src)) as unknown as {
+            serialize: () => Record<string, unknown>
+        }
+        const out = bp.serialize()
+        const pick = (k: string): unknown => out[k] ?? undefined
+        /*
+            Rebuilt rather than returned whole: serialize() carries entities and
+            a version too, and a test that compared the whole object would fail
+            for reasons that have nothing to do with snapping.
+        */
+        return {
+            'snap-to-grid': pick('snap-to-grid'),
+            'absolute-snapping': pick('absolute-snapping'),
+            'position-relative-to-grid': pick('position-relative-to-grid'),
+        } as Snapping
+    }, source)
+}
+
+test.beforeEach(async ({ page }) => {
+    await waitForEditor(page)
+})
+
+test('an absolute grid position survives the round trip', async ({ page }) => {
+    /*
+        THE ONE THAT MATTERS. This is the configuration the game itself
+        produces - absolute snapping with an offset - and the one PR #222
+        dropped, taking the field off 325 of the corpus's 367 blueprints.
+    */
+    const out = await serializedSnapping(page, {
+        'snap-to-grid': { x: 2, y: 2 },
+        'absolute-snapping': true,
+        'position-relative-to-grid': { x: 3, y: 5 },
+    })
+
+    expect(out['snap-to-grid']).toEqual({ x: 2, y: 2 })
+    expect(out['absolute-snapping']).toBe(true)
+    expect(out['position-relative-to-grid']).toEqual({ x: 3, y: 5 })
+})
+
+test('absolute snapping with no position keeps the grid and the mode', async ({ page }) => {
+    const out = await serializedSnapping(page, {
+        'snap-to-grid': { x: 4, y: 8 },
+        'absolute-snapping': true,
+    })
+
+    expect(out['snap-to-grid']).toEqual({ x: 4, y: 8 })
+    expect(out['absolute-snapping']).toBe(true)
+    expect(out['position-relative-to-grid']).toBeUndefined()
+})
+
+test('relative snapping keeps the grid and stays relative', async ({ page }) => {
+    /*
+        Relative is the ABSENCE of `absolute-snapping`, not `false` - the game
+        omits the key rather than writing false, which is why the corpus has no
+        blueprint carrying it as false and why this case is synthetic.
+    */
+    const out = await serializedSnapping(page, { 'snap-to-grid': { x: 2, y: 2 } })
+
+    expect(out['snap-to-grid']).toEqual({ x: 2, y: 2 })
+    expect(out['absolute-snapping']).toBeUndefined()
+    expect(out['position-relative-to-grid']).toBeUndefined()
+})
+
+test('a blueprint with no snapping serializes none of the three keys', async ({ page }) => {
+    /*
+        The control, and it can fail while the three above pass: a change that
+        wrote a default grid onto every blueprint would satisfy every
+        assertion up there and be caught only here. 42 of the corpus's 367
+        blueprints are in this state.
+    */
+    const out = await serializedSnapping(page, {})
+
+    expect(out['snap-to-grid']).toBeUndefined()
+    expect(out['absolute-snapping']).toBeUndefined()
+    expect(out['position-relative-to-grid']).toBeUndefined()
+})
+
+test('a grid position at the origin is carried as it arrived', async ({ page }) => {
+    /*
+        Current behaviour rather than the game's: the game omits
+        `position-relative-to-grid` at {0, 0} in both modes, so it never writes
+        this blueprint. The editor passes through what it was given, which is
+        harmless for a hand-made string and is what the other four tests
+        depend on - they assert pass-through too. Pinned so that a future
+        change to drop defaults on write is a decision someone makes, rather
+        than a side effect that quietly rewrites input.
+    */
+    const out = await serializedSnapping(page, {
+        'snap-to-grid': { x: 2, y: 2 },
+        'absolute-snapping': true,
+        'position-relative-to-grid': { x: 0, y: 0 },
+    })
+
+    expect(out['position-relative-to-grid']).toEqual({ x: 0, y: 0 })
+})

--- a/tools/oracle/fixtures/blueprint-snapping.json
+++ b/tools/oracle/fixtures/blueprint-snapping.json
@@ -1,0 +1,410 @@
+{
+    "provenance": {
+        "probe": "tools/oracle/probe-blueprint-snapping.mjs",
+        "binary": "Version: 2.0.77 (build 84539, mac-arm64, full)",
+        "modFactorioVersion": "2.0",
+        "mods": {
+            "base": "2.0.77",
+            "elevated-rails": "2.0.77",
+            "quality": "2.0.77",
+            "space-age": "2.0.77",
+            "bp_snapping": "0.0.1"
+        },
+        "question": "Which of snap-to-grid / absolute-snapping / position-relative-to-grid does the game write into an exported blueprint string, for each combination of the three LuaItemStack snapping properties?"
+    },
+    "controls": [
+        {
+            "name": "writes reach the export",
+            "detail": "6 distinct exported strings across 10 configurations",
+            "ok": true
+        },
+        {
+            "name": "properties read back as set",
+            "detail": "mismatched: no-grid",
+            "ok": false
+        },
+        {
+            "name": "export then import reproduces the properties",
+            "detail": "differed: no-grid, no-grid-absolute-set",
+            "ok": false
+        }
+    ],
+    "rows": [
+        {
+            "case": "no-grid",
+            "gridRow": false,
+            "set": {
+                "snap": null,
+                "absolute": false,
+                "position": {
+                    "x": 0,
+                    "y": 0
+                }
+            },
+            "setPosition": true,
+            "written": {
+                "snap-to-grid": null,
+                "absolute-snapping": true,
+                "position-relative-to-grid": null
+            },
+            "roundTrip": {
+                "snap": null,
+                "absolute": false,
+                "position": null
+            },
+            "absoluteAfterEachSetter": {
+                "atStart": false,
+                "afterSnap": false,
+                "afterPosition": true,
+                "afterAbsolute": true
+            }
+        },
+        {
+            "case": "no-grid-absolute-set",
+            "gridRow": false,
+            "set": {
+                "snap": null,
+                "absolute": true,
+                "position": {
+                    "x": 3,
+                    "y": 5
+                }
+            },
+            "setPosition": true,
+            "written": {
+                "snap-to-grid": null,
+                "absolute-snapping": true,
+                "position-relative-to-grid": {
+                    "x": 3,
+                    "y": 5
+                }
+            },
+            "roundTrip": {
+                "snap": null,
+                "absolute": false,
+                "position": null
+            },
+            "absoluteAfterEachSetter": {
+                "atStart": false,
+                "afterSnap": false,
+                "afterPosition": true,
+                "afterAbsolute": true
+            }
+        },
+        {
+            "case": "relative-origin",
+            "gridRow": true,
+            "set": {
+                "snap": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute": false,
+                "position": {
+                    "x": 0,
+                    "y": 0
+                }
+            },
+            "setPosition": true,
+            "written": {
+                "snap-to-grid": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute-snapping": null,
+                "position-relative-to-grid": null
+            },
+            "roundTrip": {
+                "snap": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute": false,
+                "position": null
+            },
+            "absoluteAfterEachSetter": {
+                "atStart": false,
+                "afterSnap": false,
+                "afterPosition": true,
+                "afterAbsolute": false
+            }
+        },
+        {
+            "case": "relative-offset",
+            "gridRow": true,
+            "set": {
+                "snap": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute": false,
+                "position": {
+                    "x": 3,
+                    "y": 5
+                }
+            },
+            "setPosition": true,
+            "written": {
+                "snap-to-grid": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute-snapping": null,
+                "position-relative-to-grid": null
+            },
+            "roundTrip": {
+                "snap": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute": false,
+                "position": null
+            },
+            "absoluteAfterEachSetter": {
+                "atStart": false,
+                "afterSnap": false,
+                "afterPosition": true,
+                "afterAbsolute": false
+            }
+        },
+        {
+            "case": "absolute-origin",
+            "gridRow": true,
+            "set": {
+                "snap": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute": true,
+                "position": {
+                    "x": 0,
+                    "y": 0
+                }
+            },
+            "setPosition": true,
+            "written": {
+                "snap-to-grid": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute-snapping": true,
+                "position-relative-to-grid": null
+            },
+            "roundTrip": {
+                "snap": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute": true,
+                "position": {
+                    "x": 0,
+                    "y": 0
+                }
+            },
+            "absoluteAfterEachSetter": {
+                "atStart": false,
+                "afterSnap": false,
+                "afterPosition": true,
+                "afterAbsolute": true
+            }
+        },
+        {
+            "case": "absolute-offset",
+            "gridRow": true,
+            "set": {
+                "snap": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute": true,
+                "position": {
+                    "x": 3,
+                    "y": 5
+                }
+            },
+            "setPosition": true,
+            "written": {
+                "snap-to-grid": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute-snapping": true,
+                "position-relative-to-grid": {
+                    "x": 3,
+                    "y": 5
+                }
+            },
+            "roundTrip": {
+                "snap": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute": true,
+                "position": {
+                    "x": 3,
+                    "y": 5
+                }
+            },
+            "absoluteAfterEachSetter": {
+                "atStart": false,
+                "afterSnap": false,
+                "afterPosition": true,
+                "afterAbsolute": true
+            }
+        },
+        {
+            "case": "relative-no-position-set",
+            "gridRow": true,
+            "set": {
+                "snap": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute": false,
+                "position": null
+            },
+            "setPosition": false,
+            "written": {
+                "snap-to-grid": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute-snapping": null,
+                "position-relative-to-grid": null
+            },
+            "roundTrip": {
+                "snap": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute": false,
+                "position": null
+            },
+            "absoluteAfterEachSetter": {
+                "atStart": false,
+                "afterSnap": false,
+                "afterAbsolute": false
+            }
+        },
+        {
+            "case": "absolute-no-position-set",
+            "gridRow": true,
+            "set": {
+                "snap": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute": true,
+                "position": null
+            },
+            "setPosition": false,
+            "written": {
+                "snap-to-grid": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute-snapping": true,
+                "position-relative-to-grid": null
+            },
+            "roundTrip": {
+                "snap": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute": true,
+                "position": {
+                    "x": 0,
+                    "y": 0
+                }
+            },
+            "absoluteAfterEachSetter": {
+                "atStart": false,
+                "afterSnap": false,
+                "afterAbsolute": true
+            }
+        },
+        {
+            "case": "no-grid-no-position-set",
+            "gridRow": false,
+            "set": {
+                "snap": null,
+                "absolute": false,
+                "position": null
+            },
+            "setPosition": false,
+            "written": {
+                "snap-to-grid": null,
+                "absolute-snapping": null,
+                "position-relative-to-grid": null
+            },
+            "roundTrip": {
+                "snap": null,
+                "absolute": false,
+                "position": null
+            },
+            "absoluteAfterEachSetter": {
+                "atStart": false,
+                "afterSnap": false,
+                "afterAbsolute": false
+            }
+        },
+        {
+            "case": "relative-position-then-absolute-false",
+            "gridRow": true,
+            "set": {
+                "snap": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute": false,
+                "position": {
+                    "x": 3,
+                    "y": 5
+                }
+            },
+            "setPosition": true,
+            "written": {
+                "snap-to-grid": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute-snapping": null,
+                "position-relative-to-grid": null
+            },
+            "roundTrip": {
+                "snap": {
+                    "x": 2,
+                    "y": 2
+                },
+                "absolute": false,
+                "position": null
+            },
+            "absoluteAfterEachSetter": {
+                "atStart": false,
+                "afterSnap": false,
+                "afterPosition": true,
+                "afterAbsolute": false
+            }
+        }
+    ],
+    "mechanism": "Setting blueprint_position_relative_to_grid turns blueprint_absolute_snapping ON - see absoluteAfterEachSetter.afterPosition, true on every row that sets a position. A probe that sets position last cannot reach relative mode at all, which is what the first run of this probe did.",
+    "finding": "position-relative-to-grid is written under ABSOLUTE snapping and omitted under RELATIVE. Measured on the four rows with a grid and an explicit mode: relative-offset sets position {3,5} and the game writes none; absolute-offset sets the same and the game writes {3,5}. The editor round-trips it correctly today; PR #222 inverts it.",
+    "voided": {
+        "rows": ["no-grid", "no-grid-absolute-set", "no-grid-no-position-set"],
+        "why": "A grid position or absolute snapping with no snap-to-grid is a state the GUI cannot produce, and the game answers it inconsistently - it writes keys with no grid beside them and does not reconstruct them on import. Recorded, not counted."
+    },
+    "candidateRules": {
+        "pr-222-position-under-relative": {
+            "agrees": false,
+            "disagreeingCases": [
+                "relative-offset",
+                "absolute-offset",
+                "relative-position-then-absolute-false"
+            ]
+        },
+        "inverted-position-under-absolute": {
+            "agrees": true,
+            "disagreeingCases": []
+        }
+    }
+}

--- a/tools/oracle/probe-blueprint-snapping.mjs
+++ b/tools/oracle/probe-blueprint-snapping.mjs
@@ -1,0 +1,583 @@
+/*
+    PR #222. `Blueprint.serialize` was changed to write `position-relative-to-grid`
+    only when snapping is **Relative**:
+
+        'position-relative-to-grid':
+            snapToGrid && !absoluteSnapping && !positionIsDefault ? ... : undefined
+
+    A decode of the committed corpus says that branch is never taken on real
+    data: of 367 blueprints, 325 carry `snap-to-grid` and every one of them is
+    `absolute-snapping: true`, including the only one that also carries a grid
+    position (`{80, 106}`, "Biolabs 750 SPM"). So the field is dropped on export,
+    which is what fails `blueprint-round-trip.spec.ts`.
+
+    That much is measured. What is *not* measured, and what this probe is for, is
+    the claim underneath the proposed fix: that `position-relative-to-grid`
+    belongs to Absolute rather than Relative. The corpus can only say the two
+    co-occur, never that one requires the other, because no corpus blueprint uses
+    relative snapping at all. Reasoning from 325 rows that all agree is exactly
+    the shape of argument #133 item 5 and #142 both got wrong.
+
+    This is the cheapest question that settles it, per the README. Snapping is
+    three settable properties on `LuaItemStack` - `blueprint_snap_to_grid`,
+    `blueprint_absolute_snapping`, `blueprint_position_relative_to_grid` - so
+    nothing needs placing, no surface, no `can_place_entity`. Set each
+    combination on a blueprint, `export_stack()`, and read which keys the game
+    itself writes.
+
+    What it asks, over the ten configurations in CASES below: which of the three
+    keys appear in the exported string, and what the game reports for each
+    property afterwards.
+
+    THE ANSWER, so nobody has to re-derive it: `position-relative-to-grid` is
+    written under ABSOLUTE snapping and omitted under RELATIVE. `relative-offset`
+    sets a position of {3, 5} and the game writes no position key at all;
+    `absolute-offset` sets the same and the game writes {3, 5}. So PR #222 has it
+    exactly inverted, and the editor's existing pass-through behaviour is right.
+
+    AND THE TRAP THAT COST THIS PROBE A RUN: setting
+    `blueprint_position_relative_to_grid` turns `blueprint_absolute_snapping`
+    ON. The first version set snap, then absolute, then position, so the
+    position write flipped absolute back on afterwards and every row exported as
+    absolute - relative mode was never reached, and the three relative rows were
+    measuring nothing. The readback control caught it; a per-setter trace of
+    `absolute_snapping` is what identified which setter was responsible. Set
+    position BEFORE absolute, or not at all.
+
+    Controls, in the README's sense - each can fail while the hypothesis holds:
+
+      - **Instrument, writes reach the export**: at least two configurations must
+        produce different exported strings. If every export is byte-identical the
+        setters are not reaching `export_stack` at all, and a table reading "no
+        keys written" is indistinguishable from a correct one. This is the
+        control that would have voided the elevated-rail section in #133 item 4.
+      - **Instrument, readback**: every property set must read back as set,
+        *before* exporting. If `blueprint_absolute_snapping = true` reads false,
+        the API is not doing what this assumes and every row below is about
+        something else.
+      - **Round trip**: importing each exported string into a second stack must
+        reproduce the same three properties. Measuring what the game writes says
+        nothing about what it means unless the game agrees on the way back in.
+        A key the game omits and then reconstructs is not a lost key.
+      - **Coverage**: the sweep includes a grid position of {0, 0} as well as a
+        non-zero one, in both snapping modes. Sweeping only non-zero positions
+        cannot separate "written under absolute" from "written when non-default",
+        which are different rules that agree on most rows.
+
+    And the #133 item 5 lesson, which has now paid three times: both candidate
+    serialization rules are transcribed into this file and checked against every
+    measured row *before* anyone writes code. `--write-fixture` records which
+    rule agrees with the game and which does not.
+
+    Usage: node tools/oracle/probe-blueprint-snapping.mjs
+           node tools/oracle/probe-blueprint-snapping.mjs --write-fixture && vp check --fix
+
+           # the version the editor targets, rather than whatever is installed
+           FACTORIO_BIN="$HOME/Downloads/factorio_space_age_mac_2_0_77.app/Contents/MacOS/factorio" \
+             node tools/oracle/probe-blueprint-snapping.mjs --write-fixture
+
+    The --fix is not optional if you recapture: vp's formatter collapses short
+    arrays onto one line and JSON.stringify does not.
+*/
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import { inflateSync } from 'node:zlib'
+
+const BIN =
+    process.env.FACTORIO_BIN ??
+    `${process.env.HOME}/Library/Application Support/Steam/steamapps/common/Factorio/factorio.app/Contents/MacOS/factorio`
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const FIXTURE = join(HERE, 'fixtures', 'blueprint-snapping.json')
+const WRITE_FIXTURE = process.argv.includes('--write-fixture')
+
+const MOD = 'bp_snapping'
+const DUMP = 'blueprint-snapping.json'
+
+/*
+    Ten configurations. The {0, 0} rows are what separate "written under
+    absolute" from "written when non-default" - rules that agree everywhere else.
+    The no-grid rows asked whether the other two survive with snapping off; they
+    are scored separately below, because driving the API into that state reaches
+    something the GUI cannot produce and the game answers it inconsistently.
+*/
+const CASES = [
+    { name: 'no-grid', snap: null, absolute: false, position: { x: 0, y: 0 }, setPosition: true },
+    {
+        name: 'no-grid-absolute-set',
+        snap: null,
+        absolute: true,
+        position: { x: 3, y: 5 },
+        setPosition: true,
+    },
+    {
+        name: 'relative-origin',
+        snap: { x: 2, y: 2 },
+        absolute: false,
+        position: { x: 0, y: 0 },
+        setPosition: true,
+    },
+    {
+        name: 'relative-offset',
+        snap: { x: 2, y: 2 },
+        absolute: false,
+        position: { x: 3, y: 5 },
+        setPosition: true,
+    },
+    {
+        name: 'absolute-origin',
+        snap: { x: 2, y: 2 },
+        absolute: true,
+        position: { x: 0, y: 0 },
+        setPosition: true,
+    },
+    {
+        name: 'absolute-offset',
+        snap: { x: 2, y: 2 },
+        absolute: true,
+        position: { x: 3, y: 5 },
+        setPosition: true,
+    },
+    /*
+        The first run set a position on every case and could not reach relative
+        mode at all: `blueprint_absolute_snapping = false` read back true
+        everywhere, which the readback control caught and which voided the three
+        relative rows. These four never touch the position property, to separate
+        "the setter does not work" from "setting a position turns absolute on".
+        The setter order is part of the question, the same way a probe entity's
+        own lattice was in #141.
+    */
+    {
+        name: 'relative-no-position-set',
+        snap: { x: 2, y: 2 },
+        absolute: false,
+        position: null,
+        setPosition: false,
+    },
+    {
+        name: 'absolute-no-position-set',
+        snap: { x: 2, y: 2 },
+        absolute: true,
+        position: null,
+        setPosition: false,
+    },
+    {
+        name: 'no-grid-no-position-set',
+        snap: null,
+        absolute: false,
+        position: null,
+        setPosition: false,
+    },
+    {
+        name: 'relative-position-then-absolute-false',
+        snap: { x: 2, y: 2 },
+        absolute: false,
+        position: { x: 3, y: 5 },
+        setPosition: true,
+    },
+]
+
+const version = spawnSync(BIN, ['--version'], { encoding: 'utf8' }).stdout ?? ''
+const binaryLine = version.split('\n')[0].trim()
+const binaryVersion = (binaryLine.match(/(\d+)\.(\d+)\.(\d+)/) ?? []).slice(1)
+if (binaryVersion.length !== 3) {
+    console.error(`Could not read a version out of ${BIN}: ${JSON.stringify(binaryLine)}`)
+    process.exit(1)
+}
+/* Derived, not hardcoded: a mod declaring the wrong version is silently skipped. */
+const MOD_FACTORIO_VERSION = `${binaryVersion[0]}.${binaryVersion[1]}`
+
+const work = mkdtempSync(join(tmpdir(), 'fbe-oracle-'))
+const writeData = join(work, 'write-data')
+const modDir = join(work, 'mods')
+const modPath = join(modDir, `${MOD}_0.0.1`)
+mkdirSync(writeData, { recursive: true })
+mkdirSync(modPath, { recursive: true })
+
+writeFileSync(
+    join(modPath, 'info.json'),
+    JSON.stringify({
+        name: MOD,
+        version: '0.0.1',
+        title: 'Which snapping keys does the game write into a blueprint string',
+        author: 'oracle',
+        factorio_version: MOD_FACTORIO_VERSION,
+        dependencies: ['base', 'elevated-rails', 'space-age'],
+    })
+)
+
+const luaCases = CASES.map(c => {
+    const snap = c.snap === null ? 'nil' : `{x = ${c.snap.x}, y = ${c.snap.y}}`
+    const px = c.position === null ? 0 : c.position.x
+    const py = c.position === null ? 0 : c.position.y
+    return `{name = "${c.name}", snap = ${snap}, absolute = ${c.absolute}, px = ${px}, py = ${py}, setPosition = ${c.setPosition}}`
+}).join(',\n  ')
+
+writeFileSync(
+    join(modPath, 'control.lua'),
+    `
+local out = {errors = {}, mods = {}, cases = {}}
+
+local CASES = {
+  ${luaCases}
+}
+
+script.on_init(function()
+  for name, v in pairs(script.active_mods) do out.mods[name] = v end
+
+  local inv = game.create_inventory(2)
+
+  for _, c in pairs(CASES) do
+    local stack = inv[1]
+    stack.clear()
+    stack.set_stack{name = "blueprint"}
+    stack.set_blueprint_entities({
+      {entity_number = 1, name = "wooden-chest", position = {x = 0.5, y = 0.5}},
+      {entity_number = 2, name = "wooden-chest", position = {x = 2.5, y = 0.5}},
+    })
+
+    -- A trace of absolute_snapping after each individual setter, because the
+    -- first run could not reach relative mode and the readback control could
+    -- say only that, not which setter was responsible.
+    -- (No backticks in this file's Lua: it lives inside a JS template literal,
+    -- and a pair of them silently closes and reopens it.)
+    local trace = {}
+    trace.atStart = stack.blueprint_absolute_snapping
+
+    stack.blueprint_snap_to_grid = c.snap
+    trace.afterSnap = stack.blueprint_absolute_snapping
+
+    if c.setPosition then
+      stack.blueprint_position_relative_to_grid = {x = c.px, y = c.py}
+      trace.afterPosition = stack.blueprint_absolute_snapping
+    end
+
+    stack.blueprint_absolute_snapping = c.absolute
+    trace.afterAbsolute = stack.blueprint_absolute_snapping
+
+    -- Instrument control: what was set has to read back, before exporting.
+    local snapBack = stack.blueprint_snap_to_grid
+    local posBack = stack.blueprint_position_relative_to_grid
+    local readback = {
+      snap = snapBack and {x = snapBack.x, y = snapBack.y} or nil,
+      absolute = stack.blueprint_absolute_snapping,
+      position = posBack and {x = posBack.x, y = posBack.y} or nil,
+    }
+
+    local exported = stack.export_stack()
+
+    -- Round-trip control: does the game reconstruct the same three properties?
+    local second = inv[2]
+    second.clear()
+    second.set_stack{name = "blueprint"}
+    second.import_stack(exported)
+    local rsnap = second.blueprint_snap_to_grid
+    local rpos = second.blueprint_position_relative_to_grid
+    local roundTrip = {
+      snap = rsnap and {x = rsnap.x, y = rsnap.y} or nil,
+      absolute = second.blueprint_absolute_snapping,
+      position = rpos and {x = rpos.x, y = rpos.y} or nil,
+    }
+
+    out.cases[#out.cases + 1] = {
+      name = c.name,
+      readback = readback,
+      trace = trace,
+      exported = exported,
+      roundTrip = roundTrip,
+    }
+  end
+
+  helpers.write_file("${DUMP}", helpers.table_to_json(out))
+  error("DUMPED-OK")
+end)
+`
+)
+
+writeFileSync(
+    join(work, 'config.ini'),
+    `[path]\nread-data=__PATH__executable__/../data\nwrite-data=${writeData}\n[general]\n[other]\n`
+)
+
+const res = spawnSync(
+    BIN,
+    [
+        '--create',
+        join(work, 'p.zip'),
+        '--mod-directory',
+        modDir,
+        '--config',
+        join(work, 'config.ini'),
+    ],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+)
+
+const dumpPath = join(writeData, 'script-output', DUMP)
+if (!existsSync(dumpPath)) {
+    console.error(
+        `No dump. Mod declared factorio_version ${MOD_FACTORIO_VERSION} against ${binaryLine}.\n` +
+            'Factorio tail:\n' +
+            ((res.stdout ?? '') + (res.stderr ?? '')).slice(-4000)
+    )
+    process.exit(1)
+}
+
+const d = JSON.parse(readFileSync(dumpPath, 'utf8'))
+const list = v => (v === undefined || v === null ? [] : Object.values(v))
+for (const e of list(d.errors)) console.log(`! ${e}`)
+
+console.log(`\n=== binary: ${binaryLine} (mod declared factorio_version ${MOD_FACTORIO_VERSION})`)
+console.log(
+    `=== mods: ${Object.entries(d.mods ?? {})
+        .map(([n, v]) => `${n} ${v}`)
+        .join(', ')}\n`
+)
+
+const decode = s => JSON.parse(inflateSync(Buffer.from(s.slice(1), 'base64')).toString())
+const pt = p => (p === undefined || p === null ? null : { x: p.x, y: p.y })
+
+const rows = list(d.cases).map(c => {
+    const bp = decode(c.exported).blueprint
+    return {
+        case: c.name,
+        set: CASES.find(x => x.name === c.name),
+        readback: {
+            snap: pt(c.readback?.snap),
+            absolute: c.readback?.absolute === true,
+            position: pt(c.readback?.position),
+        },
+        written: {
+            'snap-to-grid': pt(bp['snap-to-grid']),
+            'absolute-snapping': bp['absolute-snapping'] ?? null,
+            'position-relative-to-grid': pt(bp['position-relative-to-grid']),
+        },
+        roundTrip: {
+            snap: pt(c.roundTrip?.snap),
+            absolute: c.roundTrip?.absolute === true,
+            position: pt(c.roundTrip?.position),
+        },
+        trace: c.trace ?? {},
+        exportedLength: c.exported.length,
+    }
+})
+
+/* ------------------------------------------------------------------ *
+ * Controls.                                                           *
+ * ------------------------------------------------------------------ */
+const controls = []
+
+const distinctExports = new Set(list(d.cases).map(c => c.exported)).size
+controls.push({
+    name: 'writes reach the export',
+    detail: `${distinctExports} distinct exported strings across ${rows.length} configurations`,
+    ok: distinctExports > 1,
+})
+
+const readbackFailures = rows.filter(r => {
+    const wantSnap = r.set.snap === null ? null : r.set.snap
+    const snapOk = JSON.stringify(r.readback.snap) === JSON.stringify(wantSnap)
+    return !snapOk || r.readback.absolute !== r.set.absolute
+})
+controls.push({
+    name: 'properties read back as set',
+    detail:
+        readbackFailures.length === 0
+            ? 'every configuration read back as written'
+            : `mismatched: ${readbackFailures.map(r => r.case).join(', ')}`,
+    ok: readbackFailures.length === 0,
+})
+
+const roundTripFailures = rows.filter(
+    r => JSON.stringify(r.roundTrip) !== JSON.stringify(r.readback)
+)
+controls.push({
+    name: 'export then import reproduces the properties',
+    detail:
+        roundTripFailures.length === 0
+            ? 'every configuration survived a round trip'
+            : `differed: ${roundTripFailures.map(r => r.case).join(', ')}`,
+    ok: roundTripFailures.length === 0,
+})
+
+/* ------------------------------------------------------------------ *
+ * Both candidate rules, transcribed and checked against every row      *
+ * BEFORE any code is written. #133 item 5's lesson, third outing.      *
+ * ------------------------------------------------------------------ */
+const isDefault = p => p === null || (p.x === 0 && p.y === 0)
+
+/** PR #222 as it stands: position written only in RELATIVE mode. */
+const rulePR222 = s => ({
+    'snap-to-grid': s.snap,
+    'absolute-snapping': s.snap && s.absolute ? true : null,
+    'position-relative-to-grid':
+        s.snap && !s.absolute && !isDefault(s.position) ? s.position : null,
+})
+
+/** The inversion the review comment proposes: position written under ABSOLUTE. */
+const ruleInverted = s => ({
+    'snap-to-grid': s.snap,
+    'absolute-snapping': s.snap && s.absolute ? true : null,
+    'position-relative-to-grid': s.snap && s.absolute && !isDefault(s.position) ? s.position : null,
+})
+
+const same = (a, b) => JSON.stringify(a) === JSON.stringify(b)
+const scoreRule = fn =>
+    rows.map(r => {
+        const want = fn({ snap: r.set.snap, absolute: r.set.absolute, position: r.set.position })
+        return { case: r.case, agrees: same(want, r.written), predicted: want, actual: r.written }
+    })
+
+/*
+    The two no-grid rows are voided by their own controls and are scored
+    separately rather than counted against either rule. Driving the API into
+    "a grid position, and absolute snapping, with no grid" reaches a state the
+    game's own GUI cannot produce - the absolute checkbox and the position
+    fields only exist while snap-to-grid is on - and the game answers it
+    inconsistently: it writes `absolute-snapping: true` and even a
+    `position-relative-to-grid` with no `snap-to-grid` beside them, and then
+    fails to reconstruct the same properties on import. That is a finding about
+    an unreachable state, not about serialization, and #133 item 4's lesson is
+    to record a section its control voids rather than read it as an answer.
+*/
+const isGridRow = r => r.set.snap !== null
+const gridRows = rows.filter(isGridRow)
+const voidedRows = rows.filter(r => !isGridRow(r))
+
+const pr222 = scoreRule(rulePR222).filter(s => gridRows.some(r => r.case === s.case))
+const inverted = scoreRule(ruleInverted).filter(s => gridRows.some(r => r.case === s.case))
+
+/* ------------------------------------------------------------------ *
+ * Report.                                                             *
+ * ------------------------------------------------------------------ */
+console.log('=== what the game writes ===\n')
+const cell = v => (v === null ? '-' : typeof v === 'object' ? `${v.x},${v.y}` : String(v))
+console.log(
+    ['case', 'set snap', 'set abs', 'set pos', 'wrote snap', 'wrote abs', 'wrote pos']
+        .map((h, i) => h.padEnd([22, 9, 8, 8, 11, 10, 9][i]))
+        .join('')
+)
+for (const r of rows) {
+    console.log(
+        [
+            r.case.padEnd(22),
+            cell(r.set.snap).padEnd(9),
+            String(r.set.absolute).padEnd(8),
+            cell(r.set.position).padEnd(8),
+            cell(r.written['snap-to-grid']).padEnd(11),
+            cell(r.written['absolute-snapping']).padEnd(10),
+            cell(r.written['position-relative-to-grid']).padEnd(9),
+        ].join('')
+    )
+}
+
+console.log('\n=== absolute_snapping after each setter ===')
+console.log(
+    ['case', 'atStart', 'afterSnap', 'afterPos', 'afterAbs', 'wanted']
+        .map((h, i) => h.padEnd([38, 9, 11, 10, 10, 8][i]))
+        .join('')
+)
+for (const r of rows) {
+    const tr = r.trace ?? {}
+    console.log(
+        [
+            r.case.padEnd(38),
+            String(tr.atStart ?? '-').padEnd(9),
+            String(tr.afterSnap ?? '-').padEnd(11),
+            String(tr.afterPosition ?? '(skipped)').padEnd(10),
+            String(tr.afterAbsolute ?? '-').padEnd(10),
+            String(r.set.absolute).padEnd(8),
+        ].join('')
+    )
+}
+
+console.log('\n=== controls ===')
+for (const c of controls) console.log(`${c.ok ? 'ok  ' : 'FAIL'} ${c.name}: ${c.detail}`)
+
+console.log(
+    `\n=== candidate rules against the ${gridRows.length} rows with a grid ` +
+        `(${voidedRows.length} no-grid rows voided by their own controls) ===`
+)
+/** @type {[string, {case: string, agrees: boolean, predicted: any, actual: any}[]][]} */
+const candidates = [
+    ['PR #222 as written (position under Relative)', pr222],
+    ['inverted (position under Absolute)', inverted],
+]
+for (const [label, scored] of candidates) {
+    const bad = scored.filter(s => !s.agrees)
+    console.log(`${bad.length === 0 ? 'AGREES' : 'DISAGREES'}  ${label}`)
+    for (const b of bad) {
+        console.log(
+            `    ${b.case}: predicted pos=${cell(b.predicted['position-relative-to-grid'])} ` +
+                `abs=${cell(b.predicted['absolute-snapping'])}, ` +
+                `game wrote pos=${cell(b.actual['position-relative-to-grid'])} ` +
+                `abs=${cell(b.actual['absolute-snapping'])}`
+        )
+    }
+}
+
+if (controls.some(c => !c.ok)) {
+    console.log(
+        '\nA control failed. Per the README, a failing control usually means the\n' +
+            'question is wrong rather than the answer - read the section it voids\n' +
+            'as unmeasured rather than as a finding.'
+    )
+}
+
+if (WRITE_FIXTURE) {
+    const fixture = {
+        provenance: {
+            probe: 'tools/oracle/probe-blueprint-snapping.mjs',
+            binary: binaryLine,
+            modFactorioVersion: MOD_FACTORIO_VERSION,
+            mods: d.mods ?? {},
+            question:
+                'Which of snap-to-grid / absolute-snapping / position-relative-to-grid does ' +
+                'the game write into an exported blueprint string, for each combination of ' +
+                'the three LuaItemStack snapping properties?',
+        },
+        controls,
+        rows: rows.map(r => ({
+            case: r.case,
+            gridRow: isGridRow(r),
+            set: { snap: r.set.snap, absolute: r.set.absolute, position: r.set.position },
+            setPosition: r.set.setPosition,
+            written: r.written,
+            roundTrip: r.roundTrip,
+            absoluteAfterEachSetter: r.trace,
+        })),
+        mechanism:
+            'Setting blueprint_position_relative_to_grid turns blueprint_absolute_snapping ' +
+            'ON - see absoluteAfterEachSetter.afterPosition, true on every row that sets a ' +
+            'position. A probe that sets position last cannot reach relative mode at all, ' +
+            'which is what the first run of this probe did.',
+        finding:
+            'position-relative-to-grid is written under ABSOLUTE snapping and omitted under ' +
+            'RELATIVE. Measured on the four rows with a grid and an explicit mode: ' +
+            'relative-offset sets position {3,5} and the game writes none; absolute-offset ' +
+            'sets the same and the game writes {3,5}. The editor round-trips it correctly ' +
+            'today; PR #222 inverts it.',
+        voided: {
+            rows: voidedRows.map(r => r.case),
+            why:
+                'A grid position or absolute snapping with no snap-to-grid is a state the ' +
+                'GUI cannot produce, and the game answers it inconsistently - it writes keys ' +
+                'with no grid beside them and does not reconstruct them on import. Recorded, ' +
+                'not counted.',
+        },
+        candidateRules: {
+            'pr-222-position-under-relative': {
+                agrees: pr222.every(s => s.agrees),
+                disagreeingCases: pr222.filter(s => !s.agrees).map(s => s.case),
+            },
+            'inverted-position-under-absolute': {
+                agrees: inverted.every(s => s.agrees),
+                disagreeingCases: inverted.filter(s => !s.agrees).map(s => s.case),
+            },
+        },
+    }
+    writeFileSync(FIXTURE, `${JSON.stringify(fixture, null, 4)}\n`)
+    console.log(`\nwrote ${FIXTURE}`)
+}


### PR DESCRIPTION
Evidence for #222, captured on **2.0.77** — the version the editor targets, not the 2.1.12 most fixtures here come from.

## The question

#222 rewrites `Blueprint.serialize` to write `position-relative-to-grid` only under **Relative** snapping. That drops it from every real blueprint: 325 of the corpus's 367 carry snapping and all 325 are `absolute-snapping: true`.

The corpus can say the two co-occur. It cannot say one *requires* the other, because no corpus blueprint uses relative snapping at all. Arguing from 325 rows that all agree is the shape of argument #133 item 5 and #142 both got wrong, so this asks the binary instead.

## The answer

The game writes `position-relative-to-grid` under **Absolute** and omits it under **Relative**:

| case | set snap | set abs | set pos | wrote snap | wrote abs | wrote pos |
|---|---|---|---|---|---|---|
| relative-origin | 2,2 | false | 0,0 | 2,2 | - | - |
| **relative-offset** | 2,2 | false | **3,5** | 2,2 | - | **-** |
| absolute-origin | 2,2 | true | 0,0 | 2,2 | true | - |
| **absolute-offset** | 2,2 | true | **3,5** | 2,2 | true | **3,5** |

Both candidate rules were transcribed into the probe and scored against every measured row **before** any editor code was touched:

```
DISAGREES  PR #222 as written (position under Relative)   - 3 of 7 rows
AGREES     inverted (position under Absolute)             - 7 of 7 rows
```

## The trap, which cost a run

**Setting `blueprint_position_relative_to_grid` turns `blueprint_absolute_snapping` ON.**

The first version set snap, then absolute, then position — so the position write flipped absolute back on afterwards, every row exported as absolute, and relative mode was never reached. The three relative rows were measuring nothing while looking perfectly plausible.

The readback control caught that the instrument was broken. It could not say *which* setter was responsible; a per-setter trace of `absolute_snapping` is what identified it, and that trace is now part of the probe:

```
case              atStart  afterSnap  afterPos  afterAbs  wanted
relative-offset   false    false      true      false     false
```

Set position before absolute, or not at all.

## Three rows recorded and deliberately not scored

A grid position or absolute snapping with **no** `snap-to-grid` is a state the GUI cannot produce, and the game answers it inconsistently — writing keys with no grid beside them, then failing to reconstruct them on import. Per #133 item 4, that's a section its own control voids, recorded rather than read as an answer.

## Conclusion for the editor

**No change.** The existing pass-through is correct. The fix #222 needs is the inversion of what it currently does, and this fixture is the table to code against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Dbza77QEZnkqt1mGssY71