### PR TITLE
Drop the apt install for chromium's libraries; assert them instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,14 +246,7 @@ jobs:
     # backstop against a hung suite rather than an estimate: a shard that has
     # genuinely stopped making progress should be killed, and one that is merely
     # slow should not.
-    #
-    # 20 -> 25 because the retry around `Install browser system dependencies`
-    # below bounds that step at 12 minutes rather than the 20 it once ran to,
-    # and 12 + ~1 setup + ~4 specs does not fit under 20. This is not a way of
-    # tolerating a slower suite: the specs are measured at 96-226s and nothing
-    # here expects that to move. If a shard reaches 25 minutes, something is
-    # hung, which is the same thing the 20 meant.
-    timeout-minutes: 25
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -287,44 +280,55 @@ jobs:
         if: steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
-      # TEMPORARY EXPERIMENT - not the shape this PR intends to merge.
+      # No apt here, on purpose, and this replaces an install rather than
+      # retrying one. Measured: the ubuntu-24.04 image already carries every
+      # shared library the cached chromium needs, so `playwright install-deps`
+      # had nothing to do on a cache hit - while being by a wide margin the
+      # least reliable step in this workflow. Over 44 runs of it: median 17s,
+      # a tail to 686s, and 2 that never finished and took the job timeout and
+      # the deploy with them. The suite then passed on all four shards with it
+      # removed entirely.
       #
-      # The question this run exists to answer: is this step needed at all on a
-      # cache hit? The comment it replaces asserts that the OS packages do not
-      # survive the cache, which is true, but never checked whether the
-      # ubuntu-24.04 image already carries them. If it does, the right fix is to
-      # delete the step rather than to retry it, and an apt call leaves the
-      # critical path entirely.
+      # Why it hung, since the number alone does not say: apt stalls on the
+      # mirrorlist fetch. Wrapping it in `timeout` does not help and actively
+      # hurts - timeout kills its own child, `npx`, while the root-owned
+      # `apt-get` underneath survives holding /var/lib/apt/lists/lock, so every
+      # retry after the first dies instantly on the lock. That was measured too,
+      # on all four shards, and is why this is a deletion and not a retry.
       #
-      # So: no apt here. Ask the linker directly which of chromium's shared
-      # libraries are actually missing, which takes about a second and cannot
-      # hang. Then let the specs run regardless. Two independent readings come
-      # out of the same run - what ldd says is missing, and whether the suite
-      # passes without the install - and they should agree.
+      # What is left is an assertion, not an install: ask the linker whether
+      # anything is actually missing. About a second, and it cannot hang. If a
+      # future runner image ever drops a library, this fails here naming the
+      # binary, instead of surfacing as chromium failing to launch inside an
+      # unrelated spec.
       #
-      # Never fails the job on purpose: a missing library should present as the
-      # specs failing, which is the reading being tested, not as this step
-      # pre-empting them.
-      - name: Probe chromium shared libraries (no apt)
+      # THE BINARY COUNT IS PART OF THE ASSERTION, and is the more important
+      # half. The first draft of this check looked for `headless_shell` when the
+      # file is `chrome-headless-shell`, so it silently probed one binary rather
+      # than two and reported a clean result for a binary the specs do not run -
+      # `headless: true` in playwright.config.ts means the headless shell is
+      # what they use. A missing-library count is only meaningful next to the
+      # number of things it looked at.
+      - name: Verify chromium's shared libraries (no apt)
         if: steps.pw-cache.outputs.cache-hit == 'true'
         run: |
-          missing=0
+          expected=2
           found=0
+          bad=0
           while IFS= read -r bin; do
             found=$((found + 1))
             echo "--- $bin"
-            if ldd "$bin" 2>/dev/null | grep -F 'not found' ; then
-              missing=$((missing + 1))
+            if ldd "$bin" | grep -F 'not found'; then
+              echo "::error::$bin is missing the shared libraries listed above"
+              bad=$((bad + 1))
             fi
