### PR TITLE
Update the Rust futures crate and the vite-plus toolchain

### DIFF
--- a/.github/actions/setup-vp/action.yml
+++ b/.github/actions/setup-vp/action.yml
@@ -11,7 +11,7 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ~/.vite-plus
-        key: vite-plus-${{ runner.os }}-0.2.8
+        key: vite-plus-${{ runner.os }}-0.2.9
 
     - name: Cache npm downloads
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -31,6 +31,6 @@ runs:
         # when intentionally upgrading the toolchain.
         curl -fsSL https://vite.plus -o vp-install.sh
         echo "58bb052c6a007e662e99667d65686251b16d6b39aa21155487da6d51280b3d54  vp-install.sh" | sha256sum -c -
-        VP_VERSION=0.2.8 VP_NODE_MANAGER=yes bash vp-install.sh
+        VP_VERSION=0.2.9 VP_NODE_MANAGER=yes bash vp-install.sh
         echo "$HOME/.vite-plus/bin" >> "$GITHUB_PATH"
         rm -f vp-install.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "serve": "^14.2.6",
                 "typed-factorio": "^3.36.0",
                 "typescript": "^7.0.2",
-                "vite-plus": "0.2.8"
+                "vite-plus": "0.2.9"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1250,9 +1250,9 @@
             }
         },
         "node_modules/@oxc-project/runtime": {
-            "version": "0.142.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.142.0.tgz",
-            "integrity": "sha512-Dv3jRrcXFdvUBUEljUu9kusrEo9G0iiqZFZNg3yCg+mkET4DD4S2Ow6Q6shFWDJwPidSa980d6YVXBlErUGADw==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.143.0.tgz",
+            "integrity": "sha512-zIuXUf+YGIgsPk0xlQmzTY8NCSc8jE/pSfDodlQ9H3EGZABmr+AtIjXRrnpQAXuXzhDSNqZz9cuhud8hDDLvpg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1260,9 +1260,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.142.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
-            "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+            "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1270,9 +1270,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm-eabi": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.61.0.tgz",
-            "integrity": "sha512-BaS+1OVvg9sr+Xav0+KdWedQRcAzrdoEcwMZeqoc2F6ieC1s/t5eM35YQoRPQ7vAqkZ+p3tbQb1r9I9mrV5oGA==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.62.0.tgz",
+            "integrity": "sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw==",
             "cpu": [
                 "arm"
             ],
@@ -1287,9 +1287,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm64": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.61.0.tgz",
-            "integrity": "sha512-of8atAV0M1egGcVOMbgZCvc10sFOP3ayQBNQV5h5G3fNq8gACdEswfFk9bzGrdbM23rtg0Coxi7np7oPLcueNw==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.62.0.tgz",
+            "integrity": "sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog==",
             "cpu": [
                 "arm64"
             ],
@@ -1304,9 +1304,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-arm64": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.61.0.tgz",
-            "integrity": "sha512-7l8+5ov4BGwtAcmpzvEik/TG3bciwyw/S3e6j5GKH7pcQqcgCVxD3AuJeP6upto+SOTBKQ4wrrdbMt0gq8fHSQ==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.62.0.tgz",
+            "integrity": "sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1321,9 +1321,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-x64": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.61.0.tgz",
-            "integrity": "sha512-Fnz4dDDXBb7udk+DmwelNjxbD6yptyxwCqwCH2ebo4RVLxVsRfFsn/AHJC49KIltPrVokamGv4SSOsiV50DTxQ==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.62.0.tgz",
+            "integrity": "sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ==",
             "cpu": [
                 "x64"
             ],
@@ -1338,9 +1338,9 @@
             }
         },
         "node_modules/@oxfmt/binding-freebsd-x64": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.61.0.tgz",
-            "integrity": "sha512-mddOebKNCP+AucmzfNsk3jgbr681qAUvgMqi865GW5gWLJ/AnzXbvjQRrny0e++NAN8aphav/aRSrfFxNsNjpA==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.62.0.tgz",
+            "integrity": "sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g==",
             "cpu": [
                 "x64"
             ],
@@ -1355,9 +1355,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.61.0.tgz",
-            "integrity": "sha512-svx59iYL+DbaZGZUIoice4W0CjRXGExnbz7Re+awIb60rVxBS2KrU7Hnlx+nZYanLGLpjneUEgo/VFEKkSZAyQ==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.62.0.tgz",
+            "integrity": "sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g==",
             "cpu": [
                 "arm"
             ],
@@ -1372,9 +1372,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.61.0.tgz",
-            "integrity": "sha512-BYK9MPJPCf6d+fLKMTruThmEyCtHzQ1zLcsrTlUVkmnoXIaHAbfpeLYQwX1tkjs7W11dyzoi6HFvKcdnvX1zNg==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.62.0.tgz",
+            "integrity": "sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog==",
             "cpu": [
                 "arm"
             ],
