### PR TITLE
Draft: Add a BookDialog tree view, opened from a button beside BlueprintInfoButton

### DIFF
--- a/packages/editor/src/Editor.ts
+++ b/packages/editor/src/Editor.ts
@@ -11,7 +11,7 @@ import { Application, TextureSource, setBasisTranscoderPath, Assets } from 'pixi
 import basisTranscoderJS from './basis/transcoder.1.16.4.js?url'
 import basisTranscoderWASM from './basis/transcoder.1.16.4.wasm?url'
 import { loadData } from './core/factorioData'
-import G, { Logger } from './common/globals'
+import G, { Logger, QuickActions } from './common/globals'
 import { Entity } from './core/Entity'
 import { Blueprint, oilOutpostSettings, IOilOutpostSettings } from './core/Blueprint'
 import { BlueprintContainer, EditorMode, GridPattern } from './containers/BlueprintContainer'
@@ -21,16 +21,28 @@ import { Dialog } from './UI/controls/Dialog'
 import { ActionRegistry, MouseButton } from './actions'
 import { IPoint } from './types'
 
+/**
+ * A single object rather than trailing positional parameters, so a required
+ * `quickActions` and an optional `logger` don't have to fight over which
+ * comes first, and a third option later doesn't reshuffle anyone's call site.
+ */
+export interface EditorInitOptions {
+    quickActions: QuickActions
+    logger?: Logger
+}
+
 export class Editor {
-    public async init(canvas: HTMLCanvasElement, logger?: Logger): Promise<void> {
+    public async init(canvas: HTMLCanvasElement, options: EditorInitOptions): Promise<void> {
         setBasisTranscoderPath({ jsUrl: basisTranscoderJS, wasmUrl: basisTranscoderWASM })
 
         TextureSource.defaultOptions.scaleMode = 'linear'
         TextureSource.defaultOptions.addressMode = 'repeat'
 
-        if (logger) {
-            G.logger = logger
+        if (options.logger) {
+            G.logger = options.logger
         }
+
+        G.quickActions = options.quickActions
 
         const app = new Application()
 

--- a/packages/editor/src/UI/BookButton.ts
+++ b/packages/editor/src/UI/BookButton.ts
@@ -1,0 +1,48 @@
+import { Container, FederatedPointerEvent } from 'pixi.js'
+import G from '../common/globals'
+import { Button } from './controls/Button'
+import F from './controls/functions'
+
+/**
+ * Persistent top-left button that opens BookDialog.
+ *
+ * Positioned just right of the website's own DOM corner overlay (the FBE logo
+ * plus the Discord/Github buttons in packages/website/index.html), which is
+ * 140px wide and sits at the fixed (0, 0) corner - a canvas-drawn button at
+ * that x would render underneath it. Left rather than right avoids
+ * EntityInfoPanel instead, which docks flush against the right edge whenever
+ * an entity is hovered. A standalone corner button rather than a ToolsPanel
+ * slot, since "is a book loaded" is orthogonal to which quick-action panel
+ * happens to exist.
+ *
+ * Visible only while a book is loaded - polls `G.quickActions.getCurrentBook()`
+ * from the ticker rather than checking once, since "is a book loaded" changes
+ * at runtime (a book replaced by a bare blueprint, or the reverse) with
+ * nothing here to be re-constructed and notice it.
+ */
+export class BookButton extends Container {
+    private readonly m_Button: Button<undefined>
+
+    public constructor() {
+        super()
+
+        this.m_Button = new Button<undefined>(undefined, 36, 36)
+        this.m_Button.content = F.CreateIcon('blueprint-book', 24)
+        this.m_Button.on('pointerdown', this.onPointerDown)
+        this.addChild(this.m_Button)
+
+        this.position.set(152, 6)
+        this.visible = false
+
+        G.app.ticker.add(() => {
+            this.visible = G.quickActions.getCurrentBook() !== undefined
+        })
+    }
+
+    private readonly onPointerDown = (e: FederatedPointerEvent): void => {
+        e.stopPropagation()
+        if (e.button === 0) {
+            G.UI.toggleBookDialog()
+        }
+    }
+}

--- a/packages/editor/src/UI/BookDialog.ts
+++ b/packages/editor/src/UI/BookDialog.ts
@@ -1,0 +1,266 @@
+import { Container, Graphics, Rectangle, Text } from 'pixi.js'
+import { Book } from '../core/Book'
+import { IBlueprintBookEntry } from '../types'
+import G from '../common/globals'
+import F from './controls/functions'
+import { Button } from './controls/Button'
+import { Dialog } from './controls/Dialog'
+import { styles } from './style'
+
+const WIDTH = 320
+const PADDING = 12
+const ROW_HEIGHT = 24
+const ICON_SIZE = 18
+const INDENT = 14
+const VP_X = PADDING
+const VP_Y = 40
+const VP_W = WIDTH - PADDING * 2
+const VP_H = 320
+const HEIGHT = VP_Y + VP_H + PADDING
+
+/**
+ * How many `blueprint_book`s deep to descend. A guard, not a real limit -
+ * nothing seen in the wild nests anywhere close to this - so hitting it
+ * shows one placeholder row rather than silently dropping the rest of the
+ * tree, the same way a corrupt or hand-crafted string could.
+ */
+const MAX_DEPTH = 10
+
+const ROW_LABEL_STYLE = styles.dialog.label
+const ACTIVE_ROW_COLOR = 0xb16925
+
+/** A book's own icon, or its first blueprint icon, or nothing - every one
+ * of those is optional in the format, and a bad signal name in an icon
+ * throws, which is worth losing one icon over rather than the whole dialog. */
+function tryCreateIcon(name: string | undefined, size: number): Container | undefined {
+    if (name === undefined) return undefined
+    try {
+        // setAnchor stays at its default (true/centred) - every call site
+        // positions the icon by its centre.
+        return F.CreateIcon(name, size)
+    } catch {
+        return undefined
+    }
+}
+
+function firstIconName(
+    icons: readonly { signal: { name?: string } }[] | undefined
+): string | undefined {
+    return icons?.[0]?.signal.name
+}
+
+/** A non-interactive row - a nested-book header, a planner placeholder, or
+ * the depth-limit notice - dimmed to read as informational rather than
+ * clickable, since nothing here reacts to a pointer. */
+function createStaticRow(text: string, x: number, y: number, iconName?: string): Container {
+    const row = new Container()
+    row.position.set(x, y)
+    row.alpha = 0.6
+
+    const icon = tryCreateIcon(iconName, ICON_SIZE)
+    let labelX = 0
+    if (icon) {
+        icon.position.set(ICON_SIZE / 2, ROW_HEIGHT / 2)
+        row.addChild(icon)
+        labelX = ICON_SIZE + 4
+    }
+
+    const label = new Text({ text, style: ROW_LABEL_STYLE })
+    label.position.set(labelX, (ROW_HEIGHT - label.height) / 2)
+    row.addChild(label)
+
+    return row
+}
+
+/** A clickable row for one selectable blueprint entry. */
+function createBlueprintRow(
+    label: string,
+    iconName: string | undefined,
+    x: number,
+    y: number,
+    width: number,
+    active: boolean,
+    onSelect: () => void
+): Container {
+    const button = new Button<undefined>(undefined, width, ROW_HEIGHT, 0)
+    button.position.set(x, y)
+    if (active) {
+        const highlight = new Graphics().rect(0, 0, width, ROW_HEIGHT).fill(ACTIVE_ROW_COLOR)
+        button.addChildAt(highlight, 0)
+    }
+
+    const icon = tryCreateIcon(iconName, ICON_SIZE)
+    let labelX = 4
+    if (icon) {
+        icon.position.set(4 + ICON_SIZE / 2, ROW_HEIGHT / 2)
+        button.addChild(icon)
+        labelX = 4 + ICON_SIZE + 4
+    }
+
+    const text = new Text({ text: label, style: ROW_LABEL_STYLE })
+    text.position.set(labelX, (ROW_HEIGHT - text.height) / 2)
+    button.addChild(text)
+
+    button.on('pointerdown', e => {
+        if (e.button === 0) onSelect()
+    })
+
+    return button
+}
+
+/**
+ * Walks a book's raw, still-nested entries and builds one row per entry in
+ * document order - a nested book gets a header row followed by its own
+ * children indented one level further, which is the whole of "drawing a
+ * tree" here: nothing collapses, since a book rarely nests deep enough for
+ * that to matter and an always-expanded list needs no expand/collapse state.
+ *
+ * `flatIndex` is threaded through the recursion rather than looked up
+ * afterwards, incrementing on exactly the entries `Book`'s own flattened
+ * index space counts - a `blueprint` counts, a `blueprint_book` recurses
+ * without counting itself, and a planner is skipped - so a row's index
+ * lines up with what `selectBookEntry` (and `activeIndex`) mean by it.
+ */
+function buildRows(
+    entries: readonly IBlueprintBookEntry[],
+    depth: number,
+    flatIndex: { current: number },
+    activeIndex: number,
+    onSelect: (index: number) => void,
+    rows: Container[]
+): void {
+    for (const entry of entries) {
+        const x = PADDING + depth * INDENT
+        const rowWidth = VP_W - depth * INDENT
+        const y = rows.length * ROW_HEIGHT
+
+        if (entry.blueprint) {
+            const index = flatIndex.current
+            flatIndex.current += 1
+            rows.push(
+                createBlueprintRow(
+                    entry.blueprint.label || `Blueprint #${index}`,
+                    firstIconName(entry.blueprint.icons),
+                    x,
+                    y,
+                    rowWidth,
+                    index === activeIndex,
+                    () => onSelect(index)
+                )
+            )
+        } else if (entry.blueprint_book) {
+            rows.push(
+                createStaticRow(
+                    entry.blueprint_book.label || 'Blueprint Book',
+                    x,
+                    y,
+                    firstIconName(entry.blueprint_book.icons) ?? 'blueprint-book'
+                )
+            )
+
+            if (depth >= MAX_DEPTH) {
+                rows.push(
+                    createStaticRow(
+                        'Nested further, not shown',
+                        PADDING + (depth + 1) * INDENT,
+                        rows.length * ROW_HEIGHT
+                    )
+                )
+            } else {
+                buildRows(
+                    entry.blueprint_book.blueprints ?? [],
+                    depth + 1,
+                    flatIndex,
+                    activeIndex,
+                    onSelect,
+                    rows
+                )
+            }
+        } else if (entry.upgrade_planner || entry.deconstruction_planner) {
+            const label = entry.upgrade_planner ? 'Upgrade planner' : 'Deconstruction planner'
+            rows.push(createStaticRow(label, x, y))
+        }
+    }
+}
+
+/**
+ * Lists a loaded book's blueprints as a tree, matching the book's own
+ * nesting - the settings pane's "BP Book Index" number field is the only
+ * other way to switch entries, and it says nothing about what's at an
+ * index or how deep it sits.
+ */
+export class BookDialog extends Dialog {
+    private readonly m_Rows: Container
+    private readonly m_ScrollThumb: Graphics
+    private m_ContentHeight = 0
+
+    public constructor(book: Book) {
+        super(WIDTH, HEIGHT, 'Blueprint Book')
+
+        this.m_Rows = new Container()
+        this.m_Rows.position.set(0, VP_Y)
+        this.addChild(this.m_Rows)
+
+        const mask = new Graphics().rect(VP_X, VP_Y, VP_W, VP_H).fill(0xffffff)
+        this.addChild(mask)
+        this.m_Rows.mask = mask
+        this.m_Rows.eventMode = 'static'
+        this.m_Rows.hitArea = new Rectangle(0, 0, VP_W, VP_H)
+
+        this.m_ScrollThumb = new Graphics().rect(0, 0, 4, 1).fill({ color: 0xc8c8c8, alpha: 0.6 })
+        this.m_ScrollThumb.visible = false
+        this.addChild(this.m_ScrollThumb)
+
+        const rows: Container[] = []
+        buildRows(
+            book.entries,
+            0,
+            { current: 0 },
+            book.activeIndex,
+            index => {
+                G.quickActions.selectBookEntry(index).catch((error: unknown) => {
+                    G.logger({ text: String(error), type: 'error' })
+                })
+                this.close()
+            },
+            rows
+        )
+
+        for (const row of rows) {
+            this.m_Rows.addChild(row)
+        }
+        this.m_ContentHeight = rows.length * ROW_HEIGHT
+
+        const onWheel = (e: WheelEvent): void => {
+            const maxScroll = Math.max(0, this.m_ContentHeight - VP_H)
+            if (maxScroll <= 0) return
+            e.preventDefault()
+            e.stopPropagation()
+            this.m_Rows.y = Math.min(
+                VP_Y,
+                Math.max(VP_Y - maxScroll, this.m_Rows.y - Math.sign(e.deltaY) * ROW_HEIGHT)
+            )
+            this.refreshScrollbar()
+        }
+        this.m_Rows.addEventListener('wheel', onWheel, { passive: false })
+        this.on('destroyed', () => {
+            this.m_Rows.removeEventListener('wheel', onWheel)
+        })
+
+        this.refreshScrollbar()
+    }
+
+    private refreshScrollbar(): void {
+        const maxScroll = Math.max(0, this.m_ContentHeight - VP_H)
+        if (maxScroll <= 0) {
+            this.m_ScrollThumb.visible = false
+            return
+        }
+        const thumbH = Math.max(24, (VP_H * VP_H) / this.m_ContentHeight)
+        const scroll = VP_Y - this.m_Rows.y
+        const thumbY = VP_Y + (scroll / maxScroll) * (VP_H - thumbH)
+        this.m_ScrollThumb.visible = true
+        this.m_ScrollThumb.height = thumbH
+        this.m_ScrollThumb.position.set(WIDTH - PADDING - 4, thumbY)
+    }
+}

--- a/packages/editor/src/UI/UIContainer.ts
+++ b/packages/editor/src/UI/UIContainer.ts
@@ -5,7 +5,10 @@ import { QuickbarPanel } from './QuickbarPanel'
 import { EntityInfoPanel } from './EntityInfoPanel'
 import { InventoryDialog } from './InventoryDialog'
 import { WiresPanel } from './WiresPanel'
+import { BookButton } from './BookButton'
+import { BookDialog } from './BookDialog'
 import { createEditor } from './editors/factory'
+import G from '../common/globals'
 
 export class UIContainer extends Container {
     private debugContainer: DebugContainer
@@ -14,6 +17,8 @@ export class UIContainer extends Container {
     private entityInfoPanel: EntityInfoPanel
     private dialogsContainer: Container
     private paintIconContainer: Container
+    private bookButton: BookButton
+    private bookDialog: BookDialog | undefined
 
     public constructor() {
         super()
@@ -24,6 +29,7 @@ export class UIContainer extends Container {
         this.entityInfoPanel = new EntityInfoPanel()
         this.dialogsContainer = new Container()
         this.paintIconContainer = new Container()
+        this.bookButton = new BookButton()
 
         this.addChild(
             this.debugContainer,
@@ -33,7 +39,7 @@ export class UIContainer extends Container {
         )
 
         if (!isMobile.any) {
-            this.addChild(this.quickbarPanel, this.wiresPanel)
+            this.addChild(this.quickbarPanel, this.wiresPanel, this.bookButton)
         }
     }
 
@@ -91,6 +97,27 @@ export class UIContainer extends Container {
         const inv = new InventoryDialog(title, itemsFilter, selectedCallBack, showRecipePanel)
         this.dialogsContainer.addChild(inv)
         return inv
+    }
+
+    /**
+     * Opens BookDialog, or closes it if already open - BookButton's click
+     * handler. A no-op when no book is loaded, since the button that reaches
+     * this is only visible then anyway.
+     */
+    public toggleBookDialog(): void {
+        if (this.bookDialog) {
+            this.bookDialog.close()
+            return
+        }
+
+        const book = G.quickActions.getCurrentBook()
+        if (book === undefined) return
+
+        this.bookDialog = new BookDialog(book)
+        this.bookDialog.on('close', () => {
+            this.bookDialog = undefined
+        })
+        this.dialogsContainer.addChild(this.bookDialog)
     }
 
     // public changeQuickbarRows(rows: number): void {

--- a/packages/editor/src/common/globals.ts
+++ b/packages/editor/src/common/globals.ts
@@ -1,5 +1,6 @@
 import { Application, Texture, Assets, Renderer } from 'pixi.js'
 import { Blueprint } from '../core/Blueprint'
+import { Book } from '../core/Book'
 import { UIContainer } from '../UI/UIContainer'
 import { BlueprintContainer } from '../containers/BlueprintContainer'
 import { ActionRegistry } from '../actions'
@@ -12,6 +13,23 @@ export interface ILogMessage {
 }
 
 export type Logger = (msg: ILogMessage) => void
+
+/**
+ * The bridge to state that lives at the website level, not on `G` - "is a
+ * book loaded" is `loadBp`'s own `book` variable in packages/website, so
+ * BookButton/BookDialog reach it through here rather than the editor
+ * package keeping a second copy of it.
+ */
+export interface QuickActions {
+    /** The currently loaded Book, or undefined when a bare blueprint is loaded. */
+    getCurrentBook: () => Book | undefined
+    /**
+     * Switches the editor to the blueprint at the book's own flattened
+     * index - the same thing changing "BP Book Index" in the settings pane
+     * does, and what a `BookDialog` row calls on click.
+     */
+    selectBookEntry: (flatIndex: number) => Promise<void>
+}
 
 const logger: Logger = msg => {
     switch (msg.type) {
@@ -52,6 +70,7 @@ interface Globals {
     actions: ActionRegistry
     getTexture: typeof getTexture
     logger: Logger
+    quickActions: QuickActions
 }
 
 const started = new Map<string, Promise<Texture>>()

--- a/packages/editor/src/core/Book.ts
+++ b/packages/editor/src/core/Book.ts
@@ -33,6 +33,15 @@ class Book {
         return this._activeIndex
     }
 
+    /**
+     * The raw, still-nested entries, for `BookDialog` to walk directly rather
+     * than through the flattened index space `selectBlueprint` reads and
+     * writes - a tree view wants the nesting, not a position in it.
+     */
+    public get entries(): readonly IBlueprintBookEntry[] {
+        return this.blueprints
+    }
+
     public get lastBookIndex(): number {
         return countNestedBlueprints(this.blueprints) - 1
     }

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,6 +1,7 @@
 import { Book } from './core/Book'
 import { Blueprint } from './core/Blueprint'
 import { GridPattern } from './containers/BlueprintContainer'
+import type { QuickActions } from './common/globals'
 import {
     registerAction,
     forEachAction,
@@ -46,6 +47,8 @@ export {
     getSpriteData,
     SPRITE_GENERATION_FAILED,
 }
+// For packages/website, which builds the object Editor.init now requires.
+export type { QuickActions }
 export default {
     registerAction,
     forEachAction,

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -21,6 +21,7 @@ import EDITOR, {
     EntityInfoPanel,
     getSpriteData,
     SPRITE_GENERATION_FAILED,
+    type QuickActions,
 } from '@fbe/editor'
 import { initToasts } from './toasts'
 import { initSettingsPane } from './settingsPane'
@@ -132,8 +133,30 @@ for (const p of params) {
 
 let changeBookForIndexSelector: (bpOrBook: Book | Blueprint) => void
 
+/** For `BookButton`'s visibility check and `BookDialog`'s trigger - undefined
+ * whenever a bare blueprint is loaded. */
+function getCurrentBook(): Book | undefined {
+    return book
+}
+
+/**
+ * Switches to the blueprint at the book's own flattened index - what the
+ * settings pane's "BP Book Index" control, `BookDialog`'s rows, and the
+ * `selectBookIndex` test hook all do. One function rather than three copies.
+ */
+async function selectBookIndex(index: number): Promise<void> {
+    if (!book) throw new Error('No book loaded')
+    bp = book.selectBlueprint(index)
+    await editor.loadBlueprint(bp)
+}
+
+const quickActions: QuickActions = {
+    getCurrentBook,
+    selectBookEntry: selectBookIndex,
+}
+
 editor
-    .init(CANVAS, createToast)
+    .init(CANVAS, { quickActions, logger: createToast })
     .then(() => {
         const quickbarItems = storedJson<string[]>('quickbarItemNames')
         if (quickbarItems) {
@@ -141,16 +164,7 @@ editor
         }
 
         registerActions()
-
-        const changeBookIndex = async (index: number): Promise<void> => {
-            // The settings pane only shows a book index selector while a book is
-            // loaded, so this cannot fire without one - same check, and the same
-            // reason for it, as the selectBookIndex test hook below.
-            if (!book) throw new Error('No book loaded')
-            bp = book.selectBlueprint(index)
-            await editor.loadBlueprint(bp)
-        }
-        changeBookForIndexSelector = initSettingsPane(editor, changeBookIndex).changeBook
+        changeBookForIndexSelector = initSettingsPane(editor, selectBookIndex).changeBook
 
         getBlueprintOrBookFromSource(bpSource)
             .catch(error => createBPImportError(error))
@@ -325,12 +339,8 @@ const testApi = {
         }
     },
     loadingScreen,
-    getBook: () => book,
-    selectBookIndex: async (index: number) => {
-        if (!book) throw new Error('No book loaded')
-        bp = book.selectBlueprint(index)
-        await editor.loadBlueprint(bp)
-    },
+    getBook: getCurrentBook,
+    selectBookIndex,
     /*
         The blueprint string a copy would put on the clipboard, which for a loaded
         book is Book.serialize(). Nothing else reaches that method: the round-trip


### PR DESCRIPTION
The only way to switch entries in a loaded blueprint book was a bare "BP Book Index" number field in the settings pane, with no names, icons, or indication of nesting.

BookDialog walks the book's raw entries directly (not the flattened index space `Book.selectBlueprint` reads) and renders them as an always-expanded tree — nested books get a header row and indented children, planners get a dimmed placeholder row, and a depth guard of 10 stops runaway recursion on a malformed book. Rows scroll with the same mask+wheel+thumb pattern `InventoryDialog` already uses.

`BookButton` opens it, sitting one slot pitch right of `BlueprintInfoButton` and visible only while a book is loaded, rather than living in ToolsPanel (#221).

Stacked on #222 — future base is `wormeyman-space-age-support`, not the default branch.

<img width="278" height="153" alt="image" src="https://github.com/user-attachments/assets/0033cb18-6d3f-41b5-8824-6051a88962d2" />

--

<img width="349" height="394" alt="image" src="https://github.com/user-attachments/assets/948473c7-5177-44a3-b130-c31cc744f13e" />