-          done < <(find ~/.cache/ms-playwright -type f \( -name chrome -o -name headless_shell \) 2>/dev/null)
-          echo "binaries probed: $found   with missing libraries: $missing"
-          if [ "$found" -eq 0 ]; then
-            echo "::warning::found no chromium binary to probe - the reading below is not valid"
-          elif [ "$missing" -eq 0 ]; then
-            echo "::warning::EXPERIMENT: no missing shared libraries without install-deps"
-          else
-            echo "::warning::EXPERIMENT: $missing of $found binaries have missing libraries - the step is needed"
+          done < <(find ~/.cache/ms-playwright -type f \( -name chrome -o -name chrome-headless-shell \))
+          echo "probed $found chromium binaries; $bad with missing libraries"
+          if [ "$found" -lt "$expected" ]; then
+            echo "::error::expected at least $expected chromium binaries, found $found - the browser layout changed, so this check is no longer looking at what the specs run"
+            exit 1
           fi
+          [ "$bad" -eq 0 ]
 
       # The same script a maintainer runs locally, rather than a second copy of
       # "how to start the two servers" that can drift from it. It refuses to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,48 +287,44 @@ jobs:
         if: steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
-      # --with-deps is skipped above on a cache hit, but the OS packages it
-      # installs do not survive in the cache - only the browser does. This puts
-      # them back without re-downloading the browser.
+      # TEMPORARY EXPERIMENT - not the shape this PR intends to merge.
       #
-      # Wrapped in a timeout and retried because this step is bimodal, and its
-      # slow mode is slow enough to kill the job and with it the deploy.
-      # Measured over 44 runs of it across 12 CI runs: median 17s, and 32 of 42
-      # completions under 40s - then a tail of 50, 61, 106, 171, 257, 302, 377,
-      # 400, 474 and 686s, plus 2 that never finished at all and took the
-      # 20-minute job timeout with them. That is the whole of why the deploy for
-      # #244 did not run. The specs either side of it are steady at 96-226s, so
-      # the variance is entirely in this apt call and not in the suite.
+      # The question this run exists to answer: is this step needed at all on a
+      # cache hit? The comment it replaces asserts that the OS packages do not
+      # survive the cache, which is true, but never checked whether the
+      # ubuntu-24.04 image already carries them. If it does, the right fix is to
+      # delete the step rather than to retry it, and an apt call leaves the
+      # critical path entirely.
       #
-      # 240s per attempt is chosen off that distribution: it is 14x the median
-      # and clears every completion up to 171s, so a run in the fast mode is
-      # untouched and only the pathological tail is cut. Three attempts bound
-      # the worst case at 12 minutes against a 25-minute job cap, which leaves
-      # room for the ~1 minute of setup before it and the ~4 minutes of specs
-      # after. A single slow-but-progressing attempt is not what this is
-      # defending against - two of these have hung indefinitely, and no timeout
-      # value distinguishes "slow" from "hung" from the outside.
+      # So: no apt here. Ask the linker directly which of chromium's shared
+      # libraries are actually missing, which takes about a second and cannot
+      # hang. Then let the specs run regardless. Two independent readings come
+      # out of the same run - what ldd says is missing, and whether the suite
+      # passes without the install - and they should agree.
       #
-      # Deliberately not fixing a cause: apt contending with the runner image's
-      # own background upgrade job would explain the bimodality, but that is a
-      # hypothesis and nothing here has measured it. The retry is justified by
-      # the distribution alone, whatever is behind it. If someone does measure
-      # the cause, this can probably be replaced by something cheaper.
-      - name: Install browser system dependencies
+      # Never fails the job on purpose: a missing library should present as the
+      # specs failing, which is the reading being tested, not as this step
+      # pre-empting them.
+      - name: Probe chromium shared libraries (no apt)
         if: steps.pw-cache.outputs.cache-hit == 'true'
         run: |