@@ -1389,9 +1389,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.61.0.tgz",
-            "integrity": "sha512-QUaCNLq2/EC6G5ljOuFanl9Lgw6ZWp4co7rs4+KOMUzbGfA4Lq58FHRjjF9sVIG+93XSbo343MxFATrOU1qctA==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.62.0.tgz",
+            "integrity": "sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg==",
             "cpu": [
                 "arm64"
             ],
@@ -1409,9 +1409,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-musl": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.61.0.tgz",
-            "integrity": "sha512-S6uvJ6MXnRXl+zTs0CARNDvkE+cymj0EVWEKKsyKnlLlqTyQJBjw5s4D2pSIOZc+S46cy4STefzcr/sm0VzVPA==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.62.0.tgz",
+            "integrity": "sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew==",
             "cpu": [
                 "arm64"
             ],
@@ -1429,9 +1429,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.61.0.tgz",
-            "integrity": "sha512-6VDlRcytvZG6UlSIdAFKDLbppo9tvPxrWzle6vHldYFMeuDPQEfMKrkwezp7FaBq1wik9ra554ZZeRPsyIkFpg==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.62.0.tgz",
+            "integrity": "sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw==",
             "cpu": [
                 "ppc64"
             ],
@@ -1449,9 +1449,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.61.0.tgz",
-            "integrity": "sha512-KkBTYbzExpbmn15XjKPLu2fRV2PVlq+KWt+brad5rwIa03vdYoaDRWiS7raHII/dCTR6Ro4UpYUCH4t6lif4WQ==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.62.0.tgz",
+            "integrity": "sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA==",
             "cpu": [
                 "riscv64"
             ],
@@ -1469,9 +1469,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.61.0.tgz",
-            "integrity": "sha512-69tzIq7sJLVB9dxYYtvMzcSSsnZHSO+U2U19O2RqDqgj6+Q4O7HjSXdaszbcgqzhsUwzSH7z5kWvk8nmf6BHTg==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.62.0.tgz",
+            "integrity": "sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A==",
             "cpu": [
                 "riscv64"
             ],
@@ -1489,9 +1489,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.61.0.tgz",
-            "integrity": "sha512-Oqi/N0OvtOVXsPKAOOhKgGH3msRYF8BLJaNBbWiupRiKoKVyc8JRKPCfarkQJC+RgP9U8raUKLe+bNwd0HUMiA==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.62.0.tgz",
+            "integrity": "sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A==",
             "cpu": [
                 "s390x"
             ],
@@ -1509,9 +1509,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-gnu": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.61.0.tgz",
-            "integrity": "sha512-3TKwv/ed4uwJSemAA8P9XcoqETpjQI4waquF9UilhA9Mn/dhr1PdUEXWlL74mtc6ZNfmKPA9+NEJm01nRF8CVA==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.62.0.tgz",
+            "integrity": "sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w==",
             "cpu": [
                 "x64"
             ],
@@ -1529,9 +1529,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-musl": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.61.0.tgz",
-            "integrity": "sha512-uFso4u4nLkVSlMCpgjyvWV60Gt7GvDQHnk1mmRxHIkZTMB0ljpUKwCD9FYGgN9H97x2wYl0UwEjgRZaPIuhEhw==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.62.0.tgz",
+            "integrity": "sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw==",
             "cpu": [
                 "x64"
             ],
@@ -1549,9 +1549,9 @@
             }
         },
         "node_modules/@oxfmt/binding-openharmony-arm64": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.61.0.tgz",
-            "integrity": "sha512-keGLkzeOvkMpNmPp4hffXWpfoSsY6e1K8++KXD4mSSfxdvM8q9QUDsYY689TB1k6Co832DZn1MnaaVx6cIBMWQ==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.62.0.tgz",
+            "integrity": "sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA==",
             "cpu": [
                 "arm64"
             ],
@@ -1566,9 +1566,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.61.0.tgz",
-            "integrity": "sha512-VzsAISkFxmNhJ5LBDEL9VuH6tJsVJMtqYit2LyIUf/HLnsCe4Pg9SMOjjVQzGWt0bnpyfJ94CrqTqcpNZzK+ug==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.62.0.tgz",
+            "integrity": "sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw==",
             "cpu": [
                 "arm64"
             ],
@@ -1583,9 +1583,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.61.0.tgz",
-            "integrity": "sha512-xv4t7yzwJoYaLB6Zv28B3W+j7brEjsyv50rLTAQgmxJzddce9fAMCxed8dSAkbWES0zz2J29nYK5FaTuD2YBHg==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.62.0.tgz",
+            "integrity": "sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw==",
             "cpu": [
                 "ia32"
             ],
@@ -1600,9 +1600,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-x64-msvc": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.61.0.tgz",
-            "integrity": "sha512-6EZXFkqOwxdDYjIn3TSNnPk3ST5E5GiYd4FiM6UF/mCL/LZSfr6D6UygTfW3R1PCQP2quCKpCEGRlij8E3VYbg==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.62.0.tgz",
+            "integrity": "sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ==",
             "cpu": [
                 "x64"
             ],
@@ -1701,9 +1701,9 @@
             ]
         },
         "node_modules/@oxlint/binding-android-arm-eabi": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.76.0.tgz",
-            "integrity": "sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.77.0.tgz",
+            "integrity": "sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ==",
             "cpu": [
                 "arm"
             ],
@@ -1718,9 +1718,9 @@
             }
         },
         "node_modules/@oxlint/binding-android-arm64": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.76.0.tgz",
-            "integrity": "sha512-shm/ngQilHK6bs+ElJWa4oHfNj5vL1Gl/iVEJldTQjpr0/67oSgr0KUpbmcnLig5Fo0v/l6j2567A7TOL89ONA==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.77.0.tgz",
+            "integrity": "sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA==",
             "cpu": [
                 "arm64"
             ],
@@ -1735,9 +1735,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-arm64": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.76.0.tgz",
-            "integrity": "sha512-rvJmrAPKSQ9aWJ6wIS6CK2tJjwzfW0ApQH9qokq6sfDvmHwoyIHxHFMq7z7i7GiV6fdE6s8qvBqWKPTu8RmT6Q==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.77.0.tgz",
+            "integrity": "sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA==",
             "cpu": [
                 "arm64"
             ],
@@ -1752,9 +1752,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-x64": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.76.0.tgz",
-            "integrity": "sha512-U/zYdb7VYKGY6pA9Vd2rYl9O/HlCylcOlb5PGPvVLtg+oLGsk6H3XGKEMHKyqD3nmmtmlmwb/8SwU2vfSAtvMw==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.77.0.tgz",
+            "integrity": "sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA==",
             "cpu": [
                 "x64"
             ],
@@ -1769,9 +1769,9 @@
             }
         },
         "node_modules/@oxlint/binding-freebsd-x64": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.76.0.tgz",
-            "integrity": "sha512-WvKG9CAriuo0XNiFzpXjDngUZcRGFNpaK2kLyMUsnJlShxkT96u+BpJQ3KqdQwGOrvI14L6V8bAwXwAYNNY6Jg==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.77.0.tgz",
+            "integrity": "sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg==",
             "cpu": [
                 "x64"
             ],
@@ -1786,9 +1786,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.76.0.tgz",
-            "integrity": "sha512-qJ5+RH99TqFRq3UCDxkW0zJJu9c+OAHFY72vGlxZLEpuO+MpKo3POgqb8sYipL9KYm8XY6ofb0HsOuvY6hQNqQ==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.77.0.tgz",
+            "integrity": "sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA==",
             "cpu": [
                 "arm"
             ],
@@ -1803,9 +1803,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.76.0.tgz",
-            "integrity": "sha512-PvPCVptkgVARsucgIqFQQcSmJ6xc6GtnVB5bRBekRahTc9eObMtjHfMjy5M+C2tHt5UCMttWM9RuSk/H9NqYeg==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.77.0.tgz",
+            "integrity": "sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ==",
             "cpu": [
                 "arm"
             ],
@@ -1820,9 +1820,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-gnu": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.76.0.tgz",
-            "integrity": "sha512-3KeFDx8Bu4HPAXbuHZOr/oHvN+QT+JQhMw/NYPz7Z071xLSsG27Jfh9PIQVEY7hk1I+jr43ExqRIeJ6VKk2yLw==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.77.0.tgz",
+            "integrity": "sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw==",
             "cpu": [
                 "arm64"
             ],
@@ -1840,9 +1840,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-musl": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.76.0.tgz",
-            "integrity": "sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.77.0.tgz",
+            "integrity": "sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==",
             "cpu": [
                 "arm64"
             ],
@@ -1860,9 +1860,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.76.0.tgz",
-            "integrity": "sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.77.0.tgz",
+            "integrity": "sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==",
             "cpu": [
                 "ppc64"
             ],
@@ -1880,9 +1880,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.76.0.tgz",
-            "integrity": "sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.77.0.tgz",
+            "integrity": "sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==",
             "cpu": [
                 "riscv64"
             ],
@@ -1900,9 +1900,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-musl": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.76.0.tgz",
-            "integrity": "sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.77.0.tgz",
+            "integrity": "sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==",
             "cpu": [
                 "riscv64"
             ],
@@ -1920,9 +1920,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-s390x-gnu": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.76.0.tgz",
-            "integrity": "sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.77.0.tgz",
+            "integrity": "sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==",
             "cpu": [
                 "s390x"
             ],
@@ -1940,9 +1940,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-gnu": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.76.0.tgz",
-            "integrity": "sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.77.0.tgz",
+            "integrity": "sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==",
             "cpu": [
                 "x64"
             ],
@@ -1960,9 +1960,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-musl": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.76.0.tgz",
-            "integrity": "sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.77.0.tgz",
+            "integrity": "sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==",
             "cpu": [
                 "x64"
             ],