-          for attempt in 1 2 3; do
-            if timeout 240 npx playwright install-deps chromium; then
-              exit 0
+          missing=0
+          found=0
+          while IFS= read -r bin; do
+            found=$((found + 1))
+            echo "--- $bin"
+            if ldd "$bin" 2>/dev/null | grep -F 'not found' ; then
+              missing=$((missing + 1))
             fi
-            echo "::warning::install-deps attempt $attempt did not finish within 240s; retrying"
-            # A killed apt can leave dpkg mid-transaction, which would fail the
-            # next attempt for a different reason than the one being retried.
-            sudo dpkg --configure -a || true
-            sleep 10
-          done
-          echo "install-deps did not settle after 3 attempts" >&2
-          exit 1
+          done < <(find ~/.cache/ms-playwright -type f \( -name chrome -o -name headless_shell \) 2>/dev/null)
+          echo "binaries probed: $found   with missing libraries: $missing"
+          if [ "$found" -eq 0 ]; then
+            echo "::warning::found no chromium binary to probe - the reading below is not valid"
+          elif [ "$missing" -eq 0 ]; then
+            echo "::warning::EXPERIMENT: no missing shared libraries without install-deps"
+          else
+            echo "::warning::EXPERIMENT: $missing of $found binaries have missing libraries - the step is needed"
+          fi
 
       # The same script a maintainer runs locally, rather than a second copy of
       # "how to start the two servers" that can drift from it. It refuses to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,14 @@ jobs:
     # backstop against a hung suite rather than an estimate: a shard that has
     # genuinely stopped making progress should be killed, and one that is merely
     # slow should not.
-    timeout-minutes: 20
+    #
+    # 20 -> 25 because the retry around `Install browser system dependencies`
+    # below bounds that step at 12 minutes rather than the 20 it once ran to,
+    # and 12 + ~1 setup + ~4 specs does not fit under 20. This is not a way of
+    # tolerating a slower suite: the specs are measured at 96-226s and nothing
+    # here expects that to move. If a shard reaches 25 minutes, something is
+    # hung, which is the same thing the 20 meant.
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -283,9 +290,45 @@ jobs:
       # --with-deps is skipped above on a cache hit, but the OS packages it
       # installs do not survive in the cache - only the browser does. This puts
       # them back without re-downloading the browser.
+      #
+      # Wrapped in a timeout and retried because this step is bimodal, and its
+      # slow mode is slow enough to kill the job and with it the deploy.
+      # Measured over 44 runs of it across 12 CI runs: median 17s, and 32 of 42
+      # completions under 40s - then a tail of 50, 61, 106, 171, 257, 302, 377,
+      # 400, 474 and 686s, plus 2 that never finished at all and took the
+      # 20-minute job timeout with them. That is the whole of why the deploy for
+      # #244 did not run. The specs either side of it are steady at 96-226s, so
+      # the variance is entirely in this apt call and not in the suite.
+      #
+      # 240s per attempt is chosen off that distribution: it is 14x the median
+      # and clears every completion up to 171s, so a run in the fast mode is
+      # untouched and only the pathological tail is cut. Three attempts bound
+      # the worst case at 12 minutes against a 25-minute job cap, which leaves
+      # room for the ~1 minute of setup before it and the ~4 minutes of specs
+      # after. A single slow-but-progressing attempt is not what this is
+      # defending against - two of these have hung indefinitely, and no timeout
+      # value distinguishes "slow" from "hung" from the outside.
+      #
+      # Deliberately not fixing a cause: apt contending with the runner image's
+      # own background upgrade job would explain the bimodality, but that is a
+      # hypothesis and nothing here has measured it. The retry is justified by
+      # the distribution alone, whatever is behind it. If someone does measure
+      # the cause, this can probably be replaced by something cheaper.
       - name: Install browser system dependencies
         if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 240 npx playwright install-deps chromium; then
+              exit 0
+            fi
+            echo "::warning::install-deps attempt $attempt did not finish within 240s; retrying"
+            # A killed apt can leave dpkg mid-transaction, which would fail the
+            # next attempt for a different reason than the one being retried.
+            sudo dpkg --configure -a || true
+            sleep 10
+          done
+          echo "install-deps did not settle after 3 attempts" >&2
+          exit 1
 
       # The same script a maintainer runs locally, rather than a second copy of
       # "how to start the two servers" that can drift from it. It refuses to