@@ -1980,9 +1980,9 @@
             }
         },
         "node_modules/@oxlint/binding-openharmony-arm64": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.76.0.tgz",
-            "integrity": "sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.77.0.tgz",
+            "integrity": "sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==",
             "cpu": [
                 "arm64"
             ],
@@ -1997,9 +1997,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-arm64-msvc": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.76.0.tgz",
-            "integrity": "sha512-pqDWZiwcmByWUEm1NFUBNiT6aentCcaoMWJv0HbXEmuYermJ4sg8ppVrshubYP2MZ6SHccJJcpr6x469PuDFIw==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.77.0.tgz",
+            "integrity": "sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA==",
             "cpu": [
                 "arm64"
             ],
@@ -2014,9 +2014,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-ia32-msvc": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.76.0.tgz",
-            "integrity": "sha512-Ba0O659kgMv6pwO3z9PdO+K3aMxQRaw9HnG+e6AtOfgwcKFvYilciQYBoUBmxfQvOCKZe1SwjMkuB542NkuDMQ==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.77.0.tgz",
+            "integrity": "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA==",
             "cpu": [
                 "ia32"
             ],
@@ -2031,9 +2031,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-x64-msvc": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.76.0.tgz",
-            "integrity": "sha512-5qcirPHO8nKfkoowEVWtpAoVTcYDy6g0UT0NGic450Qv8J2NrOqg4uQ8QppRP4MDTC7Xx47lbZnmadTH03CGGA==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.77.0.tgz",
+            "integrity": "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw==",
             "cpu": [
                 "x64"
             ],
@@ -2743,14 +2743,14 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-core": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.8.tgz",
-            "integrity": "sha512-hqUJyozjE4HtJ3wwf2pOw6LnH/EF9W4+ys2s8arr/3fUdw64vzp/SfPFBVCxsGRv2UfjkIieOeZrQ1FH6Oa5Tw==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.9.tgz",
+            "integrity": "sha512-dWqScAAwa8h/i9jCiGAMs7YarzQWInHZ5gCJNbQkHXA6Zp6A2T2anN9YMFVPpb7CwVFwkI2iPF5yl/DXtq+zUA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/runtime": "=0.142.0",
-                "@oxc-project/types": "=0.142.0",
+                "@oxc-project/runtime": "=0.143.0",
+                "@oxc-project/types": "=0.143.0",
                 "lightningcss": "^1.33.0",
                 "postcss": "^8.5.6",
                 "yuku-codegen": "^0.5.44",
@@ -2760,14 +2760,14 @@
                 "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
             },
             "optionalDependencies": {
-                "@voidzero-dev/vite-plus-darwin-arm64": "0.2.8",
-                "@voidzero-dev/vite-plus-darwin-x64": "0.2.8",
-                "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.8",
-                "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.8",
-                "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.8",
-                "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.8",
-                "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.8",
-                "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.8",
+                "@voidzero-dev/vite-plus-darwin-arm64": "0.2.9",
+                "@voidzero-dev/vite-plus-darwin-x64": "0.2.9",
+                "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.9",
+                "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.9",
+                "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.9",
+                "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.9",
+                "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.9",
+                "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.9",
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
@@ -2859,9 +2859,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-darwin-arm64": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.8.tgz",
-            "integrity": "sha512-zcGNhemAhux0/sGDZBK5sHvv5bPm9kj+NhDKs8MYfZMjc51kpzMOV3PWhtTOXjJYDiSxv+Ss4AFj2y2wvQDgWg==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.9.tgz",
+            "integrity": "sha512-/qJHqMfyy/LiCJk4UYZfFW6Comsfm8zDuy4P8UFWnFqRjmefYvZbMK4ThYNM87tKNWYWjsnClzssjJOmDTAc8w==",
             "cpu": [
                 "arm64"
             ],
@@ -2876,9 +2876,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-darwin-x64": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.8.tgz",
-            "integrity": "sha512-56vcDhYuHg1HSqQlFIEexs9WbDtvT2Z8QXq2pEUYVplmP55ekDGx8+Ibu69jBhk+lNwmLAonCW1alffQxMKirQ==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.9.tgz",
+            "integrity": "sha512-3MGnNeazgYAqQTaC7JIbZyrTHmxSXTWFr9G1yAdeItKasB1R8HKIkCS1Qnr49Ge4S/cyOODivdbcpqFkrT93ng==",
             "cpu": [
                 "x64"
             ],
@@ -2893,9 +2893,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-linux-arm64-gnu": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.8.tgz",
-            "integrity": "sha512-EU9zlSieuouJlnLEkVNw9guig5rTQ5hfMeNH0AlRjb1C1xVpUQdf0uRjXg1PHP3os/WspyCPB46Q80lEaeRb0w==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.9.tgz",
+            "integrity": "sha512-6LmukER8qD4UBIRqMNv4Ilq7CxfRhngLUXlMv8vbTupeLRWPJSKvKEHyRxCwr6JP57Gxfr8KrX1ye42WzcZF0g==",
             "cpu": [
                 "arm64"
             ],
@@ -2913,9 +2913,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-linux-arm64-musl": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.8.tgz",
-            "integrity": "sha512-VbWUwaSAw0Ndql5uYy/Gfqt7duSy1sxTacLngD5M5kF4ZK7yoKKcx8iFiA0il1Gf3J7OGojPonKi5b3NSn3K7A==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.9.tgz",
+            "integrity": "sha512-cBs626GWkyJlwKP0nsdHlMWpuTl9xOWRxAUoqtxXPtw80bVy4WM5eNS4SXPC5pX10jR7DRIkRpzNAsy7fv8Faw==",
             "cpu": [
                 "arm64"
             ],
@@ -2933,9 +2933,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-linux-x64-gnu": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.8.tgz",
-            "integrity": "sha512-gZfnd3l9vNiP7QXQIEN9r2M9ZKCh8sg2vhBv04sZjMNAeQ05IXJMkWYkcfTUO7jhf8pdVt3VHQ4x6ULm0OnELg==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.9.tgz",
+            "integrity": "sha512-2Iy8x4PCPMNzXeu3pREevlggoeK8PwtdUiCpoSybAZBtR/aqMxsJREyt/eKv45F8lsiNlA8PbIWEvPxLSgzFLQ==",
             "cpu": [
                 "x64"
             ],
@@ -2953,9 +2953,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-linux-x64-musl": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.8.tgz",
-            "integrity": "sha512-5NtDUvjzF/HcjQraebpiVUgjX2CMKv2Jdmi5YpzHlt4g86sFA9M5a+OqBlgUctdzTeolnjxRsfurKiefG/hILA==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.9.tgz",
+            "integrity": "sha512-zuGx+eRotWPd9cmh1X9AfsC2tN/Ad9Hk6LAzlxoKJUjEkTsY3WjVJ6Da0z48SAUFuenI0JkdqXnMCrePtGvWHg==",
             "cpu": [
                 "x64"
             ],
@@ -2973,9 +2973,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-win32-arm64-msvc": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.8.tgz",
-            "integrity": "sha512-Atjz6KsG42ntfQkM6Ks09Ifxm+ZIca2DnA31tO2FcPlHetBxYEGZwSNCOHAnoNnLrh2qNm+7aOC329a2ijhxLg==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.9.tgz",
+            "integrity": "sha512-kaKb5Q8ReYTBfvLgUhdpLJG3aoNF8HOVJpf8qBm+THsd4WRrkRwsBHp2ITsU8oXl2gnDjFGhPDaURegd/z6Wxw==",
             "cpu": [
                 "arm64"
             ],
@@ -2990,9 +2990,9 @@
             }
         },
         "node_modules/@voidzero-dev/vite-plus-win32-x64-msvc": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.8.tgz",
-            "integrity": "sha512-VSpa+gK1MjOH7GeO6H5xtJLqisQOWVeRQIDQs9XKizXFX0R4NCrioYO6Rc31QLXfL0lPCkwsKhp/9M9gllImRg==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.9.tgz",
+            "integrity": "sha512-/fEk3gbQTJknCiYM/GTL/L++Azsav8rCAjmtKrjmCbqEif5IMzqTfvM68n+PiLB3JVoQJGF/mg2niODr0IE/2w==",
             "cpu": [
                 "x64"
             ],
@@ -5133,9 +5133,9 @@
             }
         },
         "node_modules/oxfmt": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.61.0.tgz",