### PR DESCRIPTION
`npx playwright install-deps chromium` was the least reliable step in this workflow, and on a cache hit it had nothing to do. This deletes it and asserts the thing it was there to guarantee.

Both halves are measured. Neither was assumed, and the first attempt at this PR got it wrong - see the history at the bottom.

## It was unreliable

44 runs of the step across 12 CI runs, from the API rather than from any single run:

| | `install-deps` | `Run Playwright specs` |
|---|---|---|
| min | 11s | 96s |
| median | **17s** | - |
| max completed | **686s** | 226s |
| over 5 minutes | 5 of 42 | 0 of 39 |
| never finished | **2** | 0 |

Bimodal rather than noisy: 32 of 42 under 40s, then a long tail with nothing in between, while the specs either side stay tight. The two that never finished took the 20-minute job timeout with them, and with it `deploy`, which waits on `e2e`. That is what stopped #244 reaching fbe.factorygamefan.com twice, on a commit whose every other job passed.

## It was unnecessary

With the step gone, all four shards passed and `ldd` reports no missing shared libraries. The `ubuntu-24.04` image already carries what the cached chromium needs.

The comment being deleted is not wrong, it just stops one question early. The OS packages genuinely do not survive the cache - only the browser does. Nobody had checked whether they needed to.

## Retrying it was the wrong fix, and the log says why

The first version of this PR wrapped the step in `timeout` and retried. It made CI worse: all four shards failed at ~4m40s where most had passed in 17s.

```
16:19:35  Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist    <- apt stalls here
16:23:34  ##[warning]install-deps attempt 1 did not finish within 240s; retrying
16:23:47  E: Could not get lock /var/lib/apt/lists/lock. It is held by process 2428 (apt-get)
```

`timeout` kills its own child, `npx`. The root-owned `apt-get` underneath survives and keeps the lock, so attempts 2 and 3 die instantly. Identical on all four shards. **A timeout around a `sudo` call does not bound the `sudo` call.**

Worth noting all four hung on attempt 1 in that run, against a median of 17s, which points at the mirror having a bad period rather than at per-runner variance - so no retry count would reliably have helped either.

## What replaces it

An assertion, not an install: `ldd` over the cached chromium binaries. About a second, and it cannot hang. If a runner image ever drops a library, this fails here naming the binary, instead of surfacing as chromium failing to launch inside an unrelated spec.

**The expected binary count is part of the assertion, and is the half worth keeping.** The first draft of the check searched for `headless_shell` when the file is `chrome-headless-shell`, so it probed one binary instead of two and reported a clean result for a binary the specs do not run - `headless: true` in playwright.config.ts means the headless shell is what they use. A missing-library count means nothing without the number of things it looked at.

Tested under `bash -eo pipefail`, which is what Actions uses:

| Case | Expected | Result |
|---|---|---|
| both binaries, no missing libs | exit 0 | pass |
| both binaries, a library missing | **exit 1** | pass |
| only `chrome` present, count short | **exit 1** | pass |
| headless shell under the old wrong name | **exit 1** | pass |
| no binaries found at all | **exit 1** | pass |

The fourth case reproduces the exact mistake above and now fails instead of passing quietly.

`timeout-minutes` is unchanged at 20 - nothing slow is left in the job. The net diff is one step replaced and nothing else.

## Note on how this PR got here

Three commits: a retry that made CI worse, an experiment that measured why and whether the step was needed, and this. Kept rather than squashed away in the branch, because the useful part is the sequence - a plausible fix, a measurement that refuted it, and a smaller change that follows from what was measured. It will squash to one commit on merge.

The transferable bit: the test I wrote before pushing the retry stubbed the command out, so it verified the loop's control flow and was blind to apt's global system state, which is the thing that actually breaks. A stub tests the code around the call, never the call's interaction with the system.