-            "integrity": "sha512-DxdHBEMYpcEnHoUHjjOigUqV2TYKsvxLwUPXnVYBjgFdqrcQ/91OtwubtZ2PUodCs3sStI8R5Qw3fKNGK4e8wQ==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.62.0.tgz",
+            "integrity": "sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5151,25 +5151,25 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxfmt/binding-android-arm-eabi": "0.61.0",
-                "@oxfmt/binding-android-arm64": "0.61.0",
-                "@oxfmt/binding-darwin-arm64": "0.61.0",
-                "@oxfmt/binding-darwin-x64": "0.61.0",
-                "@oxfmt/binding-freebsd-x64": "0.61.0",
-                "@oxfmt/binding-linux-arm-gnueabihf": "0.61.0",
-                "@oxfmt/binding-linux-arm-musleabihf": "0.61.0",
-                "@oxfmt/binding-linux-arm64-gnu": "0.61.0",
-                "@oxfmt/binding-linux-arm64-musl": "0.61.0",
-                "@oxfmt/binding-linux-ppc64-gnu": "0.61.0",
-                "@oxfmt/binding-linux-riscv64-gnu": "0.61.0",
-                "@oxfmt/binding-linux-riscv64-musl": "0.61.0",
-                "@oxfmt/binding-linux-s390x-gnu": "0.61.0",
-                "@oxfmt/binding-linux-x64-gnu": "0.61.0",
-                "@oxfmt/binding-linux-x64-musl": "0.61.0",
-                "@oxfmt/binding-openharmony-arm64": "0.61.0",
-                "@oxfmt/binding-win32-arm64-msvc": "0.61.0",
-                "@oxfmt/binding-win32-ia32-msvc": "0.61.0",
-                "@oxfmt/binding-win32-x64-msvc": "0.61.0"
+                "@oxfmt/binding-android-arm-eabi": "0.62.0",
+                "@oxfmt/binding-android-arm64": "0.62.0",
+                "@oxfmt/binding-darwin-arm64": "0.62.0",
+                "@oxfmt/binding-darwin-x64": "0.62.0",
+                "@oxfmt/binding-freebsd-x64": "0.62.0",
+                "@oxfmt/binding-linux-arm-gnueabihf": "0.62.0",
+                "@oxfmt/binding-linux-arm-musleabihf": "0.62.0",
+                "@oxfmt/binding-linux-arm64-gnu": "0.62.0",
+                "@oxfmt/binding-linux-arm64-musl": "0.62.0",
+                "@oxfmt/binding-linux-ppc64-gnu": "0.62.0",
+                "@oxfmt/binding-linux-riscv64-gnu": "0.62.0",
+                "@oxfmt/binding-linux-riscv64-musl": "0.62.0",
+                "@oxfmt/binding-linux-s390x-gnu": "0.62.0",
+                "@oxfmt/binding-linux-x64-gnu": "0.62.0",
+                "@oxfmt/binding-linux-x64-musl": "0.62.0",
+                "@oxfmt/binding-openharmony-arm64": "0.62.0",
+                "@oxfmt/binding-win32-arm64-msvc": "0.62.0",
+                "@oxfmt/binding-win32-ia32-msvc": "0.62.0",
+                "@oxfmt/binding-win32-x64-msvc": "0.62.0"
             },
             "peerDependencies": {
                 "svelte": "^5.0.0",
@@ -5185,9 +5185,9 @@
             }
         },
         "node_modules/oxlint": {
-            "version": "1.76.0",
-            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.76.0.tgz",
-            "integrity": "sha512-6QoFioEU4fNdiUx/2Eo6TRd6NG7H7njnRCz8rhB66cZmMHDTqcm1Rjvl8Wry+ZTQMBAmyb4Mlf62Mk5X+eHSOw==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.77.0.tgz",
+            "integrity": "sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -5200,25 +5200,25 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxlint/binding-android-arm-eabi": "1.76.0",
-                "@oxlint/binding-android-arm64": "1.76.0",
-                "@oxlint/binding-darwin-arm64": "1.76.0",
-                "@oxlint/binding-darwin-x64": "1.76.0",
-                "@oxlint/binding-freebsd-x64": "1.76.0",
-                "@oxlint/binding-linux-arm-gnueabihf": "1.76.0",
-                "@oxlint/binding-linux-arm-musleabihf": "1.76.0",
-                "@oxlint/binding-linux-arm64-gnu": "1.76.0",
-                "@oxlint/binding-linux-arm64-musl": "1.76.0",
-                "@oxlint/binding-linux-ppc64-gnu": "1.76.0",
-                "@oxlint/binding-linux-riscv64-gnu": "1.76.0",
-                "@oxlint/binding-linux-riscv64-musl": "1.76.0",
-                "@oxlint/binding-linux-s390x-gnu": "1.76.0",
-                "@oxlint/binding-linux-x64-gnu": "1.76.0",
-                "@oxlint/binding-linux-x64-musl": "1.76.0",
-                "@oxlint/binding-openharmony-arm64": "1.76.0",
-                "@oxlint/binding-win32-arm64-msvc": "1.76.0",
-                "@oxlint/binding-win32-ia32-msvc": "1.76.0",
-                "@oxlint/binding-win32-x64-msvc": "1.76.0"
+                "@oxlint/binding-android-arm-eabi": "1.77.0",
+                "@oxlint/binding-android-arm64": "1.77.0",
+                "@oxlint/binding-darwin-arm64": "1.77.0",
+                "@oxlint/binding-darwin-x64": "1.77.0",
+                "@oxlint/binding-freebsd-x64": "1.77.0",
+                "@oxlint/binding-linux-arm-gnueabihf": "1.77.0",
+                "@oxlint/binding-linux-arm-musleabihf": "1.77.0",
+                "@oxlint/binding-linux-arm64-gnu": "1.77.0",
+                "@oxlint/binding-linux-arm64-musl": "1.77.0",
+                "@oxlint/binding-linux-ppc64-gnu": "1.77.0",
+                "@oxlint/binding-linux-riscv64-gnu": "1.77.0",
+                "@oxlint/binding-linux-riscv64-musl": "1.77.0",
+                "@oxlint/binding-linux-s390x-gnu": "1.77.0",
+                "@oxlint/binding-linux-x64-gnu": "1.77.0",
+                "@oxlint/binding-linux-x64-musl": "1.77.0",
+                "@oxlint/binding-openharmony-arm64": "1.77.0",
+                "@oxlint/binding-win32-arm64-msvc": "1.77.0",
+                "@oxlint/binding-win32-ia32-msvc": "1.77.0",
+                "@oxlint/binding-win32-x64-msvc": "1.77.0"
             },
             "peerDependencies": {
                 "oxlint-tsgolint": ">=7.0.2001",
@@ -6144,14 +6144,14 @@
         },
         "node_modules/vite": {
             "name": "@voidzero-dev/vite-plus-core",
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.8.tgz",
-            "integrity": "sha512-hqUJyozjE4HtJ3wwf2pOw6LnH/EF9W4+ys2s8arr/3fUdw64vzp/SfPFBVCxsGRv2UfjkIieOeZrQ1FH6Oa5Tw==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.9.tgz",
+            "integrity": "sha512-dWqScAAwa8h/i9jCiGAMs7YarzQWInHZ5gCJNbQkHXA6Zp6A2T2anN9YMFVPpb7CwVFwkI2iPF5yl/DXtq+zUA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/runtime": "=0.142.0",
-                "@oxc-project/types": "=0.142.0",
+                "@oxc-project/runtime": "=0.143.0",
+                "@oxc-project/types": "=0.143.0",
                 "lightningcss": "^1.33.0",
                 "postcss": "^8.5.6",
                 "yuku-codegen": "^0.5.44",
@@ -6161,14 +6161,14 @@
                 "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
             },
             "optionalDependencies": {
-                "@voidzero-dev/vite-plus-darwin-arm64": "0.2.8",
-                "@voidzero-dev/vite-plus-darwin-x64": "0.2.8",
-                "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.8",
-                "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.8",
-                "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.8",
-                "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.8",
-                "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.8",
-                "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.8",
+                "@voidzero-dev/vite-plus-darwin-arm64": "0.2.9",
+                "@voidzero-dev/vite-plus-darwin-x64": "0.2.9",
+                "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.9",
+                "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.9",
+                "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.9",
+                "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.9",
+                "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.9",
+                "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.9",
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
@@ -6268,13 +6268,13 @@
             }
         },
         "node_modules/vite-plus": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.8.tgz",
-            "integrity": "sha512-JULDOsy7gxG0o2FuvnsWnzRjzD1x9WM9mya3MNMOJUqTsL2pqiN2nq+dzoQMw+FGCytRw7yG1/p5qNcmYMM5Fw==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.9.tgz",
+            "integrity": "sha512-8uRNqAxh9no3AU4Lep8BEYhkim07+3NO+mhuxTWiN0k30syGT/2+ue/DtWYhtzQ7yi2f2WKpjOhoI4/QkWWbUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.142.0",
+                "@oxc-project/types": "=0.143.0",
                 "@oxlint/plugins": "=1.73.0",
                 "@vitest/browser": "4.1.10",
                 "@vitest/browser-preview": "4.1.10",
@@ -6285,9 +6285,9 @@
                 "@vitest/snapshot": "4.1.10",
                 "@vitest/spy": "4.1.10",
                 "@vitest/utils": "4.1.10",
-                "@voidzero-dev/vite-plus-core": "0.2.8",
-                "oxfmt": "=0.61.0",
-                "oxlint": "=1.76.0",
+                "@voidzero-dev/vite-plus-core": "0.2.9",
+                "oxfmt": "=0.62.0",
+                "oxlint": "=1.77.0",
                 "oxlint-tsgolint": "=7.0.2001",
                 "vitest": "4.1.10"
             },
@@ -6301,14 +6301,14 @@
                 "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
             },
             "optionalDependencies": {
-                "@voidzero-dev/vite-plus-darwin-arm64": "0.2.8",
-                "@voidzero-dev/vite-plus-darwin-x64": "0.2.8",
-                "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.8",
-                "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.8",
-                "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.8",
-                "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.8",
-                "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.8",
-                "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.8"
+                "@voidzero-dev/vite-plus-darwin-arm64": "0.2.9",
+                "@voidzero-dev/vite-plus-darwin-x64": "0.2.9",
+                "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.9",
+                "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.9",
+                "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.9",
+                "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.9",
+                "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.9",
+                "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.9"
             },
             "peerDependencies": {
                 "@vitest/browser-playwright": "4.1.10",
@@ -6787,7 +6787,7 @@
             "devDependencies": {
                 "@types/pathfinding": "0.1.0",
                 "typed-factorio": "^3.36.0",
-                "vite-plus": "0.2.8"
+                "vite-plus": "0.2.9"
             }
         },
         "packages/website": {
@@ -6804,7 +6804,7 @@
                 "@types/file-saver": "2.0.7",
                 "rollup-plugin-visualizer": "^7.0.1",
                 "vite-plugin-static-copy": "^4.1.1",
-                "vite-plus": "0.2.8"
+                "vite-plus": "0.2.9"
             }
         },
         "packages/worker": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "serve": "^14.2.6",
         "typed-factorio": "^3.36.0",
         "typescript": "^7.0.2",
-        "vite-plus": "0.2.8"
+        "vite-plus": "0.2.9"
     },
     "devEngines": {
         "packageManager": {
@@ -37,6 +37,6 @@
         }
     },
     "overrides": {
-        "vite": "npm:@voidzero-dev/vite-plus-core@0.2.8"
+        "vite": "npm:@voidzero-dev/vite-plus-core@0.2.9"
     }
 }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -30,6 +30,6 @@
     "devDependencies": {
         "@types/pathfinding": "0.1.0",
         "typed-factorio": "^3.36.0",
-        "vite-plus": "0.2.8"
+        "vite-plus": "0.2.9"
     }
 }

--- a/packages/exporter/Cargo.lock
+++ b/packages/exporter/Cargo.lock
@@ -498,9 +498,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -523,15 +523,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -540,38 +540,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -19,6 +19,6 @@
         "@types/file-saver": "2.0.7",
         "rollup-plugin-visualizer": "^7.0.1",
         "vite-plugin-static-copy": "^4.1.1",
-        "vite-plus": "0.2.8"
+        "vite-plus": "0.2.9"
     }
 }


### PR DESCRIPTION
Combines #239 and #240 into one PR so the two changes share a single CI run. Both are Renovate updates and they touch no file in common.

| Update | From | To | Files |
|---|---|---|---|
| Rust crate `futures` (#239) | 0.3.33 | 0.3.34 | `packages/exporter/Cargo.lock` |
| vite-plus toolchain (#240) | 0.2.8 | 0.2.9 | root + editor + website manifests, root `overrides`, `setup-vp` action, lockfile |

## The lockfile fix that #240 needed

#240 could not have merged as it stood. Its `checks` job and all four Playwright shards failed in about 20 seconds each:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: vite@0.2.9 from lock file
npm error Missing: fsevents@2.3.3 from lock file
```

Renovate bumped the `vite` alias in the root `overrides` (`npm:@voidzero-dev/vite-plus-core@0.2.9`) but **deleted** the matching `node_modules/vite` lockfile entry and its nested `fsevents` instead of updating them. `npm ci` then had a manifest asking for a package the lockfile no longer described.

The fix is a plain `npm install --package-lock-only`, which restores exactly those two entries at 0.2.9 and nothing else: 117 insertions, zero deletions, no other package path touched. It is folded into the toolchain commit so neither commit is left in a state where `npm ci` fails.

## Toolchain pins

All five places the vite-plus version is written moved together, and the sixth thing is unchanged for a measured reason:

- root, `packages/editor` and `packages/website` `package.json` - 0.2.9
- root `overrides` `vite` alias - 0.2.9
- `.github/actions/setup-vp/action.yml` `VP_VERSION` and cache key - 0.2.9
- the installer sha256 in that same action - **unchanged, and verified rather than assumed.** Re-fetched https://vite.plus and re-hashed it: `58bb052c...b3d54`, matching the committed value. The bootstrap script is versioned separately from the toolchain, so most bumps leave it alone.

0.2.9 carries oxfmt 0.61 -> 0.62 and oxlint 1.76 -> 1.77. The release notes warn that both can report problems in code that passed before. They do not here - `vp check` is clean with no reformatting needed.

## What was verified locally

Every command below was run on this branch. The Playwright and `npm ci` runs are the ones that matter, since they are what failed on #240.

| Check | Result |
|---|---|
| `npm ci` | succeeds - this is the command that failed on #240 |
| `vp check` | 237 files formatted, 175 files with no lint or type errors |
| `vp test` | 184 passed |
| `npx playwright test` | 198 passed, 5.1m |
| `cargo metadata --locked` | lockfile coherent with `Cargo.toml`, `futures` at 0.3.34 |

The browser suite ran against a dev server reporting `VITE+ v0.2.9`, not the old build. `vp install` left `node_modules` on 0.2.8 even after the lockfile moved, so the first pass would have measured the wrong toolchain; `npm ci` was used instead, which is also what CI runs.

`npm audit` is unchanged at 3 (2 moderate, 1 high), all `undici` reached through `wrangler` -> `miniflare`. Both links are exact pins, so nothing in range moves them, and `npm audit --omit=dev` is 0 - none of it ships to users. This is the standing hold already recorded in CLAUDE.md, not something this batch introduced.

## The Rust half

`futures` 0.3.33 -> 0.3.34 is a lockfile-only patch bump: preserve cloned waker identity, and `syn` moved to 3. CI compiles the exporter on ubuntu and Windows but cannot run it - that needs a Factorio install and `./basisu`, for which only a macOS ARM64 binary is tracked. This change touches neither image handling nor archive handling, so the compile jobs are the appropriate evidence and a local run would prove nothing extra.

Closes #239. Closes #240.
