### PR TITLE
Measure what the blueprint GUI's Grid position field does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -541,28 +541,66 @@ Four things came out of it, and the first is the one to remember.
   capture while the exported entity coordinates moved on each one. Reading only
   the attribute said "nothing is happening" for four rows running, which looked
   exactly like a field the GUI was refusing to write.
-- **`getGridPositionDisplay()` reads centres where the game reads edges**, so it
-  is off by `floor(size/2)` on whichever axis a multi-tile entity sets the
-  minimum. A belt-edged blueprint agrees and an assembler-edged one is a tile
-  out. **The editor stays self-consistent, which is what hides it**:
-  `commitGridPosition` solves for the offset using the same formula it reads
-  back with, so the box always shows what was typed and no round-trip inside the
-  editor can expose it. Only a comparison against the game can.
-- **That last measurement cannot separate the two candidate edges**, and which
-  one it is decides the fix. For `assembling-machine-1` the tile-footprint edge
-  (9.0) and the collision-box edge (about 9.1) floor to the same integer. It
-  needs an entity whose collision box is inset by more than the fractional part.
-  Note `tile_width` is not the field to reach for - #142 established it is a
-  centring parity rather than a size.
+- **`getGridPositionDisplay()` reads centres where the game reads the tile
+  footprint edge**, so it is off by `floor(size/2)` on whichever axis a
+  multi-tile entity sets the minimum. A belt-edged blueprint agrees and an
+  assembler-edged one is a tile out. **The editor stays self-consistent, which
+  is what hides it**: `commitGridPosition` solves for the offset using the same
+  formula it reads back with, so the box always shows what was typed and no
+  round-trip inside the editor can expose it. Only a comparison against the
+  game can.
+- **Which edge took a second run, and the first one could not have answered
+  it.** Run 1 left two readings standing, footprint edge and collision-box
+  edge, because for every entity it placed the two floor to the same integer -
+  `assembling-machine-1` is 9.0 against 9.3. Separating them needs an entity
+  whose box escapes its own footprint, and almost none can: the editor derives
+  a footprint by _ceiling_ the box (`factorioData.ts:617`), so only a declared
+  `tile_width`/`tile_height` overrides that. Five of 155 entities manage it and
+  `half-diagonal-rail` is the only one splitting all three readings on one
+  axis. Run 2 scored two rows and each wrong reading missed by exactly one tile
+  on y in opposite directions: **the footprint edge wins**, and `getEntitySize`
+  already returns it. Note `tile_width` is not the field to reach for directly
+    - #142 established it is a centring parity rather than a size.
+- **A four-way analysis that leaves one survivor can still be wrong, and the
+  fix is to add the reading rather than to re-run.** Run 1 reported a single
+  surviving rule and it was overstated: the candidate that would have tied with
+  it had never been written down, so "one survivor" meant "one of the rules I
+  thought of". Adding the fifth reading made the _same_ data report two, which
+  is the honest answer. **The rival list is part of the instrument.**
 
-Two notes about running it rather than about the game. `control_lua_file` in a
+And a **fourth** thing, which is not about this field at all and is filed as
+#251: `data.json` disagrees with the running game about collision boxes for
+**every rail prototype and nothing else**. Of 155 entities, 139 agree to within
+one 1/256 step - Factorio's position quantum, not a finding - and all 16 that
+exceed it are rails, including each `dummy-` and `elevated-` variant, worst
+case 1.45 tiles on `legacy-curved-rail`, whose runtime box is not even
+symmetric where `data.json` says it is. Measured by
+`tools/oracle/probe-rail-box-orientation/`, a headless run written only to
+check one number a different probe hardcoded. **A control that asks "does the
+number I hardcoded match the game" is worth writing even when you expect it to
+pass.** That same probe also found the rail's box does _not_ rotate with
+direction and that a rail requested at (20,20) is placed at (21,21).
+
+The game also **validates this field three ways and the editor validates it
+none** (#252): it refused Grid position 3,5 on run 2's layout having accepted
+the same 3,5 on run 1's, so the parity rule depends on the blueprint's own
+content. Unmeasured on purpose - that the rules exist and are unimplemented is
+the finding.
+
+Three notes about running it rather than about the game. `control_lua_file` in a
 `probe.json` is **repo-relative and read against the shell's cwd**, not against
 the probe file, so an absolute `--probe` from elsewhere fails naming the Lua
-file rather than the cause; the `SESSION.md` command carries the `cd`. And an
+file rather than the cause; the `SESSION.md` command carries the `cd`. An
 interactive probe **ends when the person stops playing**, so the analyzer emits
 `stepsNotCaptured` - a fixture that simply omits a step reads as "this step does
 not exist" rather than "it was not run", which is the silent cap the method
-warns about.
+warns about. And **a `]]` inside a `--[[` Lua comment closes it**: a probe
+header explaining a collision box in Lua table notation silently turned the
+rest of the file into code, so the mod never registered its `on_init` and the
+run reported "no oracle-dump.json was written" - the same message a
+`factorio_version` mismatch gives. What located it was running the CLI's own
+example probe as a **control**, and the tell in the log is a line that is
+_absent_: a working run prints `Checksum for script __<mod>__/control.lua`.
 
 `tools/oracle/fixtures` is exempt from oxfmt in `vite.config.ts` because of this
 probe: the generator writes `JSON.stringify(x, null, 4)` and oxfmt collapses

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -501,6 +501,75 @@ JS template literal, so **a backtick in a Lua comment closes the template**. A
 matched pair on one line closes it and reopens it, which a scan for odd backtick
 counts cannot see. Cost a debugging round; there is a comment at that spot now.
 
+And what the blueprint GUI's **"Grid position"** field does (reviewing PR #243,
+`tools/oracle/fixtures/blueprint-grid-position-gui.json`), measured on
+**2.0.77** and the first probe here to need a person at the keyboard since the
+zoom one. The rule is `-floor(min corner) = T`, the corner taken over entity
+**edges** and tiles, and it is an **absolute target rather than a relative
+nudge** - setting 8,9 on top of 3,5 moved the corner to -8,-9 and not to
+-11,-14, which is the only thing that separates the two.
+
+**The headline is that this field is not the one above it, and reading the
+paragraph above as though it were is what cost a session.** The panel carries
+**three** X/Y pairs, not two:
+
+```
+☑ Snap to grid
+  Grid size        Width 12   Height 17    <- snap-to-grid
+  Grid position        X 3    Y 5          <- shifts the exported content
+  ● Absolute           X 9    Y 10         <- position-relative-to-grid
+  ○ Relative
+```
+
+Grid position writes **no key at all** into the export; it translates the entity
+and tile coordinates instead, which is why nothing in `runtime-api.json` reaches
+it and why the probe had to be interactive. `blueprint-snapping.json` above
+measured the **Absolute** row. Both fixtures are right and they answer different
+questions - the second carries a `supersedes` block saying so.
+
+Four things came out of it, and the first is the one to remember.
+
+- **When two measurements contradict, look for a name collision before believing
+  either.** The shipped `getGridPositionDisplay()` said grid position moves
+  entities; `blueprint-grid-position.json` scored that premise 0 of 2 on the
+  same 2.0.77. Neither was wrong. **Name the attribute, not the concept**,
+  wherever the game ships a label using the same words -
+  `factorio-oracle/docs/method.md` has this as its own section now, because its
+  PR #222 entry was true of the attribute and read as a refutation of the field.
+- **Decode the export; do not read one API attribute and stop.**
+  `blueprint_position_relative_to_grid` sat unchanged at 9,10 across every
+  capture while the exported entity coordinates moved on each one. Reading only
+  the attribute said "nothing is happening" for four rows running, which looked
+  exactly like a field the GUI was refusing to write.
+- **`getGridPositionDisplay()` reads centres where the game reads edges**, so it
+  is off by `floor(size/2)` on whichever axis a multi-tile entity sets the
+  minimum. A belt-edged blueprint agrees and an assembler-edged one is a tile
+  out. **The editor stays self-consistent, which is what hides it**:
+  `commitGridPosition` solves for the offset using the same formula it reads
+  back with, so the box always shows what was typed and no round-trip inside the
+  editor can expose it. Only a comparison against the game can.
+- **That last measurement cannot separate the two candidate edges**, and which
+  one it is decides the fix. For `assembling-machine-1` the tile-footprint edge
+  (9.0) and the collision-box edge (about 9.1) floor to the same integer. It
+  needs an entity whose collision box is inset by more than the fractional part.
+  Note `tile_width` is not the field to reach for - #142 established it is a
+  centring parity rather than a size.
+
+Two notes about running it rather than about the game. `control_lua_file` in a
+`probe.json` is **repo-relative and read against the shell's cwd**, not against
+the probe file, so an absolute `--probe` from elsewhere fails naming the Lua
+file rather than the cause; the `SESSION.md` command carries the `cd`. And an
+interactive probe **ends when the person stops playing**, so the analyzer emits
+`stepsNotCaptured` - a fixture that simply omits a step reads as "this step does
+not exist" rather than "it was not run", which is the silent cap the method
+warns about.
+
+`tools/oracle/fixtures` is exempt from oxfmt in `vite.config.ts` because of this
+probe: the generator writes `JSON.stringify(x, null, 4)` and oxfmt collapses
+short arrays, so whichever ran last won and the other reported a failure.
+**"Never hand-edit a fixture to make something pass" applies to a formatter as
+much as to a person.**
+
 ## Cloudflare Deployment
 
 The editor is deployed to Cloudflare Workers at https://fbe.factorygamefan.com (custom

--- a/tools/oracle/analyze-blueprint-grid-position-gui.mjs
+++ b/tools/oracle/analyze-blueprint-grid-position-gui.mjs
@@ -59,14 +59,19 @@ const FIXTURE = join(HERE, 'fixtures', 'blueprint-grid-position-gui.json')
  * (`factorioData.ts:617`), so a box cannot escape its own footprint unless a
  * declared `tile_width`/`tile_height` overrides that. Five of the 155 entities
  * in `data.json` manage it, and this is the only one that splits all three
- * readings apart on a single axis: at a centre of y=20 it gives centre 20,
- * footprint edge 19, collision edge 17.764. `offshore-pump` separates the two
+ * readings apart on a single axis: at its snapped centre of y=21 it gives
+ * centre 21, footprint edge 20, collision edge 19.102. `offshore-pump` separates the two
  * edges but not centre from footprint edge, being 1x1.
  */
 const GEOMETRY = {
     'assembling-machine-1': { w: 3, h: 3, box: [-1.2, -1.2] },
     'wooden-chest': { w: 1, h: 1, box: [-0.35, -0.35] },
-    'half-diagonal-rail': { w: 2, h: 2, box: [-0.75, -2.236] },
+    // Measured, not read from data.json. `rail-box-orientation.json` found
+    // that data.json and the 2.0.77 runtime disagree about this box - 2.236
+    // against 1.8984375 - and that all 16 such disagreements across 155
+    // entities are rails. The game is what this probe compares against, so
+    // the game's number is the one that belongs here.
+    'half-diagonal-rail': { w: 2, h: 2, box: [-0.75, -1.8984375] },
 }
 
 /** Names seen in a capture that `GEOMETRY` has no entry for. */

--- a/tools/oracle/analyze-blueprint-grid-position-gui.mjs
+++ b/tools/oracle/analyze-blueprint-grid-position-gui.mjs
@@ -205,6 +205,25 @@ const EXPECTED = {
     'snap-off': { gridPosition: undefined },
 }
 
+/**
+ * What a step was asked to set, for the label given.
+ *
+ * Any `gridpos-<x>-<y>` label is read from its own numbers rather than looked
+ * up, because **the game refuses some values and the session says to
+ * substitute**: the parity rule ("Grid position and blueprint grid position
+ * coordinates need to be either all even or all odd") rejected 3,5 outright on
+ * run 2's layout, having accepted it on run 1's. SESSION.md already told the
+ * operator to use the nearest accepted value and record it, and until now the
+ * analysis could not read anything but the three labels it happened to know -
+ * so following that instruction produced an unscored row and a session that
+ * measured nothing. Negative values are allowed: `gridpos--3-5` is x=-3, y=5.
+ */
+function expectedFor(label) {
+    const m = /^gridpos-(-?\d+)-(-?\d+)$/.exec(label)
+    if (m) return { gridPosition: { x: Number(m[1]), y: Number(m[2]) } }
+    return EXPECTED[label]
+}
+
 function pointsEqual(a, b) {
     if (a === undefined || b === undefined) return a === b
     return a.x === b.x && a.y === b.y
@@ -307,7 +326,7 @@ function main() {
             const entities = asArray(decoded.entities)
             const tiles = asArray(decoded.tiles)
             const readings = corners(entities, tiles)
-            const expected = EXPECTED[row.label]
+            const expected = expectedFor(row.label)
 
             const scored = expected?.gridPosition !== undefined
             const agrees = scored
@@ -373,9 +392,17 @@ function main() {
     // steps do not exist" rather than "these steps were not run" - the silent
     // cap docs/method.md warns about. Named here so a reader can tell a gap
     // from a finding.
-    const stepsNotCaptured = Object.keys(EXPECTED).filter(
-        label => !cases.some(c => c.label === label)
+    const substituted = cases.some(
+        c => c.label.startsWith('gridpos-') && EXPECTED[c.label] === undefined
     )
+    const stepsNotCaptured = Object.keys(EXPECTED).filter(label => {
+        if (cases.some(c => c.label === label)) return false
+        // A refused value means the operator captured `gridpos-4-6` in place of
+        // `gridpos-3-5`. Reporting the asked-for label as "not captured" would
+        // read as a skipped step rather than a substituted one.
+        if (substituted && label.startsWith('gridpos-')) return false
+        return true
+    })
 
     // Pushed here rather than inside scoreControls(), because GEOMETRY coverage is
     // only known once corners() has walked every capture, and that happens

--- a/tools/oracle/analyze-blueprint-grid-position-gui.mjs
+++ b/tools/oracle/analyze-blueprint-grid-position-gui.mjs
@@ -31,17 +31,46 @@ const HERE = dirname(fileURLToPath(import.meta.url))
 const FIXTURE = join(HERE, 'fixtures', 'blueprint-grid-position-gui.json')
 
 /**
- * The three entities this probe's layout uses, and their tile footprints.
+ * The entities this probe's layout uses, and their tile footprints.
+ *
  * Hardcoded rather than read from `data.json`, because the layout is owned by
  * the probe next door rather than discovered: these are the sizes it placed,
  * and a `data.json` that disagreed would mean the exporter had drifted, not
- * that the measurement should change. Cross-checked below when data.json is
- * present, and reported rather than silently trusted.
+ * that the measurement should change.
+ *
+ * A name reaching `corners()` without an entry here used to default to 1x1
+ * silently, which is the worst possible failure for this file: a 1x1 default
+ * puts the edge half a tile from the centre, so `entityEdges*` collapses
+ * towards `entityCentres*` and the discrimination the whole probe exists for
+ * quietly stops working, with `controlsAllPassed: true` and nothing said.
+ * `unsizedEntities` below turns that into a failed control instead. Found by
+ * review on PR #249, and it is not hypothetical - `half-diagonal-rail` was
+ * added to this table and to the layout in the same change, and had it been
+ * missed the run would have reported a clean answer to the wrong question.
+ *
+ * `box` is the prototype's `collision_box`, carried so the *third* candidate
+ * corner can be computed. Run 1 established the corner is read from an edge
+ * rather than a centre, and could not say which edge, because for every entity
+ * it placed the footprint edge and the collision edge floor to the same
+ * integer - `assembling-machine-1` is 9.0 against 9.3.
+ *
+ * `half-diagonal-rail` is what settles it, and it is close to unique. The
+ * editor derives a footprint by *ceiling* the collision box
+ * (`factorioData.ts:617`), so a box cannot escape its own footprint unless a
+ * declared `tile_width`/`tile_height` overrides that. Five of the 155 entities
+ * in `data.json` manage it, and this is the only one that splits all three
+ * readings apart on a single axis: at a centre of y=20 it gives centre 20,
+ * footprint edge 19, collision edge 17.764. `offshore-pump` separates the two
+ * edges but not centre from footprint edge, being 1x1.
  */
-const SIZES = {
-    'assembling-machine-1': { w: 3, h: 3 },
-    'wooden-chest': { w: 1, h: 1 },
+const GEOMETRY = {
+    'assembling-machine-1': { w: 3, h: 3, box: [-1.2, -1.2] },
+    'wooden-chest': { w: 1, h: 1, box: [-0.35, -0.35] },
+    'half-diagonal-rail': { w: 2, h: 2, box: [-0.75, -2.236] },
 }
+
+/** Names seen in a capture that `GEOMETRY` has no entry for. */
+const unsizedEntities = new Set()
 
 function decodeBlueprintString(str) {
     return JSON.parse(inflateSync(Buffer.from(str.slice(1), 'base64')).toString('utf8'))
@@ -66,6 +95,17 @@ function readRunReport(path) {
 }
 
 function readStream(workDir, run) {
+    // The usage guard accepts --work-dir OR --run, so a run report that carries
+    // no `scriptOutput` leaves nothing to join against. Without this, join()
+    // throws ERR_INVALID_ARG_TYPE on undefined and buries the real problem -
+    // a partial or malformed run report - under a stack trace about paths.
+    if (run?.scriptOutput === undefined && workDir === undefined) {
+        throw new Error(
+            'No script-output directory: the run report carries no scriptOutput, ' +
+                'and no --work-dir was given to fall back on. The run probably did ' +
+                'not get far enough to write one.'
+        )
+    }
     const path =
         run?.scriptOutput !== undefined
             ? join(run.scriptOutput, 'grid-position-gui.jsonl')
@@ -92,12 +132,20 @@ function asArray(value) {
     return Array.isArray(value) ? value : []
 }
 
-/** The four readings of "the minimum corner" this probe exists to separate. */
+/** The five readings of "the minimum corner" this probe exists to separate. */
 function corners(entities, tiles) {
     const eCentreX = entities.map(e => e.position.x)
     const eCentreY = entities.map(e => e.position.y)
-    const eEdgeX = entities.map(e => e.position.x - (SIZES[e.name]?.w ?? 1) / 2)
-    const eEdgeY = entities.map(e => e.position.y - (SIZES[e.name]?.h ?? 1) / 2)
+    for (const e of entities) {
+        if (GEOMETRY[e.name] === undefined) unsizedEntities.add(e.name)
+    }
+    const eEdgeX = entities.map(e => e.position.x - (GEOMETRY[e.name]?.w ?? 1) / 2)
+    const eEdgeY = entities.map(e => e.position.y - (GEOMETRY[e.name]?.h ?? 1) / 2)
+    // The collision box's own minimum, which for most entities sits inside the
+    // footprint and floors to the same integer. Where it does not, this is the
+    // reading that tells the two apart.
+    const eBoxX = entities.map(e => e.position.x + (GEOMETRY[e.name]?.box[0] ?? -0.5))
+    const eBoxY = entities.map(e => e.position.y + (GEOMETRY[e.name]?.box[1] ?? -0.5))
     const tX = tiles.map(t => t.position.x)
     const tY = tiles.map(t => t.position.y)
 
@@ -113,6 +161,10 @@ function corners(entities, tiles) {
         entityEdgesAndTiles: {
             x: neg(min([...eEdgeX, ...tX])),
             y: neg(min([...eEdgeY, ...tY])),
+        },
+        entityCollisionEdgesAndTiles: {
+            x: neg(min([...eBoxX, ...tX])),
+            y: neg(min([...eBoxY, ...tY])),
         },
         entityCentresOnly: { x: neg(min(eCentreX)), y: neg(min(eCentreY)) },
         entityEdgesOnly: { x: neg(min(eEdgeX)), y: neg(min(eEdgeY)) },
@@ -162,9 +214,23 @@ function scoreControls(rows) {
     let movedOk = false
     let movedDetail = 'missing the shift control'
     if (base && shifted) {
-        const a = asArray(base.entities).map(e => `${e.position.x},${e.position.y}`)
-        const b = asArray(shifted.entities).map(e => `${e.position.x},${e.position.y}`)
-        movedOk = a.join('|') !== b.join('|')
+        // Read through the *decoded export*, not through `capture()`'s
+        // `entities` field. Those are two different instruments -
+        // `get_blueprint_entities()` and `export_stack()` - and every scored
+        // row below is read from the export. Checking the other one proved the
+        // wrong instrument could see a shift: a stale or unresponsive
+        // `export_stack()` would leave this control passing, `instrument-repeat`
+        // trivially passing on two identical stale exports, and the probe
+        // reporting a confident `survivingReadings: []` with nothing flagged.
+        // The `rival-field` control below already read the export, so this file
+        // disagreed with itself. Found by review on PR #249.
+        const positions = row =>
+            asArray(decodeBlueprintString(row.export).blueprint?.entities).map(
+                e => `${e.position.x},${e.position.y}`
+            )
+        const a = positions(base)
+        const b = positions(shifted)
+        movedOk = a.length > 0 && b.length > 0 && a.join('|') !== b.join('|')
         movedDetail = `baseline ${a.join(' ')} vs script-shifted ${b.join(' ')}`
     }
     out.push({
@@ -293,8 +359,26 @@ function main() {
         label => !cases.some(c => c.label === label)
     )
 
+    // Pushed here rather than inside scoreControls(), because GEOMETRY coverage is
+    // only known once corners() has walked every capture, and that happens
+    // while building `cases` above.
+    controls.push({
+        name: 'every entity in a capture has a known footprint',
+        ok: unsizedEntities.size === 0,
+        detail:
+            unsizedEntities.size === 0
+                ? `all entity names matched GEOMETRY (${Object.keys(GEOMETRY).join(', ')})`
+                : `no footprint for ${[...unsizedEntities].join(', ')} - the edge readings ` +
+                  `for these defaulted to 1x1 and collapsed towards the centre readings, ` +
+                  `so the numbers below cannot separate edges from centres`,
+    })
+
     const fixture = {
         probe: 'probe-blueprint-grid-position-gui/control.lua',
+        // What was on the ground, read from the run's own setup emit rather
+        // than from the probe's current LAYOUT constant. A fixture measured
+        // against one layout must not read as though it described a later one.
+        layout: setup?.layout,
         runner: 'factorio-oracle run --probe tools/oracle/probe-blueprint-grid-position-gui/probe.json',
         question:
             'What does the blueprint GUI\'s "Grid position" field do to an exported blueprint string?',
@@ -328,9 +412,15 @@ function main() {
         rivalReadings: {
             entityCentresAndTiles:
                 'what packages/editor/src/core/Blueprint.ts getGridPositionDisplay() ships',
-            entityEdgesAndTiles: 'the same, reading entity edges rather than centres',
+            entityEdgesAndTiles:
+                "the same, reading the edge of an entity's tile footprint rather than its centre",
+            entityCollisionEdgesAndTiles:
+                "the same again, reading the edge of the entity's collision_box. " +
+                'Indistinguishable from entityEdgesAndTiles unless the layout holds an ' +
+                'entity whose box escapes its own footprint, which is why run 1 could ' +
+                'not separate them and left both standing',
             entityCentresOnly: 'entities only, tiles ignored',
-            entityEdgesOnly: 'entities only, edges',
+            entityEdgesOnly: 'entities only, footprint edges',
         },
         controls,
         controlsAllPassed: controls.every(c => c.ok),

--- a/tools/oracle/analyze-blueprint-grid-position-gui.mjs
+++ b/tools/oracle/analyze-blueprint-grid-position-gui.mjs
@@ -284,6 +284,15 @@ function main() {
             }))
     })()
 
+    // Which steps the session never reached. An interactive probe ends when the
+    // person stops playing, so a fixture that simply omits them reads as "these
+    // steps do not exist" rather than "these steps were not run" - the silent
+    // cap docs/method.md warns about. Named here so a reader can tell a gap
+    // from a finding.
+    const stepsNotCaptured = Object.keys(EXPECTED).filter(
+        label => !cases.some(c => c.label === label)
+    )
+
     const fixture = {
         probe: 'probe-blueprint-grid-position-gui/control.lua',
         runner: 'factorio-oracle run --probe tools/oracle/probe-blueprint-grid-position-gui/probe.json',
@@ -327,6 +336,7 @@ function main() {
         controlsAllPassed: controls.every(c => c.ok),
         survivingReadings: survivors ?? 'unmeasured - no scored step was captured',
         scoredRows: scoredCases.length,
+        stepsNotCaptured,
         movedRelativeToUntouched,
         notes,
         cases,

--- a/tools/oracle/analyze-blueprint-grid-position-gui.mjs
+++ b/tools/oracle/analyze-blueprint-grid-position-gui.mjs
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+/**
+ * Scores what the blueprint GUI's "Grid position" field did, from the capture
+ * stream `probe-blueprint-grid-position-gui/control.lua` wrote.
+ *
+ * The split is issue #235's: `factorio-oracle` ran the game and handed back a
+ * work directory; this half is the analysis, and it stays here because it
+ * compares the game against *this editor's own* reimplementation, which only
+ * makes sense in this repo's terms.
+ *
+ * Usage:
+ *   node tools/oracle/analyze-blueprint-grid-position-gui.mjs <work-dir> [options]
+ *
+ *     --run <report.json>   the JSON `factorio-oracle run` printed. Preferred:
+ *                           it names the script-output directory outright, and
+ *                           carries the binary path, the Factorio version and
+ *                           the mods that actually loaded, so the fixture's
+ *                           provenance is read rather than asserted.
+ *     --write-fixture       write fixtures/blueprint-grid-position-gui.json
+ *
+ * Without `--run`, the capture stream is looked for at the conventional
+ * `<work-dir>/write/script-output/grid-position-gui.jsonl`.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { inflateSync } from 'node:zlib'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const FIXTURE = join(HERE, 'fixtures', 'blueprint-grid-position-gui.json')
+
+/**
+ * The three entities this probe's layout uses, and their tile footprints.
+ * Hardcoded rather than read from `data.json`, because the layout is owned by
+ * the probe next door rather than discovered: these are the sizes it placed,
+ * and a `data.json` that disagreed would mean the exporter had drifted, not
+ * that the measurement should change. Cross-checked below when data.json is
+ * present, and reported rather than silently trusted.
+ */
+const SIZES = {
+    'assembling-machine-1': { w: 3, h: 3 },
+    'wooden-chest': { w: 1, h: 1 },
+}
+
+function decodeBlueprintString(str) {
+    return JSON.parse(inflateSync(Buffer.from(str.slice(1), 'base64')).toString('utf8'))
+}
+
+/**
+ * Provenance the runner recorded, rather than anything this script inferred.
+ * Returns undefined when no run report was passed, in which case the fixture
+ * says so instead of carrying a guess - a fixture's provenance is a record of
+ * the moment it was captured, and a plausible-looking blank is worse than an
+ * admitted one.
+ */
+function readRunReport(path) {
+    if (path === undefined) return undefined
+    const report = JSON.parse(readFileSync(path, 'utf8'))
+    return {
+        scriptOutput: report.scriptOutput,
+        binaryPath: report.provenance?.binaryPath,
+        factorioVersion: report.provenance?.factorioVersion,
+        loadedMods: report.loadedMods,
+    }
+}
+
+function readStream(workDir, run) {
+    const path =
+        run?.scriptOutput !== undefined
+            ? join(run.scriptOutput, 'grid-position-gui.jsonl')
+            : join(workDir, 'write', 'script-output', 'grid-position-gui.jsonl')
+    if (!existsSync(path)) {
+        throw new Error(
+            `No capture stream at ${path}.\n` +
+                `Did the run reach the game? An interactive run writes nothing until ` +
+                `the mod loads, and a factorio_version mismatch skips the mod in silence.`
+        )
+    }
+    return readFileSync(path, 'utf8')
+        .split('\n')
+        .filter(line => line.trim() !== '')
+        .map(line => JSON.parse(line))
+}
+
+/**
+ * Lua's JSON encoder writes an empty table as `{}`, so a blueprint with no
+ * tiles arrives as an object rather than an array - the same trap
+ * `factorioData.ts` documents for `data.json`, one layer out.
+ */
+function asArray(value) {
+    return Array.isArray(value) ? value : []
+}
+
+/** The four readings of "the minimum corner" this probe exists to separate. */
+function corners(entities, tiles) {
+    const eCentreX = entities.map(e => e.position.x)
+    const eCentreY = entities.map(e => e.position.y)
+    const eEdgeX = entities.map(e => e.position.x - (SIZES[e.name]?.w ?? 1) / 2)
+    const eEdgeY = entities.map(e => e.position.y - (SIZES[e.name]?.h ?? 1) / 2)
+    const tX = tiles.map(t => t.position.x)
+    const tY = tiles.map(t => t.position.y)
+
+    const min = xs => (xs.length === 0 ? undefined : Math.min(...xs))
+    const neg = v => (v === undefined ? undefined : -Math.floor(v))
+
+    return {
+        // What packages/editor/src/core/Blueprint.ts ships today.
+        entityCentresAndTiles: {
+            x: neg(min([...eCentreX, ...tX])),
+            y: neg(min([...eCentreY, ...tY])),
+        },
+        entityEdgesAndTiles: {
+            x: neg(min([...eEdgeX, ...tX])),
+            y: neg(min([...eEdgeY, ...tY])),
+        },
+        entityCentresOnly: { x: neg(min(eCentreX)), y: neg(min(eCentreY)) },
+        entityEdgesOnly: { x: neg(min(eEdgeX)), y: neg(min(eEdgeY)) },
+    }
+}
+
+/**
+ * What each labelled step was asked to set, so a row can be scored rather than
+ * merely displayed. Keys match the labels control.lua prints in its on-screen
+ * instructions; anything else is carried through unscored rather than guessed
+ * at, which is what #133 item 4 asks for.
+ */
+const EXPECTED = {
+    untouched: { gridPosition: undefined },
+    'snap-on': { gridPosition: undefined },
+    'gridpos-3-5': { gridPosition: { x: 3, y: 5 } },
+    'gridpos-8-9': { gridPosition: { x: 8, y: 9 } },
+    'gridpos-0-0': { gridPosition: { x: 0, y: 0 } },
+    'abs-2-6': { gridPosition: { x: 0, y: 0 }, positionRelativeToGrid: { x: 2, y: 6 } },
+    'snap-off': { gridPosition: undefined },
+}
+
+function pointsEqual(a, b) {
+    if (a === undefined || b === undefined) return a === b
+    return a.x === b.x && a.y === b.y
+}
+
+function scoreControls(rows) {
+    const byLabel = new Map(rows.filter(r => r.kind === 'capture').map(r => [r.label, r]))
+    const out = []
+
+    const r1 = byLabel.get('control-instrument-repeat-1')
+    const r2 = byLabel.get('control-instrument-repeat-2')
+    out.push({
+        name: 'instrument: two captures with nothing changed are identical',
+        ok: Boolean(r1 && r2 && r1.export === r2.export),
+        detail:
+            r1 && r2
+                ? r1.export === r2.export
+                    ? 'exports byte-identical'
+                    : 'exports DIFFER with no change made - every "it moved" row below is void'
+                : 'missing one or both repeat captures',
+    })
+
+    const base = r1
+    const shifted = byLabel.get('control-positive-shift')
+    let movedOk = false
+    let movedDetail = 'missing the shift control'
+    if (base && shifted) {
+        const a = asArray(base.entities).map(e => `${e.position.x},${e.position.y}`)
+        const b = asArray(shifted.entities).map(e => `${e.position.x},${e.position.y}`)
+        movedOk = a.join('|') !== b.join('|')
+        movedDetail = `baseline ${a.join(' ')} vs script-shifted ${b.join(' ')}`
+    }
+    out.push({
+        name: 'positive control: the comparison can see a shift at all',
+        ok: movedOk,
+        detail: movedDetail,
+    })
+
+    const rival = byLabel.get('control-rival-field')
+    let rivalOk = false
+    let rivalDetail = 'missing the rival-field control'
+    if (rival) {
+        const bp = decodeBlueprintString(rival.export).blueprint ?? {}
+        rivalOk = pointsEqual(bp['position-relative-to-grid'], { x: 3, y: 5 })
+        rivalDetail =
+            `script set position_relative_to_grid={3,5}; export carries ` +
+            `${JSON.stringify(bp['position-relative-to-grid'])}, ` +
+            `absolute-snapping=${JSON.stringify(bp['absolute-snapping'])}, ` +
+            `snap-to-grid=${JSON.stringify(bp['snap-to-grid'])}`
+    }
+    out.push({
+        name: 'rival field: the neighbouring field is reachable and does serialize',
+        ok: rivalOk,
+        detail: rivalDetail,
+    })
+
+    return out
+}
+
+function main() {
+    const argv = process.argv.slice(2)
+    const flags = argv.filter(a => a.startsWith('--'))
+    const positional = argv.filter(a => !a.startsWith('--'))
+    const runIndex = argv.indexOf('--run')
+    const runPath = runIndex === -1 ? undefined : argv[runIndex + 1]
+    const workDir = positional.find(p => p !== runPath)
+
+    if (workDir === undefined && runPath === undefined) {
+        console.error(
+            'usage: node tools/oracle/analyze-blueprint-grid-position-gui.mjs <work-dir> ' +
+                '[--run <report.json>] [--write-fixture]'
+        )
+        process.exit(2)
+    }
+
+    const run = readRunReport(runPath)
+    const rows = readStream(workDir, run)
+    const setup = rows.find(r => r.kind === 'setup')
+    const notes = rows.filter(r => r.kind === 'note').map(r => r.text)
+    const controls = scoreControls(rows)
+
+    const cases = rows
+        .filter(r => r.kind === 'capture' && r.tag === 'human')
+        .map(row => {
+            const decoded = decodeBlueprintString(row.export).blueprint ?? {}
+            const entities = asArray(decoded.entities)
+            const tiles = asArray(decoded.tiles)
+            const readings = corners(entities, tiles)
+            const expected = EXPECTED[row.label]
+
+            const scored = expected?.gridPosition !== undefined
+            const agrees = scored
+                ? Object.fromEntries(
+                      Object.entries(readings).map(([k, v]) => [
+                          k,
+                          pointsEqual(v, expected.gridPosition),
+                      ])
+                  )
+                : undefined
+
+            return {
+                label: row.label,
+                typedGridPosition: expected?.gridPosition,
+                scored,
+                exportedKeys: {
+                    'snap-to-grid': decoded['snap-to-grid'],
+                    'absolute-snapping': decoded['absolute-snapping'],
+                    'position-relative-to-grid': decoded['position-relative-to-grid'],
+                },
+                exportedEntityPositions: entities.map(e => ({
+                    name: e.name,
+                    x: e.position.x,
+                    y: e.position.y,
+                })),
+                exportedTilePositions: tiles.map(t => ({ x: t.position.x, y: t.position.y })),
+                minCornerReadings: readings,
+                agrees,
+            }
+        })
+
+    // docs/method.md: report the rules that survive *every* row, not the one
+    // that fits the last result.
+    //
+    // The zero-row case is handled separately and deliberately. `every()` on an
+    // empty list is true, so a session that captured no scored step would
+    // report all four readings as surviving - four confident answers drawn from
+    // no evidence, which is the exact shape of a control that cannot fail. A
+    // session that got no further than the controls has measured nothing, and
+    // has to say so.
+    const scoredCases = cases.filter(c => c.scored)
+    const readingNames = Object.keys(corners([], []))
+    const survivors =
+        scoredCases.length === 0
+            ? undefined
+            : readingNames.filter(name => scoredCases.every(c => c.agrees?.[name] === true))
+
+    const movedRelativeToUntouched = (() => {
+        const baseline = cases.find(c => c.label === 'untouched')
+        if (!baseline) return undefined
+        return cases
+            .filter(c => c !== baseline)
+            .map(c => ({
+                label: c.label,
+                moved:
+                    JSON.stringify(c.exportedEntityPositions) !==
+                    JSON.stringify(baseline.exportedEntityPositions),
+            }))
+    })()
+
+    const fixture = {
+        probe: 'probe-blueprint-grid-position-gui/control.lua',
+        runner: 'factorio-oracle run --probe tools/oracle/probe-blueprint-grid-position-gui/probe.json',
+        question:
+            'What does the blueprint GUI\'s "Grid position" field do to an exported blueprint string?',
+        issue: '#235 (shared oracle CLI), reviewing PR #243',
+        provenance: {
+            capturedOn: new Date().toISOString().slice(0, 10),
+            method: 'interactive: a person drove the blueprint GUI, the mod captured after each step',
+            binary: run?.binaryPath ?? 'unrecorded - re-run the analysis with --run <report.json>',
+            factorioVersion:
+                run?.factorioVersion ?? 'unrecorded - re-run the analysis with --run <report.json>',
+            loadedMods: run?.loadedMods,
+            // What the mod itself saw, which is not the same list: per
+            // factorio-oracle's gotchas, `script.active_mods` never reports
+            // `core`, so the two disagreeing by exactly that is expected.
+            activeModsSeenByMod: setup?.active_mods,
+            evidence: 'captured',
+            caveat:
+                'The GUI field has no scripting API on 2.0.77 (runtime-api.json exposes only ' +
+                'blueprint_snap_to_grid, blueprint_absolute_snapping and ' +
+                'blueprint_position_relative_to_grid), so this cannot be re-captured headlessly.',
+        },
+        supersedes: {
+            fixture: 'blueprint-grid-position.json',
+            why:
+                "That capture set blueprint_position_relative_to_grid, which the game's own " +
+                'locale separates from this field in one line - core.cfg:274, "Grid position and ' +
+                'blueprint grid position coordinates need to be either all even or all odd". Its ' +
+                'answer is about the neighbouring field and stands; it is not an answer to this ' +
+                'question.',
+        },
+        rivalReadings: {
+            entityCentresAndTiles:
+                'what packages/editor/src/core/Blueprint.ts getGridPositionDisplay() ships',
+            entityEdgesAndTiles: 'the same, reading entity edges rather than centres',
+            entityCentresOnly: 'entities only, tiles ignored',
+            entityEdgesOnly: 'entities only, edges',
+        },
+        controls,
+        controlsAllPassed: controls.every(c => c.ok),
+        survivingReadings: survivors ?? 'unmeasured - no scored step was captured',
+        scoredRows: scoredCases.length,
+        movedRelativeToUntouched,
+        notes,
+        cases,
+    }
+
+    const json = JSON.stringify(fixture, null, 4)
+
+    if (flags.includes('--write-fixture')) {
+        writeFileSync(FIXTURE, json + '\n')
+        console.log(`wrote ${FIXTURE}`)
+    } else {
+        console.log(json)
+    }
+
+    if (!fixture.controlsAllPassed) {
+        console.error(
+            '\nA control failed. Per docs/method.md, record the section its control voids as ' +
+                'unmeasured rather than reading the numbers as a finding.'
+        )
+        process.exit(1)
+    }
+}
+
+main()

--- a/tools/oracle/analyze-blueprint-grid-position-gui.mjs
+++ b/tools/oracle/analyze-blueprint-grid-position-gui.mjs
@@ -90,6 +90,19 @@ function decodeBlueprintString(str) {
  */
 function readRunReport(path) {
     if (path === undefined) return undefined
+    // A missing report is the ordinary mistake, not a corrupt one: running the
+    // analysis before the probe, or after a run that never reached the game.
+    // Without this it surfaces as a raw ENOENT stack trace out of node:fs,
+    // which names the path and nothing about what to do. Measured: it happened
+    // the first time run 2 was attempted.
+    if (!existsSync(path)) {
+        throw new Error(
+            `No run report at ${path}.\n` +
+                `That file is written by \`factorio-oracle run\`, so this usually means ` +
+                `the probe has not been run yet - the analysis is step 3 of SESSION.md, ` +
+                `not step 1.`
+        )
+    }
     const report = JSON.parse(readFileSync(path, 'utf8'))
     return {
         scriptOutput: report.scriptOutput,

--- a/tools/oracle/analyze-rail-box-orientation.mjs
+++ b/tools/oracle/analyze-rail-box-orientation.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * Scores the `probe-rail-box-orientation` dump.
+ *
+ * Two questions, and the second one grew out of the first.
+ *
+ * 1. Does a `half-diagonal-rail` have the box the grid-position probe's run 2
+ *    layout assumes, at the orientation it assumes? That layout depends on one
+ *    rail producing three distinct floors on the y axis, and a rotated box
+ *    would silently collapse them.
+ * 2. Does `data.json` agree with the running game about collision boxes at
+ *    all? The per-rail check needed a control - "the number the analyzer
+ *    hardcodes must match the game" - and running it across all 155 entities
+ *    costs nothing extra once the dump is in hand.
+ *
+ * Usage:
+ *   node tools/oracle/analyze-rail-box-orientation.mjs <dump.json> [--write-fixture]
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const FIXTURE = join(HERE, 'fixtures', 'rail-box-orientation.json')
+const DATA_JSON = join(HERE, '..', '..', 'packages', 'exporter', 'data', 'output', 'data.json')
+
+/**
+ * Factorio stores positions in 1/256 of a tile, so a runtime `collision_box`
+ * is the declared one snapped to that grid. Any difference at or below one
+ * step is representation rather than disagreement, and lumping the two
+ * together would bury 16 real findings under 139 uninteresting ones.
+ */
+const QUANTUM = 1 / 256
+
+const dumpPath = process.argv[2]
+if (dumpPath === undefined || dumpPath.startsWith('--')) {
+    console.error('usage: analyze-rail-box-orientation.mjs <dump.json> [--write-fixture]')
+    process.exit(2)
+}
+const dump = JSON.parse(readFileSync(dumpPath, 'utf8'))
+const fd = JSON.parse(readFileSync(DATA_JSON, 'utf8')).entities
+
+const box = b => [b.left_top.x, b.left_top.y, b.right_bottom.x, b.right_bottom.y]
+
+const placed = dump.directions.filter(d => d.created)
+const boxes = placed.map(d => JSON.stringify(box(d.bounding_box)))
+const positions = placed.map(d => `${d.position.x},${d.position.y}`)
+
+const quantised = []
+const disagreements = []
+for (const [name, e] of Object.entries(fd)) {
+    const declared = e.collision_box
+    const runtime = dump.all_collision_boxes?.[name]
+    if (declared === undefined || runtime === undefined) continue
+    const a = [declared[0][0], declared[0][1], declared[1][0], declared[1][1]]
+    const deviation = Math.max(...a.map((v, i) => Math.abs(v - runtime[i])))
+    if (deviation <= QUANTUM) quantised.push({ name, deviation })
+    else disagreements.push({ name, deviation, dataJson: a, runtime })
+}
+disagreements.sort((x, y) => y.deviation - x.deviation)
+
+const controls = [
+    {
+        name: 'every direction produced a placement',
+        ok: placed.length === dump.directions.length,
+        detail: `${placed.length} of ${dump.directions.length} directions created an entity`,
+    },
+    {
+        // Without this the "it does not rotate" finding is unfalsifiable: a
+        // probe that only ever placed one orientation would report the same
+        // single box and look just as clean.
+        name: 'the sweep covered more than one stored direction',
+        ok: new Set(placed.map(d => d.stored_direction)).size > 1,
+        detail: `stored directions seen: ${[...new Set(placed.map(d => d.stored_direction))].sort((a, b) => a - b).join(', ')}`,
+    },
+    {
+        name: 'the probe recorded no Lua errors',
+        ok: (dump.errors?.length ?? 0) === 0,
+        detail: `${dump.errors?.length ?? 0} errors`,
+    },
+]
+
+const fixture = {
+    question:
+        "Does a half-diagonal-rail's collision box rotate with direction, and does data.json agree with the running game about collision boxes?",
+    probe: 'probe-rail-box-orientation/control.lua',
+    runner: 'factorio-oracle run --probe tools/oracle/probe-rail-box-orientation/probe.json',
+    issue: 'de-risking run 2 of probe-blueprint-grid-position-gui; bears on PR #243 finding 15',
+    provenance: {
+        capturedOn: new Date().toISOString().slice(0, 10),
+        method: 'headless create run; no player needed, so no interactive session',
+        factorioVersion: '2.0.77',
+        activeModsSeenByMod: dump.active_mods,
+    },
+    controls,
+    controlsAllPassed: controls.every(c => c.ok),
+    findings: {
+        boxRotatesWithDirection: new Set(boxes).size > 1,
+        distinctBoxesAcrossAllDirections: new Set(boxes).size,
+        snapsAwayFromTheRequestedPosition:
+            new Set(positions).size === 1 && positions[0] !== '20,20',
+        requestedPosition: dump.requested_position,
+        actualPosition: placed[0]?.position,
+        storedDirections: [...new Set(placed.map(d => d.stored_direction))].sort((a, b) => a - b),
+        runtimeCollisionBox: box(dump.directions.find(d => d.created).bounding_box),
+        prototypeCollisionBox: dump.prototype_collision_box,
+    },
+    dataJsonVersusRuntime: {
+        // The headline: the disagreement is not general, it is rails.
+        entitiesCompared: quantised.length + disagreements.length,
+        agreeWithinOneQuantum: quantised.length,
+        quantum: QUANTUM,
+        worstQuantisedDeviation: Math.max(...quantised.map(q => q.deviation)),
+        disagreeBeyondQuantisation: disagreements.length,
+        allDisagreementsAreRails: disagreements.every(d => d.name.includes('rail')),
+        disagreements,
+    },
+}
+
+const json = JSON.stringify(fixture, null, 4)
+if (process.argv.includes('--write-fixture')) {
+    writeFileSync(FIXTURE, json + '\n')
+    console.log(`wrote ${FIXTURE}`)
+} else {
+    console.log(json)
+}
+if (!fixture.controlsAllPassed) {
+    console.error('\nA control failed. The numbers above are void rather than a finding.')
+    process.exit(1)
+}

--- a/tools/oracle/fixtures/blueprint-grid-position-gui.json
+++ b/tools/oracle/fixtures/blueprint-grid-position-gui.json
@@ -1,5 +1,49 @@
 {
     "probe": "probe-blueprint-grid-position-gui/control.lua",
+    "layout": {
+        "entities": [
+            {
+                "name": "assembling-machine-1",
+                "position": {
+                    "x": 10.5,
+                    "y": 20.5
+                }
+            },
+            {
+                "name": "wooden-chest",
+                "position": {
+                    "x": 20.5,
+                    "y": 20.5
+                }
+            },
+            {
+                "name": "wooden-chest",
+                "position": {
+                    "x": 20.5,
+                    "y": 26.5
+                }
+            }
+        ],
+        "tiles": [
+            {
+                "x": 14,
+                "y": 10
+            },
+            {
+                "x": 15,
+                "y": 10
+            },
+            {
+                "x": 14,
+                "y": 11
+            },
+            {
+                "x": 15,
+                "y": 11
+            }
+        ],
+        "tile_name": "stone-path"
+    },
     "runner": "factorio-oracle run --probe tools/oracle/probe-blueprint-grid-position-gui/probe.json",
     "question": "What does the blueprint GUI's \"Grid position\" field do to an exported blueprint string?",
     "issue": "#235 (shared oracle CLI), reviewing PR #243",
@@ -31,9 +75,10 @@
     },
     "rivalReadings": {
         "entityCentresAndTiles": "what packages/editor/src/core/Blueprint.ts getGridPositionDisplay() ships",
-        "entityEdgesAndTiles": "the same, reading entity edges rather than centres",
+        "entityEdgesAndTiles": "the same, reading the edge of an entity's tile footprint rather than its centre",
+        "entityCollisionEdgesAndTiles": "the same again, reading the edge of the entity's collision_box. Indistinguishable from entityEdgesAndTiles unless the layout holds an entity whose box escapes its own footprint, which is why run 1 could not separate them and left both standing",
         "entityCentresOnly": "entities only, tiles ignored",
-        "entityEdgesOnly": "entities only, edges"
+        "entityEdgesOnly": "entities only, footprint edges"
     },
     "controls": [
         {
@@ -50,11 +95,17 @@
             "name": "rival field: the neighbouring field is reachable and does serialize",
             "ok": true,
             "detail": "script set position_relative_to_grid={3,5}; export carries {\"x\":3,\"y\":5}, absolute-snapping=true, snap-to-grid={\"x\":4,\"y\":4}"
+        },
+        {
+            "name": "every entity in a capture has a known footprint",
+            "ok": true,
+            "detail": "all entity names matched GEOMETRY (assembling-machine-1, wooden-chest, half-diagonal-rail)"
         }
     ],
     "controlsAllPassed": true,
     "survivingReadings": [
-        "entityEdgesAndTiles"
+        "entityEdgesAndTiles",
+        "entityCollisionEdgesAndTiles"
     ],
     "scoredRows": 3,
     "stepsNotCaptured": [
@@ -133,6 +184,10 @@
                     "x": -9,
                     "y": -10
                 },
+                "entityCollisionEdgesAndTiles": {
+                    "x": -9,
+                    "y": -10
+                },
                 "entityCentresOnly": {
                     "x": -10,
                     "y": -20
@@ -198,6 +253,10 @@
                     "y": 0
                 },
                 "entityEdgesAndTiles": {
+                    "x": 0,
+                    "y": 0
+                },
+                "entityCollisionEdgesAndTiles": {
                     "x": 0,
                     "y": 0
                 },
@@ -273,6 +332,10 @@
                     "x": 3,
                     "y": 5
                 },
+                "entityCollisionEdgesAndTiles": {
+                    "x": 3,
+                    "y": 5
+                },
                 "entityCentresOnly": {
                     "x": 2,
                     "y": -5
@@ -285,6 +348,7 @@
             "agrees": {
                 "entityCentresAndTiles": false,
                 "entityEdgesAndTiles": true,
+                "entityCollisionEdgesAndTiles": true,
                 "entityCentresOnly": false,
                 "entityEdgesOnly": false
             }
@@ -351,6 +415,10 @@
                     "x": 8,
                     "y": 9
                 },
+                "entityCollisionEdgesAndTiles": {
+                    "x": 8,
+                    "y": 9
+                },
                 "entityCentresOnly": {
                     "x": 7,
                     "y": -1
@@ -363,6 +431,7 @@
             "agrees": {
                 "entityCentresAndTiles": false,
                 "entityEdgesAndTiles": true,
+                "entityCollisionEdgesAndTiles": true,
                 "entityCentresOnly": false,
                 "entityEdgesOnly": false
             }
@@ -429,6 +498,10 @@
                     "x": 0,
                     "y": 0
                 },
+                "entityCollisionEdgesAndTiles": {
+                    "x": 0,
+                    "y": 0
+                },
                 "entityCentresOnly": {
                     "x": -1,
                     "y": -10
@@ -441,6 +514,7 @@
             "agrees": {
                 "entityCentresAndTiles": false,
                 "entityEdgesAndTiles": true,
+                "entityCollisionEdgesAndTiles": true,
                 "entityCentresOnly": false,
                 "entityEdgesOnly": false
             }
@@ -500,6 +574,10 @@
                     "y": 5
                 },
                 "entityEdgesAndTiles": {
+                    "x": 3,
+                    "y": 5
+                },
+                "entityCollisionEdgesAndTiles": {
                     "x": 3,
                     "y": 5
                 },

--- a/tools/oracle/fixtures/blueprint-grid-position-gui.json
+++ b/tools/oracle/fixtures/blueprint-grid-position-gui.json
@@ -3,43 +3,50 @@
     "layout": {
         "entities": [
             {
+                "name": "half-diagonal-rail",
+                "position": {
+                    "x": 21,
+                    "y": 21
+                }
+            },
+            {
                 "name": "assembling-machine-1",
                 "position": {
                     "x": 10.5,
-                    "y": 20.5
+                    "y": 30.5
                 }
             },
             {
                 "name": "wooden-chest",
                 "position": {
                     "x": 20.5,
-                    "y": 20.5
+                    "y": 30.5
                 }
             },
             {
                 "name": "wooden-chest",
                 "position": {
                     "x": 20.5,
-                    "y": 26.5
+                    "y": 36.5
                 }
             }
         ],
         "tiles": [
             {
-                "x": 14,
-                "y": 10
+                "x": 2,
+                "y": 30
             },
             {
-                "x": 15,
-                "y": 10
+                "x": 3,
+                "y": 30
             },
             {
-                "x": 14,
-                "y": 11
+                "x": 2,
+                "y": 31
             },
             {
-                "x": 15,
-                "y": 11
+                "x": 3,
+                "y": 31
             }
         ],
         "tile_name": "stone-path"
@@ -89,7 +96,7 @@
         {
             "name": "positive control: the comparison can see a shift at all",
             "ok": true,
-            "detail": "baseline 10.5,20.5 20.5,20.5 20.5,26.5 vs script-shifted 7.5,16.5 17.5,16.5 17.5,22.5"
+            "detail": "baseline 21,21 10.5,30.5 20.5,30.5 20.5,36.5 vs script-shifted 19,17 7.5,26.5 17.5,26.5 17.5,32.5"
         },
         {
             "name": "rival field: the neighbouring field is reachable and does serialize",
@@ -104,491 +111,269 @@
     ],
     "controlsAllPassed": true,
     "survivingReadings": [
-        "entityEdgesAndTiles",
-        "entityCollisionEdgesAndTiles"
+        "entityEdgesAndTiles"
     ],
-    "scoredRows": 3,
+    "scoredRows": 2,
     "stepsNotCaptured": [
+        "untouched",
         "abs-2-6",
         "snap-off"
     ],
-    "movedRelativeToUntouched": [
-        {
-            "label": "snap-on",
-            "moved": true
-        },
-        {
-            "label": "gridpos-3-5",
-            "moved": true
-        },
-        {
-            "label": "gridpos-8-9",
-            "moved": true
-        },
-        {
-            "label": "gridpos-0-0",
-            "moved": true
-        },
-        {
-            "label": "gridpos-3-5-saved",
-            "moved": true
-        }
+    "notes": [
+        "game refused Grid position 3,5 on run 2 layout: parity rule, all even or all odd. Run 1 accepted 3,5."
     ],
-    "notes": [],
     "cases": [
-        {
-            "label": "untouched",
-            "scored": false,
-            "exportedKeys": {},
-            "exportedEntityPositions": [
-                {
-                    "name": "assembling-machine-1",
-                    "x": 10.5,
-                    "y": 20.5
-                },
-                {
-                    "name": "wooden-chest",
-                    "x": 20.5,
-                    "y": 20.5
-                },
-                {
-                    "name": "wooden-chest",
-                    "x": 20.5,
-                    "y": 26.5
-                }
-            ],
-            "exportedTilePositions": [
-                {
-                    "x": 14,
-                    "y": 10
-                },
-                {
-                    "x": 15,
-                    "y": 10
-                },
-                {
-                    "x": 14,
-                    "y": 11
-                },
-                {
-                    "x": 15,
-                    "y": 11
-                }
-            ],
-            "minCornerReadings": {
-                "entityCentresAndTiles": {
-                    "x": -10,
-                    "y": -10
-                },
-                "entityEdgesAndTiles": {
-                    "x": -9,
-                    "y": -10
-                },
-                "entityCollisionEdgesAndTiles": {
-                    "x": -9,
-                    "y": -10
-                },
-                "entityCentresOnly": {
-                    "x": -10,
-                    "y": -20
-                },
-                "entityEdgesOnly": {
-                    "x": -9,
-                    "y": -19
-                }
-            }
-        },
         {
             "label": "snap-on",
             "scored": false,
             "exportedKeys": {
                 "snap-to-grid": {
-                    "x": 12,
-                    "y": 17
+                    "x": 20,
+                    "y": 18
                 },
                 "absolute-snapping": true,
                 "position-relative-to-grid": {
-                    "x": 9,
-                    "y": 10
+                    "x": 2,
+                    "y": 2
                 }
             },
             "exportedEntityPositions": [
                 {
+                    "name": "half-diagonal-rail",
+                    "x": 19,
+                    "y": 1
+                },
+                {
                     "name": "assembling-machine-1",
-                    "x": 1.5,
+                    "x": 8.5,
                     "y": 10.5
                 },
                 {
                     "name": "wooden-chest",
-                    "x": 11.5,
+                    "x": 18.5,
                     "y": 10.5
                 },
                 {
                     "name": "wooden-chest",
-                    "x": 11.5,
+                    "x": 18.5,
                     "y": 16.5
                 }
             ],
             "exportedTilePositions": [
                 {
-                    "x": 5,
-                    "y": 0
+                    "x": 0,
+                    "y": 10
                 },
                 {
-                    "x": 6,
-                    "y": 0
+                    "x": 1,
+                    "y": 10
                 },
                 {
-                    "x": 5,
+                    "x": 0,
+                    "y": 11
+                },
+                {
+                    "x": 1,
+                    "y": 11
+                }
+            ],
+            "minCornerReadings": {
+                "entityCentresAndTiles": {
+                    "x": 0,
+                    "y": -1
+                },
+                "entityEdgesAndTiles": {
+                    "x": 0,
+                    "y": 0
+                },
+                "entityCollisionEdgesAndTiles": {
+                    "x": 0,
                     "y": 1
                 },
-                {
-                    "x": 6,
-                    "y": 1
-                }
-            ],
-            "minCornerReadings": {
-                "entityCentresAndTiles": {
-                    "x": -1,
-                    "y": 0
-                },
-                "entityEdgesAndTiles": {
-                    "x": 0,
-                    "y": 0
-                },
-                "entityCollisionEdgesAndTiles": {
-                    "x": 0,
-                    "y": 0
-                },
                 "entityCentresOnly": {
-                    "x": -1,
-                    "y": -10
-                },
-                "entityEdgesOnly": {
-                    "x": 0,
-                    "y": -9
-                }
-            }
-        },
-        {
-            "label": "gridpos-3-5",
-            "typedGridPosition": {
-                "x": 3,
-                "y": 5
-            },
-            "scored": true,
-            "exportedKeys": {
-                "snap-to-grid": {
-                    "x": 12,
-                    "y": 17
-                },
-                "absolute-snapping": true,
-                "position-relative-to-grid": {
-                    "x": 9,
-                    "y": 10
-                }
-            },
-            "exportedEntityPositions": [
-                {
-                    "name": "assembling-machine-1",
-                    "x": -1.5,
-                    "y": 5.5
-                },
-                {
-                    "name": "wooden-chest",
-                    "x": 8.5,
-                    "y": 5.5
-                },
-                {
-                    "name": "wooden-chest",
-                    "x": 8.5,
-                    "y": 11.5
-                }
-            ],
-            "exportedTilePositions": [
-                {
-                    "x": 2,
-                    "y": -5
-                },
-                {
-                    "x": 3,
-                    "y": -5
-                },
-                {
-                    "x": 2,
-                    "y": -4
-                },
-                {
-                    "x": 3,
-                    "y": -4
-                }
-            ],
-            "minCornerReadings": {
-                "entityCentresAndTiles": {
-                    "x": 2,
-                    "y": 5
-                },
-                "entityEdgesAndTiles": {
-                    "x": 3,
-                    "y": 5
-                },
-                "entityCollisionEdgesAndTiles": {
-                    "x": 3,
-                    "y": 5
-                },
-                "entityCentresOnly": {
-                    "x": 2,
-                    "y": -5
-                },
-                "entityEdgesOnly": {
-                    "x": 3,
-                    "y": -4
-                }
-            },
-            "agrees": {
-                "entityCentresAndTiles": false,
-                "entityEdgesAndTiles": true,
-                "entityCollisionEdgesAndTiles": true,
-                "entityCentresOnly": false,
-                "entityEdgesOnly": false
-            }
-        },
-        {
-            "label": "gridpos-8-9",
-            "typedGridPosition": {
-                "x": 8,
-                "y": 9
-            },
-            "scored": true,
-            "exportedKeys": {
-                "snap-to-grid": {
-                    "x": 12,
-                    "y": 17
-                },
-                "absolute-snapping": true,
-                "position-relative-to-grid": {
-                    "x": 9,
-                    "y": 10
-                }
-            },
-            "exportedEntityPositions": [
-                {
-                    "name": "assembling-machine-1",
-                    "x": -6.5,
-                    "y": 1.5
-                },
-                {
-                    "name": "wooden-chest",
-                    "x": 3.5,
-                    "y": 1.5
-                },
-                {
-                    "name": "wooden-chest",
-                    "x": 3.5,
-                    "y": 7.5
-                }
-            ],
-            "exportedTilePositions": [
-                {
-                    "x": -3,
-                    "y": -9
-                },
-                {
-                    "x": -2,
-                    "y": -9
-                },
-                {
-                    "x": -3,
-                    "y": -8
-                },
-                {
-                    "x": -2,
-                    "y": -8
-                }
-            ],
-            "minCornerReadings": {
-                "entityCentresAndTiles": {
-                    "x": 7,
-                    "y": 9
-                },
-                "entityEdgesAndTiles": {
-                    "x": 8,
-                    "y": 9
-                },
-                "entityCollisionEdgesAndTiles": {
-                    "x": 8,
-                    "y": 9
-                },
-                "entityCentresOnly": {
-                    "x": 7,
+                    "x": -8,
                     "y": -1
                 },
                 "entityEdgesOnly": {
-                    "x": 8,
+                    "x": -7,
                     "y": 0
                 }
-            },
-            "agrees": {
-                "entityCentresAndTiles": false,
-                "entityEdgesAndTiles": true,
-                "entityCollisionEdgesAndTiles": true,
-                "entityCentresOnly": false,
-                "entityEdgesOnly": false
             }
         },
         {
-            "label": "gridpos-0-0",
+            "label": "gridpos-2-6",
             "typedGridPosition": {
-                "x": 0,
-                "y": 0
+                "x": 2,
+                "y": 6
             },
             "scored": true,
             "exportedKeys": {
                 "snap-to-grid": {
-                    "x": 12,
-                    "y": 17
+                    "x": 20,
+                    "y": 18
                 },
                 "absolute-snapping": true,
                 "position-relative-to-grid": {
-                    "x": 9,
-                    "y": 10
+                    "x": 2,
+                    "y": 2
                 }
             },
             "exportedEntityPositions": [
                 {
+                    "name": "half-diagonal-rail",
+                    "x": 17,
+                    "y": -5
+                },
+                {
                     "name": "assembling-machine-1",
-                    "x": 1.5,
-                    "y": 10.5
+                    "x": 6.5,
+                    "y": 4.5
                 },
                 {
                     "name": "wooden-chest",
-                    "x": 11.5,
-                    "y": 10.5
+                    "x": 16.5,
+                    "y": 4.5
                 },
                 {
                     "name": "wooden-chest",
-                    "x": 11.5,
-                    "y": 16.5
+                    "x": 16.5,
+                    "y": 10.5
                 }
             ],
             "exportedTilePositions": [
                 {
-                    "x": 5,
-                    "y": 0
+                    "x": -2,
+                    "y": 4
                 },
                 {
-                    "x": 6,
-                    "y": 0
+                    "x": -1,
+                    "y": 4
                 },
                 {
-                    "x": 5,
-                    "y": 1
+                    "x": -2,
+                    "y": 5
                 },
                 {
-                    "x": 6,
-                    "y": 1
+                    "x": -1,
+                    "y": 5
                 }
             ],
             "minCornerReadings": {
                 "entityCentresAndTiles": {
-                    "x": -1,
-                    "y": 0
+                    "x": 2,
+                    "y": 5
                 },
                 "entityEdgesAndTiles": {
-                    "x": 0,
-                    "y": 0
+                    "x": 2,
+                    "y": 6
                 },
                 "entityCollisionEdgesAndTiles": {
-                    "x": 0,
-                    "y": 0
+                    "x": 2,
+                    "y": 7
                 },
                 "entityCentresOnly": {
-                    "x": -1,
-                    "y": -10
+                    "x": -6,
+                    "y": 5
                 },
                 "entityEdgesOnly": {
-                    "x": 0,
-                    "y": -9
+                    "x": -5,
+                    "y": 6
                 }
             },
             "agrees": {
                 "entityCentresAndTiles": false,
                 "entityEdgesAndTiles": true,
-                "entityCollisionEdgesAndTiles": true,
+                "entityCollisionEdgesAndTiles": false,
                 "entityCentresOnly": false,
                 "entityEdgesOnly": false
             }
         },
         {
-            "label": "gridpos-3-5-saved",
-            "scored": false,
+            "label": "gridpos-8-10",
+            "typedGridPosition": {
+                "x": 8,
+                "y": 10
+            },
+            "scored": true,
             "exportedKeys": {
                 "snap-to-grid": {
-                    "x": 12,
-                    "y": 17
+                    "x": 20,
+                    "y": 18
                 },
                 "absolute-snapping": true,
                 "position-relative-to-grid": {
-                    "x": 9,
-                    "y": 10
+                    "x": 2,
+                    "y": 2
                 }
             },
             "exportedEntityPositions": [
                 {
+                    "name": "half-diagonal-rail",
+                    "x": 11,
+                    "y": -9
+                },
+                {
                     "name": "assembling-machine-1",
-                    "x": -1.5,
-                    "y": 5.5
+                    "x": 0.5,
+                    "y": 0.5
                 },
                 {
                     "name": "wooden-chest",
-                    "x": 8.5,
-                    "y": 5.5
+                    "x": 10.5,
+                    "y": 0.5
                 },
                 {
                     "name": "wooden-chest",
-                    "x": 8.5,
-                    "y": 11.5
+                    "x": 10.5,
+                    "y": 6.5
                 }
             ],
             "exportedTilePositions": [
                 {
-                    "x": 2,
-                    "y": -5
+                    "x": -8,
+                    "y": 0
                 },
                 {
-                    "x": 3,
-                    "y": -5
+                    "x": -7,
+                    "y": 0
                 },
                 {
-                    "x": 2,
-                    "y": -4
+                    "x": -8,
+                    "y": 1
                 },
                 {
-                    "x": 3,
-                    "y": -4
+                    "x": -7,
+                    "y": 1
                 }
             ],
             "minCornerReadings": {
                 "entityCentresAndTiles": {
-                    "x": 2,
-                    "y": 5
+                    "x": 8,
+                    "y": 9
                 },
                 "entityEdgesAndTiles": {
-                    "x": 3,
-                    "y": 5
+                    "x": 8,
+                    "y": 10
                 },
                 "entityCollisionEdgesAndTiles": {
-                    "x": 3,
-                    "y": 5
+                    "x": 8,
+                    "y": 11
                 },
                 "entityCentresOnly": {
-                    "x": 2,
-                    "y": -5
+                    "x": 0,
+                    "y": 9
                 },
                 "entityEdgesOnly": {
-                    "x": 3,
-                    "y": -4
+                    "x": 1,
+                    "y": 10
                 }
+            },
+            "agrees": {
+                "entityCentresAndTiles": false,
+                "entityEdgesAndTiles": true,
+                "entityCollisionEdgesAndTiles": false,
+                "entityCentresOnly": false,
+                "entityEdgesOnly": false
             }
         }
     ]

--- a/tools/oracle/fixtures/blueprint-grid-position-gui.json
+++ b/tools/oracle/fixtures/blueprint-grid-position-gui.json
@@ -1,0 +1,517 @@
+{
+    "probe": "probe-blueprint-grid-position-gui/control.lua",
+    "runner": "factorio-oracle run --probe tools/oracle/probe-blueprint-grid-position-gui/probe.json",
+    "question": "What does the blueprint GUI's \"Grid position\" field do to an exported blueprint string?",
+    "issue": "#235 (shared oracle CLI), reviewing PR #243",
+    "provenance": {
+        "capturedOn": "2026-08-21",
+        "method": "interactive: a person drove the blueprint GUI, the mod captured after each step",
+        "binary": "/Users/ericjohnson/GitHub/factorio-oracle/installs/factorio-2.0.77.app/Contents/MacOS/factorio",
+        "factorioVersion": "2.0.77",
+        "loadedMods": [
+            "base",
+            "core",
+            "elevated-rails",
+            "quality",
+            "space-age"
+        ],
+        "activeModsSeenByMod": {
+            "base": "2.0.77",
+            "bp_grid_position_gui": "0.0.1",
+            "elevated-rails": "2.0.77",
+            "quality": "2.0.77",
+            "space-age": "2.0.77"
+        },
+        "evidence": "captured",
+        "caveat": "The GUI field has no scripting API on 2.0.77 (runtime-api.json exposes only blueprint_snap_to_grid, blueprint_absolute_snapping and blueprint_position_relative_to_grid), so this cannot be re-captured headlessly."
+    },
+    "supersedes": {
+        "fixture": "blueprint-grid-position.json",
+        "why": "That capture set blueprint_position_relative_to_grid, which the game's own locale separates from this field in one line - core.cfg:274, \"Grid position and blueprint grid position coordinates need to be either all even or all odd\". Its answer is about the neighbouring field and stands; it is not an answer to this question."
+    },
+    "rivalReadings": {
+        "entityCentresAndTiles": "what packages/editor/src/core/Blueprint.ts getGridPositionDisplay() ships",
+        "entityEdgesAndTiles": "the same, reading entity edges rather than centres",
+        "entityCentresOnly": "entities only, tiles ignored",
+        "entityEdgesOnly": "entities only, edges"
+    },
+    "controls": [
+        {
+            "name": "instrument: two captures with nothing changed are identical",
+            "ok": true,
+            "detail": "exports byte-identical"
+        },
+        {
+            "name": "positive control: the comparison can see a shift at all",
+            "ok": true,
+            "detail": "baseline 10.5,20.5 20.5,20.5 20.5,26.5 vs script-shifted 7.5,16.5 17.5,16.5 17.5,22.5"
+        },
+        {
+            "name": "rival field: the neighbouring field is reachable and does serialize",
+            "ok": true,
+            "detail": "script set position_relative_to_grid={3,5}; export carries {\"x\":3,\"y\":5}, absolute-snapping=true, snap-to-grid={\"x\":4,\"y\":4}"
+        }
+    ],
+    "controlsAllPassed": true,
+    "survivingReadings": [
+        "entityEdgesAndTiles"
+    ],
+    "scoredRows": 3,
+    "stepsNotCaptured": [
+        "abs-2-6",
+        "snap-off"
+    ],
+    "movedRelativeToUntouched": [
+        {
+            "label": "snap-on",
+            "moved": true
+        },
+        {
+            "label": "gridpos-3-5",
+            "moved": true
+        },
+        {
+            "label": "gridpos-8-9",
+            "moved": true
+        },
+        {
+            "label": "gridpos-0-0",
+            "moved": true
+        },
+        {
+            "label": "gridpos-3-5-saved",
+            "moved": true
+        }
+    ],
+    "notes": [],
+    "cases": [
+        {
+            "label": "untouched",
+            "scored": false,
+            "exportedKeys": {},
+            "exportedEntityPositions": [
+                {
+                    "name": "assembling-machine-1",
+                    "x": 10.5,
+                    "y": 20.5
+                },
+                {
+                    "name": "wooden-chest",
+                    "x": 20.5,
+                    "y": 20.5
+                },
+                {
+                    "name": "wooden-chest",
+                    "x": 20.5,
+                    "y": 26.5
+                }
+            ],
+            "exportedTilePositions": [
+                {
+                    "x": 14,
+                    "y": 10
+                },
+                {
+                    "x": 15,
+                    "y": 10
+                },
+                {
+                    "x": 14,
+                    "y": 11
+                },
+                {
+                    "x": 15,
+                    "y": 11
+                }
+            ],
+            "minCornerReadings": {
+                "entityCentresAndTiles": {
+                    "x": -10,
+                    "y": -10
+                },
+                "entityEdgesAndTiles": {
+                    "x": -9,
+                    "y": -10
+                },
+                "entityCentresOnly": {
+                    "x": -10,
+                    "y": -20
+                },
+                "entityEdgesOnly": {
+                    "x": -9,
+                    "y": -19
+                }
+            }
+        },
+        {
+            "label": "snap-on",
+            "scored": false,
+            "exportedKeys": {
+                "snap-to-grid": {
+                    "x": 12,
+                    "y": 17
+                },
+                "absolute-snapping": true,
+                "position-relative-to-grid": {
+                    "x": 9,
+                    "y": 10
+                }
+            },
+            "exportedEntityPositions": [
+                {
+                    "name": "assembling-machine-1",
+                    "x": 1.5,
+                    "y": 10.5
+                },
+                {
+                    "name": "wooden-chest",
+                    "x": 11.5,
+                    "y": 10.5
+                },
+                {
+                    "name": "wooden-chest",
+                    "x": 11.5,
+                    "y": 16.5
+                }
+            ],
+            "exportedTilePositions": [
+                {
+                    "x": 5,
+                    "y": 0
+                },
+                {
+                    "x": 6,
+                    "y": 0
+                },
+                {
+                    "x": 5,
+                    "y": 1
+                },
+                {
+                    "x": 6,
+                    "y": 1
+                }
+            ],
+            "minCornerReadings": {
+                "entityCentresAndTiles": {
+                    "x": -1,
+                    "y": 0
+                },
+                "entityEdgesAndTiles": {
+                    "x": 0,
+                    "y": 0
+                },
+                "entityCentresOnly": {
+                    "x": -1,
+                    "y": -10
+                },
+                "entityEdgesOnly": {
+                    "x": 0,
+                    "y": -9
+                }
+            }
+        },
+        {
+            "label": "gridpos-3-5",
+            "typedGridPosition": {
+                "x": 3,
+                "y": 5
+            },
+            "scored": true,
+            "exportedKeys": {
+                "snap-to-grid": {
+                    "x": 12,
+                    "y": 17
+                },
+                "absolute-snapping": true,
+                "position-relative-to-grid": {
+                    "x": 9,
+                    "y": 10
+                }
+            },
+            "exportedEntityPositions": [
+                {
+                    "name": "assembling-machine-1",
+                    "x": -1.5,
+                    "y": 5.5
+                },
+                {
+                    "name": "wooden-chest",
+                    "x": 8.5,
+                    "y": 5.5
+                },
+                {
+                    "name": "wooden-chest",
+                    "x": 8.5,
+                    "y": 11.5
+                }
+            ],
+            "exportedTilePositions": [
+                {
+                    "x": 2,
+                    "y": -5
+                },
+                {
+                    "x": 3,
+                    "y": -5
+                },
+                {
+                    "x": 2,
+                    "y": -4
+                },
+                {
+                    "x": 3,
+                    "y": -4
+                }
+            ],
+            "minCornerReadings": {
+                "entityCentresAndTiles": {
+                    "x": 2,
+                    "y": 5
+                },
+                "entityEdgesAndTiles": {
+                    "x": 3,
+                    "y": 5
+                },
+                "entityCentresOnly": {
+                    "x": 2,
+                    "y": -5
+                },
+                "entityEdgesOnly": {
+                    "x": 3,
+                    "y": -4
+                }
+            },
+            "agrees": {
+                "entityCentresAndTiles": false,
+                "entityEdgesAndTiles": true,
+                "entityCentresOnly": false,
+                "entityEdgesOnly": false
+            }
+        },
+        {
+            "label": "gridpos-8-9",
+            "typedGridPosition": {
+                "x": 8,
+                "y": 9
+            },
+            "scored": true,
+            "exportedKeys": {
+                "snap-to-grid": {
+                    "x": 12,
+                    "y": 17
+                },
+                "absolute-snapping": true,
+                "position-relative-to-grid": {
+                    "x": 9,
+                    "y": 10
+                }
+            },
+            "exportedEntityPositions": [
+                {
+                    "name": "assembling-machine-1",
+                    "x": -6.5,
+                    "y": 1.5
+                },
+                {
+                    "name": "wooden-chest",
+                    "x": 3.5,
+                    "y": 1.5
+                },
+                {
+                    "name": "wooden-chest",
+                    "x": 3.5,
+                    "y": 7.5
+                }
+            ],
+            "exportedTilePositions": [
+                {
+                    "x": -3,
+                    "y": -9
+                },
+                {
+                    "x": -2,
+                    "y": -9
+                },
+                {
+                    "x": -3,
+                    "y": -8
+                },
+                {
+                    "x": -2,
+                    "y": -8
+                }
+            ],
+            "minCornerReadings": {
+                "entityCentresAndTiles": {
+                    "x": 7,
+                    "y": 9
+                },
+                "entityEdgesAndTiles": {
+                    "x": 8,
+                    "y": 9
+                },
+                "entityCentresOnly": {
+                    "x": 7,
+                    "y": -1
+                },
+                "entityEdgesOnly": {
+                    "x": 8,
+                    "y": 0
+                }
+            },
+            "agrees": {
+                "entityCentresAndTiles": false,
+                "entityEdgesAndTiles": true,
+                "entityCentresOnly": false,
+                "entityEdgesOnly": false
+            }
+        },
+        {
+            "label": "gridpos-0-0",
+            "typedGridPosition": {
+                "x": 0,
+                "y": 0
+            },
+            "scored": true,
+            "exportedKeys": {
+                "snap-to-grid": {
+                    "x": 12,
+                    "y": 17
+                },
+                "absolute-snapping": true,
+                "position-relative-to-grid": {
+                    "x": 9,
+                    "y": 10
+                }
+            },
+            "exportedEntityPositions": [
+                {
+                    "name": "assembling-machine-1",
+                    "x": 1.5,
+                    "y": 10.5
+                },
+                {
+                    "name": "wooden-chest",
+                    "x": 11.5,
+                    "y": 10.5
+                },
+                {
+                    "name": "wooden-chest",
+                    "x": 11.5,
+                    "y": 16.5
+                }
+            ],
+            "exportedTilePositions": [
+                {
+                    "x": 5,
+                    "y": 0
+                },
+                {
+                    "x": 6,
+                    "y": 0
+                },
+                {
+                    "x": 5,
+                    "y": 1
+                },
+                {
+                    "x": 6,
+                    "y": 1
+                }
+            ],
+            "minCornerReadings": {
+                "entityCentresAndTiles": {
+                    "x": -1,
+                    "y": 0
+                },
+                "entityEdgesAndTiles": {
+                    "x": 0,
+                    "y": 0
+                },
+                "entityCentresOnly": {
+                    "x": -1,
+                    "y": -10
+                },
+                "entityEdgesOnly": {
+                    "x": 0,
+                    "y": -9
+                }
+            },
+            "agrees": {
+                "entityCentresAndTiles": false,
+                "entityEdgesAndTiles": true,
+                "entityCentresOnly": false,
+                "entityEdgesOnly": false
+            }
+        },
+        {
+            "label": "gridpos-3-5-saved",
+            "scored": false,
+            "exportedKeys": {
+                "snap-to-grid": {
+                    "x": 12,
+                    "y": 17
+                },
+                "absolute-snapping": true,
+                "position-relative-to-grid": {
+                    "x": 9,
+                    "y": 10
+                }
+            },
+            "exportedEntityPositions": [
+                {
+                    "name": "assembling-machine-1",
+                    "x": -1.5,
+                    "y": 5.5
+                },
+                {
+                    "name": "wooden-chest",
+                    "x": 8.5,
+                    "y": 5.5
+                },
+                {
+                    "name": "wooden-chest",
+                    "x": 8.5,
+                    "y": 11.5
+                }
+            ],
+            "exportedTilePositions": [
+                {
+                    "x": 2,
+                    "y": -5
+                },
+                {
+                    "x": 3,
+                    "y": -5
+                },
+                {
+                    "x": 2,
+                    "y": -4
+                },
+                {
+                    "x": 3,
+                    "y": -4
+                }
+            ],
+            "minCornerReadings": {
+                "entityCentresAndTiles": {
+                    "x": 2,
+                    "y": 5
+                },
+                "entityEdgesAndTiles": {
+                    "x": 3,
+                    "y": 5
+                },
+                "entityCentresOnly": {
+                    "x": 2,
+                    "y": -5
+                },
+                "entityEdgesOnly": {
+                    "x": 3,
+                    "y": -4
+                }
+            }
+        }
+    ]
+}

--- a/tools/oracle/fixtures/rail-box-orientation.json
+++ b/tools/oracle/fixtures/rail-box-orientation.json
@@ -1,0 +1,337 @@
+{
+    "question": "Does a half-diagonal-rail's collision box rotate with direction, and does data.json agree with the running game about collision boxes?",
+    "probe": "probe-rail-box-orientation/control.lua",
+    "runner": "factorio-oracle run --probe tools/oracle/probe-rail-box-orientation/probe.json",
+    "issue": "de-risking run 2 of probe-blueprint-grid-position-gui; bears on PR #243 finding 15",
+    "provenance": {
+        "capturedOn": "2026-08-21",
+        "method": "headless create run; no player needed, so no interactive session",
+        "factorioVersion": "2.0.77",
+        "activeModsSeenByMod": {
+            "base": "2.0.77",
+            "elevated-rails": "2.0.77",
+            "quality": "2.0.77",
+            "rail_box_orientation": "0.0.1",
+            "space-age": "2.0.77"
+        }
+    },
+    "controls": [
+        {
+            "name": "every direction produced a placement",
+            "ok": true,
+            "detail": "16 of 16 directions created an entity"
+        },
+        {
+            "name": "the sweep covered more than one stored direction",
+            "ok": true,
+            "detail": "stored directions seen: 0, 2, 4, 6"
+        },
+        {
+            "name": "the probe recorded no Lua errors",
+            "ok": true,
+            "detail": "0 errors"
+        }
+    ],
+    "controlsAllPassed": true,
+    "findings": {
+        "boxRotatesWithDirection": false,
+        "distinctBoxesAcrossAllDirections": 1,
+        "snapsAwayFromTheRequestedPosition": true,
+        "requestedPosition": {
+            "x": 20,
+            "y": 20
+        },
+        "actualPosition": {
+            "x": 21,
+            "y": 21
+        },
+        "storedDirections": [
+            0,
+            2,
+            4,
+            6
+        ],
+        "runtimeCollisionBox": [
+            20.25,
+            19.1015625,
+            21.75,
+            22.8984375
+        ],
+        "prototypeCollisionBox": {
+            "left_top": {
+                "y": -1.8984375,
+                "x": -0.75
+            },
+            "right_bottom": {
+                "y": 1.8984375,
+                "x": 0.75
+            }
+        }
+    },
+    "dataJsonVersusRuntime": {
+        "entitiesCompared": 155,
+        "agreeWithinOneQuantum": 139,
+        "quantum": 0.00390625,
+        "worstQuantisedDeviation": 0.00374999999999992,
+        "disagreeBeyondQuantisation": 16,
+        "allDisagreementsAreRails": true,
+        "disagreements": [
+            {
+                "name": "legacy-curved-rail",
+                "deviation": 1.453125,
+                "dataJson": [
+                    -2,
+                    -2,
+                    2,
+                    2
+                ],
+                "runtime": [
+                    -0.75,
+                    -0.546875,
+                    0.75,
+                    1.59765625
+                ]
+            },
+            {
+                "name": "half-diagonal-rail",
+                "deviation": 0.3375625000000002,
+                "dataJson": [
+                    -0.75,
+                    -2.236,
+                    0.75,
+                    2.236
+                ],
+                "runtime": [
+                    -0.75,
+                    -1.8984375,
+                    0.75,
+                    1.8984375
+                ]
+            },
+            {
+                "name": "dummy-elevated-half-diagonal-rail",
+                "deviation": 0.3375625000000002,
+                "dataJson": [
+                    -0.75,
+                    -2.236,
+                    0.75,
+                    2.236
+                ],
+                "runtime": [
+                    -0.75,
+                    -1.8984375,
+                    0.75,
+                    1.8984375
+                ]
+            },
+            {
+                "name": "elevated-half-diagonal-rail",
+                "deviation": 0.3375625000000002,
+                "dataJson": [
+                    -0.75,
+                    -2.236,
+                    0.75,
+                    2.236
+                ],
+                "runtime": [
+                    -0.75,
+                    -1.8984375,
+                    0.75,
+                    1.8984375
+                ]
+            },
+            {
+                "name": "legacy-straight-rail",
+                "deviation": 0.30078125,
+                "dataJson": [
+                    -1,
+                    -1,
+                    1,
+                    1
+                ],
+                "runtime": [
+                    -0.69921875,
+                    -0.98828125,
+                    0.69921875,
+                    0.98828125
+                ]
+            },
+            {
+                "name": "straight-rail",
+                "deviation": 0.30078125,
+                "dataJson": [
+                    -1,
+                    -1,
+                    1,
+                    1
+                ],
+                "runtime": [
+                    -0.69921875,
+                    -0.98828125,
+                    0.69921875,
+                    0.98828125
+                ]
+            },
+            {
+                "name": "dummy-elevated-straight-rail",
+                "deviation": 0.30078125,
+                "dataJson": [
+                    -1,
+                    -1,
+                    1,
+                    1
+                ],
+                "runtime": [
+                    -0.69921875,
+                    -0.98828125,
+                    0.69921875,
+                    0.98828125
+                ]
+            },
+            {
+                "name": "elevated-straight-rail",
+                "deviation": 0.30078125,
+                "dataJson": [
+                    -1,
+                    -1,
+                    1,
+                    1
+                ],
+                "runtime": [
+                    -0.69921875,
+                    -0.98828125,
+                    0.69921875,
+                    0.98828125
+                ]
+            },
+            {
+                "name": "dummy-rail-ramp",
+                "deviation": 0.20234375000000004,
+                "dataJson": [
+                    -1.8,
+                    -7.8,
+                    1.8,
+                    7.8
+                ],
+                "runtime": [
+                    -1.59765625,
+                    -7.59765625,
+                    1.59765625,
+                    7.59765625
+                ]
+            },
+            {
+                "name": "rail-ramp",
+                "deviation": 0.20234375000000004,
+                "dataJson": [
+                    -1.8,
+                    -7.8,
+                    1.8,
+                    7.8
+                ],
+                "runtime": [
+                    -1.59765625,
+                    -7.59765625,
+                    1.59765625,
+                    7.59765625
+                ]
+            },
+            {
+                "name": "curved-rail-a",
+                "deviation": 0.05078125,
+                "dataJson": [
+                    -0.75,
+                    -2.516,
+                    0.75,
+                    2.516
+                ],
+                "runtime": [
+                    -0.69921875,
+                    -2.515625,
+                    0.69921875,
+                    2.515625
+                ]
+            },
+            {
+                "name": "dummy-elevated-curved-rail-a",
+                "deviation": 0.05078125,
+                "dataJson": [
+                    -0.75,
+                    -2.516,
+                    0.75,
+                    2.516
+                ],
+                "runtime": [
+                    -0.69921875,
+                    -2.515625,
+                    0.69921875,
+                    2.515625
+                ]
+            },
+            {
+                "name": "elevated-curved-rail-a",
+                "deviation": 0.05078125,
+                "dataJson": [
+                    -0.75,
+                    -2.516,
+                    0.75,
+                    2.516
+                ],
+                "runtime": [
+                    -0.69921875,
+                    -2.515625,
+                    0.69921875,
+                    2.515625
+                ]
+            },
+            {
+                "name": "curved-rail-b",
+                "deviation": 0.05078125,
+                "dataJson": [
+                    -0.75,
+                    -2.441,
+                    0.75,
+                    2.441
+                ],
+                "runtime": [
+                    -0.69921875,
+                    -2.4375,
+                    0.69921875,
+                    2.4375
+                ]
+            },
+            {
+                "name": "dummy-elevated-curved-rail-b",
+                "deviation": 0.05078125,
+                "dataJson": [
+                    -0.75,
+                    -2.441,
+                    0.75,
+                    2.441
+                ],
+                "runtime": [
+                    -0.69921875,
+                    -2.4375,
+                    0.69921875,
+                    2.4375
+                ]
+            },
+            {
+                "name": "elevated-curved-rail-b",
+                "deviation": 0.05078125,
+                "dataJson": [
+                    -0.75,
+                    -2.441,
+                    0.75,
+                    2.441
+                ],
+                "runtime": [
+                    -0.69921875,
+                    -2.4375,
+                    0.69921875,
+                    2.4375
+                ]
+            }
+        ]
+    }
+}

--- a/tools/oracle/probe-blueprint-grid-position-gui/README.md
+++ b/tools/oracle/probe-blueprint-grid-position-gui/README.md
@@ -47,17 +47,42 @@ There is no script that can set it. "No headless probe can reach it" is not
 
 ## What the layout is for
 
-One capture separates three readings of "the minimum corner" at once, by
-putting each on a different axis.
+Each axis answers one question, because each axis's corner is set by exactly
+one thing. Run 1 needed two questions. Run 2 needs three, so one axis carries
+two of them.
+
+**Run 1** (the committed fixture's `layout`):
 
 | Axis | Decided by                                    | Separates                                                 |
 | ---- | --------------------------------------------- | --------------------------------------------------------- |
 | x    | a 3x3 assembling machine at 10.5              | entity **centres** (floor 10) against **edges** (floor 9) |
 | y    | a tile at y=10, six tiles clear of everything | whether **tiles** count towards the corner at all         |
 
-The editor's formula reads centres and includes tiles. Its own doc comment
-admits the footprint half is untested, because every case measured so far used
-1x1 entities where centre-floor and edge-floor agree. This is that case.
+Both were answered: the corner reads edges, and tiles do count. What run 1
+could not say is **which** edge - a tile footprint edge or a `collision_box`
+edge - because for every entity it placed the two floor to the same integer.
+`assembling-machine-1` is 9.0 against 9.3.
+
+**Run 2** replaces the assembling machine with a `half-diagonal-rail`, which is
+close to the only entity that can settle it:
+
+| Axis | Decided by                     | Separates                                                  |
+| ---- | ------------------------------ | ---------------------------------------------------------- |
+| y    | a `half-diagonal-rail` at y=20 | centre **20**, footprint edge **19**, box edge **17.764**  |
+| x    | stone-path tiles at x=2        | whether tiles count, against the nearest entity reading, 9 |
+
+The editor derives a footprint by _ceiling_ the collision box
+(`factorioData.ts:617`), so a box cannot escape its own footprint unless a
+declared `tile_width`/`tile_height` overrides it. Five of the 155 entities in
+`data.json` manage that, and this is the only one splitting all three readings
+apart on one axis. `offshore-pump` is the near miss: it separates the two edges
+on both axes but not centre from footprint edge, being 1x1.
+
+**The rail is this layout's risk, and a known one.** `data.json` carries one box
+orientation, and half-diagonal rails exist only at diagonal orientations, so a
+rail stored at a rotated direction makes the numbers above wrong. That surfaces
+as y readings matching none of the three predictions, which the recorded
+`layout` and per-case `minCornerReadings` make visible. It is not silent.
 
 The content deliberately does not start at the origin, and the session asks for
 a second change on top of a first, because "an absolute target" and "a relative
@@ -118,7 +143,7 @@ Press `~` for the console. The steps, which the game will also print:
 3. Set **Grid position** to X=3 Y=5, close. `/gp-cap gridpos-3-5`
 4. Set **Grid position** to X=8 Y=9, close. `/gp-cap gridpos-8-9`
 5. Set **Grid position** back to X=0 Y=0, close. `/gp-cap gridpos-0-0`
-6. Pick **Absolute**, set its own X=2 Y=6, close. `/gp-cap abs-2-6`
+6. On the **Absolute** row set X=2 Y=6 (it is already picked), close. `/gp-cap abs-2-6`
 7. Untick **Snap to grid**, close. `/gp-cap snap-off`
 
 Step 4 is the one that separates a target from a nudge. Do not skip it.

--- a/tools/oracle/probe-blueprint-grid-position-gui/README.md
+++ b/tools/oracle/probe-blueprint-grid-position-gui/README.md
@@ -1,0 +1,153 @@
+# What does the blueprint GUI's "Grid position" field do?
+
+The first probe here to run on the shared `factorio-oracle` CLI (issue #235),
+and the first that needs a person at the keyboard since the zoom probe.
+
+## The question
+
+PR #243 ships a `getGridPositionDisplay()` in `packages/editor/src/core/Blueprint.ts`
+built on this rule:
+
+> Setting Grid position to `T` shifts the exported content so that
+> `-floor(min position over entities and tiles)` equals `T`, and writes no
+> snapping field.
+
+`tools/oracle/fixtures/blueprint-grid-position.json` appears to refute that. It
+scores the "grid position moves entities" premise **0 of 2**, with
+`entitiesMovedOn: 0`, measured on 2.0.77 - the version this editor targets.
+`factorio-oracle/docs/method.md` cites it as settled.
+
+Both cannot be right about the same field, and they are not about the same
+field. The earlier capture set `blueprint_position_relative_to_grid`. The game's
+own locale separates the two concepts in a single line:
+
+```
+core.cfg:274  grid-position-and-absolute-position-need-to-match=
+              Grid position and blueprint grid position coordinates need to be
+              either all even or all odd.
+```
+
+So the old fixture measured the neighbour. Its answer stands and is not an
+answer to this question.
+
+## Why a person has to drive it
+
+Checked before choosing the expensive route, per `docs/order-of-attack.md`.
+
+- `LuaItemCommon` on 2.0.77 exposes exactly three blueprint snapping
+  attributes - `blueprint_snap_to_grid`, `blueprint_absolute_snapping` and
+  `blueprint_position_relative_to_grid`. None is this field.
+- `create_blueprint` takes no anchor parameter.
+- The game's own tooltip says how the field is set:
+  `grid-position-tooltip=SHIFT + LEFT-CLICK in the preview to change the grid
+  position.`
+
+There is no script that can set it. "No headless probe can reach it" is not
+"not worth measuring".
+
+## What the layout is for
+
+One capture separates three readings of "the minimum corner" at once, by
+putting each on a different axis.
+
+| Axis | Decided by | Separates |
+| --- | --- | --- |
+| x | a 3x3 assembling machine at 10.5 | entity **centres** (floor 10) against **edges** (floor 9) |
+| y | a tile at y=10, six tiles clear of everything | whether **tiles** count towards the corner at all |
+
+The editor's formula reads centres and includes tiles. Its own doc comment
+admits the footprint half is untested, because every case measured so far used
+1x1 entities where centre-floor and edge-floor agree. This is that case.
+
+The content deliberately does not start at the origin, and the session asks for
+a second change on top of a first, because "an absolute target" and "a relative
+nudge of `-T`" agree whenever the corner already sits at 0.
+
+## Running it
+
+```fish
+# From the factorio-blueprint-editor repo root. Name the install: a bare
+# discovery finds only the Steam 2.1.14, and this targets 2.0.77.
+cd /Users/ericjohnson/GitHub/factorio-oracle
+cargo run -- run \
+    --probe /Users/ericjohnson/GitHub/factorio-blueprint-editor/tools/oracle/probe-blueprint-grid-position-gui/probe.json \
+    --work-dir /tmp/gridpos \
+    --version 2.0.77 > /tmp/gridpos-run.json
+```
+
+The game opens. There is no timeout - an interactive run lasts as long as you
+play. The mod builds the layout, hands you a blueprint, runs its four scripted
+controls, and prints the steps in the console.
+
+Press `~` for the console. The steps, which the game will also print:
+
+1. `/gp-cap untouched`
+2. Open the blueprint GUI, tick **Snap to grid**, close. `/gp-cap snap-on`
+3. Set **Grid position** to X=3 Y=5, close. `/gp-cap gridpos-3-5`
+4. Set **Grid position** to X=8 Y=9, close. `/gp-cap gridpos-8-9`
+5. Set **Grid position** back to X=0 Y=0, close. `/gp-cap gridpos-0-0`
+6. Pick **Absolute**, set its own X=2 Y=6, close. `/gp-cap abs-2-6`
+7. Untick **Snap to grid**, close. `/gp-cap snap-off`
+
+Step 4 is the one that separates a target from a nudge. Do not skip it.
+
+`/gp-note <text>` records anything surprising - a value the game refused, a
+field that reset itself, a parity warning. Those are findings, not noise. The
+locale carries two refusal strings and a parity rule, so expect at least one.
+
+`/gp-reset` rebuilds and starts over. `/gp-help` reprints the steps.
+
+Quit the game when done. Nothing is lost by quitting: the mod appends each
+capture as it happens.
+
+## Reading the result
+
+```fish
+cd /Users/ericjohnson/GitHub/factorio-blueprint-editor
+node tools/oracle/analyze-blueprint-grid-position-gui.mjs \
+    --run /tmp/gridpos-run.json --write-fixture
+```
+
+It exits non-zero if a control failed, in which case the numbers are void
+rather than a finding.
+
+`survivingReadings` is the answer. It lists the readings that match **every**
+scored row, not the one that fits the last. If it is empty, all four candidate
+rules are wrong and the real one has not been written down yet - which is a
+result, and a more interesting one.
+
+## The controls, and why each is there
+
+A control has to be able to fail while the hypothesis holds. PR #222's original
+capture had four cases that would have reported "the coordinates did not
+change" whether the probe was right or reading the same field twice.
+
+| Control | Fails when |
+| --- | --- |
+| `instrument-repeat` | export is not deterministic, which voids every "it moved" row |
+| `positive-shift` | the comparison cannot see a shift at all, which makes "nothing moved" mean nothing |
+| `rival-field` | the neighbouring field is not reachable, so the two cannot be told apart |
+
+`rival-field` is the one that matters most here. It sets
+`blueprint_position_relative_to_grid` on the same rig, so if the human-driven
+rows move the same numbers as the scripted ones, the two fields are one field
+after all and the old fixture was right.
+
+Everything the script set is tagged `script` and excluded from the scoring by
+tag rather than by value, because a script-set value is not a measured one.
+
+## Instrument check
+
+The analysis was validated against a synthetic capture stream with known
+answers before any game time was spent:
+
+- All four readings computed as hand-derived, and all four differ, so the
+  instrument can discriminate.
+- Planting a world where entity-centres-plus-tiles is the true rule leaves
+  exactly that one reading surviving and kills the other three on every row.
+- Mutating the repeat captures to differ fails the instrument control and only
+  that one. Mutating the positive control not to move fails that one and only
+  that one. Both exit non-zero.
+- A session that captures no scored step reports `unmeasured` rather than four
+  vacuously surviving readings, which is what `every()` over an empty list
+  would otherwise have produced.

--- a/tools/oracle/probe-blueprint-grid-position-gui/README.md
+++ b/tools/oracle/probe-blueprint-grid-position-gui/README.md
@@ -40,7 +40,7 @@ Checked before choosing the expensive route, per `docs/order-of-attack.md`.
 - `create_blueprint` takes no anchor parameter.
 - The game's own tooltip says how the field is set:
   `grid-position-tooltip=SHIFT + LEFT-CLICK in the preview to change the grid
-  position.`
+position.`
 
 There is no script that can set it. "No headless probe can reach it" is not
 "not worth measuring".
@@ -50,10 +50,10 @@ There is no script that can set it. "No headless probe can reach it" is not
 One capture separates three readings of "the minimum corner" at once, by
 putting each on a different axis.
 
-| Axis | Decided by | Separates |
-| --- | --- | --- |
-| x | a 3x3 assembling machine at 10.5 | entity **centres** (floor 10) against **edges** (floor 9) |
-| y | a tile at y=10, six tiles clear of everything | whether **tiles** count towards the corner at all |
+| Axis | Decided by                                    | Separates                                                 |
+| ---- | --------------------------------------------- | --------------------------------------------------------- |
+| x    | a 3x3 assembling machine at 10.5              | entity **centres** (floor 10) against **edges** (floor 9) |
+| y    | a tile at y=10, six tiles clear of everything | whether **tiles** count towards the corner at all         |
 
 The editor's formula reads centres and includes tiles. Its own doc comment
 admits the footprint half is untested, because every case measured so far used
@@ -63,6 +63,29 @@ The content deliberately does not start at the origin, and the session asks for
 a second change on top of a first, because "an absolute target" and "a relative
 nudge of `-T`" agree whenever the corner already sits at 0.
 
+## The three pairs in the panel
+
+Measured 2026-08-21, and worth knowing before driving it, because two of the
+three look alike and only one is the subject of this probe:
+
+```
+☑ Snap to grid
+  Grid size        Width 12   Height 17    <- snap-to-grid
+  Grid position        X 3    Y 5          <- THIS ONE: shifts the exported content
+  ● Absolute           X 9    Y 10         <- position-relative-to-grid
+  ○ Relative
+```
+
+Both lower pairs were on screen at once holding different values, which is what
+proves they are separate fields rather than one field read twice. The Grid
+position pair writes **no key at all** into the export - it moves the entity and
+tile coordinates instead, which is exactly the model PR #243 is built on, and is
+why no scripting API can reach it.
+
+Absolute is selected by default the moment Snap to grid is ticked, so the
+session's step 6 sets that row's own pair rather than picking the mode. Relative
+is the only side of the toggle a person has to travel to.
+
 ## Running it
 
 Name the install with `--factorio`. `--version` on its own is not enough: a bare
@@ -71,8 +94,17 @@ down to. `--factorio` puts that root at the front of the candidate list, and
 `--version` is then a guard that makes picking the wrong game impossible rather
 than merely unlikely.
 
+Run it from this repo's root. `control_lua_file` in `probe.json` is a
+repo-relative path and `read_control_lua` in the CLI reads it verbatim, so it
+resolves against the shell's working directory rather than against the probe
+file's own directory. An absolute `--probe` from elsewhere therefore fails with
+`reading control_lua_file ... No such file or directory`, which names the Lua
+file rather than the real cause. Not a CLI bug to fix: its own
+`examples/pumpjack-terminals/probe.json` uses the same convention, and
+resolving relative to the probe file would break that one.
+
 ```fish
-cargo run --quiet --manifest-path ~/GitHub/factorio-oracle/Cargo.toml -- run --probe ~/GitHub/factorio-blueprint-editor/tools/oracle/probe-blueprint-grid-position-gui/probe.json --work-dir /tmp/gridpos --factorio ~/GitHub/factorio-oracle/installs/factorio-2.0.77.app --version 2.0.77 >/tmp/gridpos-run.json
+cd ~/GitHub/factorio-blueprint-editor; and cargo run --quiet --manifest-path ~/GitHub/factorio-oracle/Cargo.toml -- run --probe tools/oracle/probe-blueprint-grid-position-gui/probe.json --work-dir /tmp/gridpos --factorio ~/GitHub/factorio-oracle/installs/factorio-2.0.77.app --version 2.0.77 >/tmp/gridpos-run.json
 ```
 
 The game opens. There is no timeout - an interactive run lasts as long as you
@@ -120,11 +152,11 @@ A control has to be able to fail while the hypothesis holds. PR #222's original
 capture had four cases that would have reported "the coordinates did not
 change" whether the probe was right or reading the same field twice.
 
-| Control | Fails when |
-| --- | --- |
-| `instrument-repeat` | export is not deterministic, which voids every "it moved" row |
-| `positive-shift` | the comparison cannot see a shift at all, which makes "nothing moved" mean nothing |
-| `rival-field` | the neighbouring field is not reachable, so the two cannot be told apart |
+| Control             | Fails when                                                                         |
+| ------------------- | ---------------------------------------------------------------------------------- |
+| `instrument-repeat` | export is not deterministic, which voids every "it moved" row                      |
+| `positive-shift`    | the comparison cannot see a shift at all, which makes "nothing moved" mean nothing |
+| `rival-field`       | the neighbouring field is not reachable, so the two cannot be told apart           |
 
 `rival-field` is the one that matters most here. It sets
 `blueprint_position_relative_to_grid` on the same rig, so if the human-driven

--- a/tools/oracle/probe-blueprint-grid-position-gui/README.md
+++ b/tools/oracle/probe-blueprint-grid-position-gui/README.md
@@ -65,14 +65,14 @@ nudge of `-T`" agree whenever the corner already sits at 0.
 
 ## Running it
 
+Name the install with `--factorio`. `--version` on its own is not enough: a bare
+discovery finds only the Steam 2.1.14, so there is no 2.0.77 for it to filter
+down to. `--factorio` puts that root at the front of the candidate list, and
+`--version` is then a guard that makes picking the wrong game impossible rather
+than merely unlikely.
+
 ```fish
-# From the factorio-blueprint-editor repo root. Name the install: a bare
-# discovery finds only the Steam 2.1.14, and this targets 2.0.77.
-cd /Users/ericjohnson/GitHub/factorio-oracle
-cargo run -- run \
-    --probe /Users/ericjohnson/GitHub/factorio-blueprint-editor/tools/oracle/probe-blueprint-grid-position-gui/probe.json \
-    --work-dir /tmp/gridpos \
-    --version 2.0.77 > /tmp/gridpos-run.json
+cargo run --quiet --manifest-path ~/GitHub/factorio-oracle/Cargo.toml -- run --probe ~/GitHub/factorio-blueprint-editor/tools/oracle/probe-blueprint-grid-position-gui/probe.json --work-dir /tmp/gridpos --factorio ~/GitHub/factorio-oracle/installs/factorio-2.0.77.app --version 2.0.77 >/tmp/gridpos-run.json
 ```
 
 The game opens. There is no timeout - an interactive run lasts as long as you
@@ -103,9 +103,7 @@ capture as it happens.
 ## Reading the result
 
 ```fish
-cd /Users/ericjohnson/GitHub/factorio-blueprint-editor
-node tools/oracle/analyze-blueprint-grid-position-gui.mjs \
-    --run /tmp/gridpos-run.json --write-fixture
+node ~/GitHub/factorio-blueprint-editor/tools/oracle/analyze-blueprint-grid-position-gui.mjs --run /tmp/gridpos-run.json --write-fixture
 ```
 
 It exits non-zero if a control failed, in which case the numbers are void

--- a/tools/oracle/probe-blueprint-grid-position-gui/SESSION.md
+++ b/tools/oracle/probe-blueprint-grid-position-gui/SESSION.md
@@ -10,8 +10,14 @@ appended the moment you run it.
 
 ## 1. Start it
 
+**Run it from this repo's root.** `probe.json` names its `control.lua` by a
+repo-relative path and the CLI reads that against the shell's working
+directory, not against the probe file - so an absolute `--probe` from anywhere
+else fails with `reading control_lua_file ... No such file or directory`. That
+is the convention the CLI's own example follows too.
+
 ```fish
-cargo run --quiet --manifest-path ~/GitHub/factorio-oracle/Cargo.toml -- run --probe ~/GitHub/factorio-blueprint-editor/tools/oracle/probe-blueprint-grid-position-gui/probe.json --work-dir /tmp/gridpos --factorio ~/GitHub/factorio-oracle/installs/factorio-2.0.77.app --version 2.0.77 >/tmp/gridpos-run.json
+cd ~/GitHub/factorio-blueprint-editor; and cargo run --quiet --manifest-path ~/GitHub/factorio-oracle/Cargo.toml -- run --probe tools/oracle/probe-blueprint-grid-position-gui/probe.json --work-dir /tmp/gridpos --factorio ~/GitHub/factorio-oracle/installs/factorio-2.0.77.app --version 2.0.77 >/tmp/gridpos-run.json
 ```
 
 The game opens. There is no timeout - it lasts as long as you play.
@@ -46,22 +52,28 @@ Do the thing, close the GUI, then type the command. Order matters.
 
       /gp-cap gridpos-3-5
 
-- [ ] **Grid position 8, 9.** Set **Grid position** X=8 Y=9. Close.
+- [ ] **Grid position 8, 9.** Set **Grid position** X=8 Y=9. Close. Do not skip
+      this one - a second value on top of the first is the only thing that
+      tells an absolute target from a relative nudge.
 
       /gp-cap gridpos-8-9
-
-      This is the one that matters most. Setting a second value on top of the
-      first is the only thing that tells an absolute target from a relative
-      nudge. Do not skip it.
 
 - [ ] **Grid position 0, 0.** Set **Grid position** back to X=0 Y=0. Close.
 
       /gp-cap gridpos-0-0
 
-- [ ] **Absolute 2, 6.** Pick **Absolute**. Set its **own** X=2 Y=6 - the pair
-      on the Absolute row, not the Grid position pair above it. Close.
+- [ ] **Absolute 2, 6.** Leave **Grid position** at 0, 0. On the **Absolute**
+      row - the third pair down, not the Grid position one - set X=2 Y=6.
+      Close. Absolute is already selected; it is the default as soon as Snap
+      to grid is ticked. See the README for the panel's three pairs.
 
       /gp-cap abs-2-6
+
+- [ ] **Relative.** Switch the toggle to **Relative**. Close. Unscored, and
+      worth having anyway: PR #222 measured that the game drops the position
+      key under relative snapping.
+
+      /gp-cap relative
 
 - [ ] **Snap off.** Untick **Snap to grid**. Close.
 
@@ -83,13 +95,13 @@ than a finding.
 `survivingReadings` is the answer. It lists the rules that match **every**
 scored row.
 
-| Result | Means |
-| --- | --- |
-| `["entityCentresAndTiles"]` | PR #243's formula is right as shipped |
-| `["entityEdgesAndTiles"]` | right shape, wrong corner - it reads edges, not centres |
-| `["entityCentresOnly"]` or `["entityEdgesOnly"]` | tiles do not count towards the corner |
-| `[]` | all four candidates are wrong, and the real rule is not written down yet |
-| `unmeasured ...` | no scored step was captured - check step 1 |
+| Result                                           | Means                                                                    |
+| ------------------------------------------------ | ------------------------------------------------------------------------ |
+| `["entityCentresAndTiles"]`                      | PR #243's formula is right as shipped                                    |
+| `["entityEdgesAndTiles"]`                        | right shape, wrong corner - it reads edges, not centres                  |
+| `["entityCentresOnly"]` or `["entityEdgesOnly"]` | tiles do not count towards the corner                                    |
+| `[]`                                             | all four candidates are wrong, and the real rule is not written down yet |
+| `unmeasured ...`                                 | no scored step was captured - check step 1                               |
 
 ---
 
@@ -104,7 +116,7 @@ refusal. Its locale carries three relevant strings:
 - `__1__ is an invalid grid position value.`
 - `Grid position value for this blueprint has to be multiple of __1__.`
 - `Grid position and blueprint grid position coordinates need to be either all
-  even or all odd.`
+even or all odd.`
 
 If X=3 Y=5 or X=8 Y=9 is refused for parity or multiples, **note it and use the
 nearest value the game accepts**, then note what you actually used. A refusal is
@@ -120,8 +132,8 @@ analysis scores against what you record, not against what the step asked for.
 
 ## Other commands
 
-| Command | Does |
-| --- | --- |
-| `/gp-note <text>` | record a note in the capture stream |
-| `/gp-help` | reprint the steps in game |
-| `/gp-reset` | rebuild the layout and re-run the controls, start over |
+| Command           | Does                                                   |
+| ----------------- | ------------------------------------------------------ |
+| `/gp-note <text>` | record a note in the capture stream                    |
+| `/gp-help`        | reprint the steps in game                              |
+| `/gp-reset`       | rebuild the layout and re-run the controls, start over |

--- a/tools/oracle/probe-blueprint-grid-position-gui/SESSION.md
+++ b/tools/oracle/probe-blueprint-grid-position-gui/SESSION.md
@@ -1,0 +1,127 @@
+# Grid position session - follow along
+
+Keep this open while you play. Reference and reasoning are in `README.md`;
+this is just the steps.
+
+Roughly 15 minutes. Nothing is lost if you quit early - every capture is
+appended the moment you run it.
+
+---
+
+## 1. Start it
+
+```fish
+cargo run --quiet --manifest-path ~/GitHub/factorio-oracle/Cargo.toml -- run --probe ~/GitHub/factorio-blueprint-editor/tools/oracle/probe-blueprint-grid-position-gui/probe.json --work-dir /tmp/gridpos --factorio ~/GitHub/factorio-oracle/installs/factorio-2.0.77.app --version 2.0.77 >/tmp/gridpos-run.json
+```
+
+The game opens. There is no timeout - it lasts as long as you play.
+
+**Before going further, confirm the mod actually loaded.** A `factorio_version`
+mismatch skips it in silence and you would play a whole session capturing
+nothing. You should see this in the chat log:
+
+```
+[grid-probe] Layout built, blueprint in your inventory, controls captured.
+```
+
+If you do not see it, quit and say so - do not carry on.
+
+Press `~` for the console.
+
+---
+
+## 2. The steps
+
+Do the thing, close the GUI, then type the command. Order matters.
+
+- [ ] **Baseline.** Change nothing.
+
+      /gp-cap untouched
+
+- [ ] **Snap on.** Open the blueprint GUI. Tick **Snap to grid**. Close.
+
+      /gp-cap snap-on
+
+- [ ] **Grid position 3, 5.** Set **Grid position** X=3 Y=5. Close.
+
+      /gp-cap gridpos-3-5
+
+- [ ] **Grid position 8, 9.** Set **Grid position** X=8 Y=9. Close.
+
+      /gp-cap gridpos-8-9
+
+      This is the one that matters most. Setting a second value on top of the
+      first is the only thing that tells an absolute target from a relative
+      nudge. Do not skip it.
+
+- [ ] **Grid position 0, 0.** Set **Grid position** back to X=0 Y=0. Close.
+
+      /gp-cap gridpos-0-0
+
+- [ ] **Absolute 2, 6.** Pick **Absolute**. Set its **own** X=2 Y=6 - the pair
+      on the Absolute row, not the Grid position pair above it. Close.
+
+      /gp-cap abs-2-6
+
+- [ ] **Snap off.** Untick **Snap to grid**. Close.
+
+      /gp-cap snap-off
+
+- [ ] Quit the game.
+
+---
+
+## 3. Read the result
+
+```fish
+node ~/GitHub/factorio-blueprint-editor/tools/oracle/analyze-blueprint-grid-position-gui.mjs --run /tmp/gridpos-run.json --write-fixture
+```
+
+Exits non-zero if a control failed, in which case the numbers are void rather
+than a finding.
+
+`survivingReadings` is the answer. It lists the rules that match **every**
+scored row.
+
+| Result | Means |
+| --- | --- |
+| `["entityCentresAndTiles"]` | PR #243's formula is right as shipped |
+| `["entityEdgesAndTiles"]` | right shape, wrong corner - it reads edges, not centres |
+| `["entityCentresOnly"]` or `["entityEdgesOnly"]` | tiles do not count towards the corner |
+| `[]` | all four candidates are wrong, and the real rule is not written down yet |
+| `unmeasured ...` | no scored step was captured - check step 1 |
+
+---
+
+## Two things to watch for
+
+**Note anything surprising with `/gp-note <text>`.** These are findings, not
+noise.
+
+The game validates this field and the editor does not, so expect at least one
+refusal. Its locale carries three relevant strings:
+
+- `__1__ is an invalid grid position value.`
+- `Grid position value for this blueprint has to be multiple of __1__.`
+- `Grid position and blueprint grid position coordinates need to be either all
+  even or all odd.`
+
+If X=3 Y=5 or X=8 Y=9 is refused for parity or multiples, **note it and use the
+nearest value the game accepts**, then note what you actually used. A refusal is
+worth more than a clean run: `BlueprintAlignment.ts` has no validation at all,
+so the editor can already write a grid position the game will not take back.
+
+**If the Grid position X/Y turn out not to be typeable**, the tooltip says the
+field is set by shift + left-click in the preview instead. Use that to get as
+close as you can, note the value you actually landed on, and carry on - the
+analysis scores against what you record, not against what the step asked for.
+
+---
+
+## Other commands
+
+| Command | Does |
+| --- | --- |
+| `/gp-note <text>` | record a note in the capture stream |
+| `/gp-help` | reprint the steps in game |
+| `/gp-reset` | rebuild the layout and re-run the controls, start over |

--- a/tools/oracle/probe-blueprint-grid-position-gui/SESSION.md
+++ b/tools/oracle/probe-blueprint-grid-position-gui/SESSION.md
@@ -98,10 +98,16 @@ scored row.
 | Result                                           | Means                                                                    |
 | ------------------------------------------------ | ------------------------------------------------------------------------ |
 | `["entityCentresAndTiles"]`                      | PR #243's formula is right as shipped                                    |
-| `["entityEdgesAndTiles"]`                        | right shape, wrong corner - it reads edges, not centres                  |
+| `["entityEdgesAndTiles"]`                        | it reads the edge of the **tile footprint**, not the centre              |
+| `["entityCollisionEdgesAndTiles"]`               | it reads the edge of the **collision box**                               |
+| both of those two                                | what run 1 gave: an edge, but the layout could not say which             |
 | `["entityCentresOnly"]` or `["entityEdgesOnly"]` | tiles do not count towards the corner                                    |
-| `[]`                                             | all four candidates are wrong, and the real rule is not written down yet |
+| `[]`                                             | all five candidates are wrong, and the real rule is not written down yet |
 | `unmeasured ...`                                 | no scored step was captured - check step 1                               |
+
+Run 2 exists to turn that "both" row into one of the two above it. If it comes
+back `[]`, suspect the rail's orientation before suspecting the rule - see the
+README's note on it.
 
 ---
 

--- a/tools/oracle/probe-blueprint-grid-position-gui/control.lua
+++ b/tools/oracle/probe-blueprint-grid-position-gui/control.lua
@@ -48,33 +48,59 @@ local function emit(row)
 end
 
 --[[
-One capture separates three readings of "the minimum corner" at once, by
-putting each question on a different axis:
-
-  x-min is decided by the 3x3 assembling machine. Its centre sits at 10.5 and
-        its left edge at 9.0, which floor to different integers, so a formula
-        reading centres and one reading edges cannot agree. The editor's
-        getGridPositionDisplay() reads centres and says so in its own comment,
-        noting that every case measured so far used 1x1 entities where the two
-        coincide. This is that untested case.
-  y-min is decided by a tile at y=10, six tiles above anything else, so
-        whether tiles count towards the corner at all is visible rather than
-        assumed. The editor's formula includes them.
-
 docs/method.md: a probe entity is part of the question, not a neutral
-instrument.
+instrument. This layout is the second one, and what changed and why is the
+whole of the comment below.
+
+Run 1's layout put a 3x3 assembling machine on x (centre 10.5 against footprint
+edge 9.0, so centres and edges could not agree) and a lone tile on y (so
+whether tiles count at all was visible rather than assumed). Both questions
+were answered: the corner reads edges, and tiles do count.
+
+Run 2's layout. Run 1 settled that the corner is read from an entity **edge**
+rather than its centre, and could not say *which* edge - and the fix to
+`getGridPositionDisplay()` depends on that: for `assembling-machine-1` the tile
+footprint edge is 9.0 and the collision-box edge 9.3, which floor to the same
+integer, so both candidate rules agreed on every row of run 1.
+
+`half-diagonal-rail` is what separates them, and it is close to unique. The
+editor derives a footprint by *ceiling* the collision box
+(`factorioData.ts:617`), so a box cannot escape its own footprint unless a
+declared `tile_width`/`tile_height` overrides that. Five of the 155 entities in
+`data.json` manage it, and this is the only one that splits **all three**
+readings apart on a single axis. `offshore-pump`, the obvious alternative,
+splits the two edges but not centre from footprint edge, being 1x1 - centre
+4.5 and footprint edge 4.0 both floor to 4.
+
+Three questions, two axes, so one axis has to carry two of them:
+
+  y: half-diagonal-rail at 20   centre 20, footprint edge 19, box edge 17.764
+  x: stone-path tiles at 2      against the nearest entity reading of 9
+
+That is why the tiles moved to the left and everything else moved down. The
+rail must own the y minimum under all three readings, and the tiles must own x
+under all three while owning y under none - otherwise an axis answers nothing.
+
+The rail is the risk in this layout, and it is a known one. `data.json` carries
+one box orientation and half-diagonal rails only exist at diagonal
+orientations, so if the game stores this one at a direction whose box is
+rotated, the numbers above are wrong. That shows up as a run whose y readings
+do not match any of the three predictions, which the recorded `layout` and the
+per-case `minCornerReadings` make visible rather than mysterious. It is not a
+silent failure mode.
 ]]
 local LAYOUT = {
     entities = {
-        { name = 'assembling-machine-1', position = { x = 10.5, y = 20.5 } },
-        { name = 'wooden-chest', position = { x = 20.5, y = 20.5 } },
-        { name = 'wooden-chest', position = { x = 20.5, y = 26.5 } },
+        { name = 'half-diagonal-rail', position = { x = 20, y = 20 } },
+        { name = 'assembling-machine-1', position = { x = 10.5, y = 30.5 } },
+        { name = 'wooden-chest', position = { x = 20.5, y = 30.5 } },
+        { name = 'wooden-chest', position = { x = 20.5, y = 36.5 } },
     },
     tiles = {
-        { x = 14, y = 10 },
-        { x = 15, y = 10 },
-        { x = 14, y = 11 },
-        { x = 15, y = 11 },
+        { x = 2, y = 30 },
+        { x = 3, y = 30 },
+        { x = 2, y = 31 },
+        { x = 3, y = 31 },
     },
     tile_name = 'stone-path',
 }
@@ -98,11 +124,24 @@ local function build_layout(player)
     surface.set_tiles(tiles)
 
     for _, e in pairs(LAYOUT.entities) do
-        surface.create_entity {
+        local built = surface.create_entity {
             name = e.name,
             position = e.position,
             force = player.force,
         }
+        --[[
+        Say so rather than carrying on. `create_entity` ignores buildability,
+        but it still returns nil when it cannot place a thing at all, and a
+        dropped `half-diagonal-rail` would take the entire edge question with
+        it while every other row still looked healthy. The analysis cannot see
+        an entity that was never placed - it only ever sees what the export
+        carries - so the complaint has to happen here, at the only point that
+        knows what was asked for.
+        ]]
+        if not built then
+            player.print('[grid-probe] FAILED to create ' .. e.name .. ' - do not trust this run')
+            emit { kind = 'note', text = 'create_entity returned nil for ' .. e.name }
+        end
     end
 end
 
@@ -243,7 +282,8 @@ local INSTRUCTIONS = {
     '  4. Set Grid position to X=8 Y=9. Close.                 /gp-cap gridpos-8-9',
     '     (This is the step that separates an absolute target from a nudge.)',
     '  5. Set Grid position back to X=0 Y=0. Close.            /gp-cap gridpos-0-0',
-    '  6. Pick "Absolute". Set its own X/Y to X=2 Y=6. Close.  /gp-cap abs-2-6',
+    '  6. On the "Absolute" ROW (the third X/Y pair, not Grid position)',
+    '     set X=2 Y=6. Absolute is already picked. Close.     /gp-cap abs-2-6',
     '  7. Untick "Snap to grid". Close.                        /gp-cap snap-off',
     '',
     'Use /gp-note <text> if anything surprises you - a value the game refused,',
@@ -262,6 +302,27 @@ local function setup(player)
     build_layout(player)
 
     local inv = player.get_main_inventory()
+
+    --[[
+    Clear every set-up blueprint already in the inventory before making a new
+    one. Without this, `/gp-reset` silently corrupts the whole rest of the
+    session: this function takes the first blueprint that is *not* set up,
+    while `find_bp()` takes the first that *is*, by slot order. So the old
+    blueprint keeps a lower slot index and every later `/gp-cap` captures the
+    previous session's layout while printing `captured: <label>` as though it
+    worked - straight into the committed fixture. Found by review on PR #249.
+    ]]
+    for i = 1, #inv do
+        local s = inv[i]
+        if s.valid_for_read and s.is_blueprint and s.is_blueprint_setup() then
+            s.clear()
+        end
+    end
+    local cursor = player.cursor_stack
+    if cursor and cursor.valid_for_read and cursor.is_blueprint and cursor.is_blueprint_setup() then
+        cursor.clear()
+    end
+
     inv.insert { name = 'blueprint', count = 1 }
     local bp = nil
     for i = 1, #inv do

--- a/tools/oracle/probe-blueprint-grid-position-gui/control.lua
+++ b/tools/oracle/probe-blueprint-grid-position-gui/control.lua
@@ -1,0 +1,342 @@
+--[[
+What does the blueprint GUI's "Grid position" field actually do to an
+exported blueprint string?
+
+Why this probe is interactive, which is the expensive choice and was checked
+before being made. Measured against 2.0.77's own `doc-html/runtime-api.json`:
+`LuaItemCommon` exposes exactly three blueprint snapping attributes -
+`blueprint_snap_to_grid`, `blueprint_absolute_snapping` and
+`blueprint_position_relative_to_grid` - and none of them is this field.
+`create_blueprint` takes no anchor parameter either. The game's own tooltip
+(`core.cfg:2335`) says the field is set by shift + left-click in the preview.
+So there is no script that can set it, and a person has to.
+
+Why it is worth measuring at all. `tools/oracle/fixtures/blueprint-grid-
+position.json` already asked "does a blueprint's grid position move its
+entities" and answered no, scoring the premise 0 of 2 with `entitiesMovedOn: 0`.
+That capture set `blueprint_position_relative_to_grid`. The game's own locale
+separates the two concepts in one line - `core.cfg:274`, "Grid position and
+blueprint grid position coordinates need to be either all even or all odd" -
+so the earlier fixture measured the neighbouring field, not this one. Its
+answer is not wrong; it is about something else.
+
+The rival readings this has to separate, decided before the run rather than
+after it (docs/method.md, "which hypotheses a probe value can separate is part
+of the question"):
+
+  H1  Setting Grid position to T shifts the exported content so that
+      -floor(min position over entities and tiles) == T, and writes no
+      snapping field. This is what packages/editor/src/core/Blueprint.ts
+      ships today.
+  H2  Grid position does not move anything and writes
+      `position-relative-to-grid`.
+  H3  It writes some field the editor does not currently decode.
+  H4  It moves everything by exactly (-T.x, -T.y). This was PR #222's original
+      premise.
+
+H1 and H4 agree whenever the content's minimum corner already sits at the
+origin, so the layout below deliberately does not start there, and the session
+asks for a second change on top of a first: only a non-zero starting corner and
+a repeated change separate "an absolute target" from "a relative nudge".
+]]
+
+local OUT = 'grid-position-gui.jsonl'
+
+local function emit(row)
+    row.tick = game.tick
+    helpers.write_file(OUT, helpers.table_to_json(row) .. '\n', true)
+end
+
+--[[
+One capture separates three readings of "the minimum corner" at once, by
+putting each question on a different axis:
+
+  x-min is decided by the 3x3 assembling machine. Its centre sits at 10.5 and
+        its left edge at 9.0, which floor to different integers, so a formula
+        reading centres and one reading edges cannot agree. The editor's
+        getGridPositionDisplay() reads centres and says so in its own comment,
+        noting that every case measured so far used 1x1 entities where the two
+        coincide. This is that untested case.
+  y-min is decided by a tile at y=10, six tiles above anything else, so
+        whether tiles count towards the corner at all is visible rather than
+        assumed. The editor's formula includes them.
+
+docs/method.md: a probe entity is part of the question, not a neutral
+instrument.
+]]
+local LAYOUT = {
+    entities = {
+        { name = 'assembling-machine-1', position = { x = 10.5, y = 20.5 } },
+        { name = 'wooden-chest', position = { x = 20.5, y = 20.5 } },
+        { name = 'wooden-chest', position = { x = 20.5, y = 26.5 } },
+    },
+    tiles = {
+        { x = 14, y = 10 },
+        { x = 15, y = 10 },
+        { x = 14, y = 11 },
+        { x = 15, y = 11 },
+    },
+    tile_name = 'stone-path',
+}
+
+local AREA = { { 0, 0 }, { 40, 40 } }
+
+local function build_layout(player)
+    local surface = player.surface
+    -- Clear first, so the blueprint holds the layout and nothing the map
+    -- generator happened to put in the same square.
+    for _, e in pairs(surface.find_entities_filtered { area = AREA }) do
+        if e.valid and e.type ~= 'character' then
+            e.destroy()
+        end
+    end
+
+    local tiles = {}
+    for _, t in pairs(LAYOUT.tiles) do
+        tiles[#tiles + 1] = { name = LAYOUT.tile_name, position = { t.x, t.y } }
+    end
+    surface.set_tiles(tiles)
+
+    for _, e in pairs(LAYOUT.entities) do
+        surface.create_entity {
+            name = e.name,
+            position = e.position,
+            force = player.force,
+        }
+    end
+end
+
+local function fill_blueprint(stack, player)
+    stack.create_blueprint {
+        surface = player.surface,
+        force = player.force,
+        area = AREA,
+        always_include_tiles = true,
+    }
+end
+
+--[[
+Finds the blueprint the person is working with. Searches the cursor first,
+because the GUI is opened on a held blueprint as often as on one in a slot,
+and `is_blueprint_setup()` keeps an empty spare from being picked up instead.
+]]
+local function find_bp(player)
+    local cursor = player.cursor_stack
+    if cursor and cursor.valid_for_read and cursor.is_blueprint and cursor.is_blueprint_setup() then
+        return cursor
+    end
+    local inv = player.get_main_inventory()
+    for i = 1, #inv do
+        local s = inv[i]
+        if s.valid_for_read and s.is_blueprint and s.is_blueprint_setup() then
+            return s
+        end
+    end
+    return nil
+end
+
+--[[
+`tag` marks who set the state being captured. docs/method.md: a script-set
+value is not a measured one, and must be excluded by tag rather than by value,
+or the controls below join the sample they exist to validate.
+]]
+local function capture(player, label, tag, stack)
+    local bp = stack or find_bp(player)
+    if not bp then
+        player.print('[grid-probe] no set-up blueprint found - is one in your inventory?')
+        return false
+    end
+
+    emit {
+        kind = 'capture',
+        label = label,
+        tag = tag,
+        snap_to_grid = bp.blueprint_snap_to_grid,
+        absolute_snapping = bp.blueprint_absolute_snapping,
+        position_relative_to_grid = bp.blueprint_position_relative_to_grid,
+        entities = bp.get_blueprint_entities(),
+        tiles = bp.get_blueprint_tiles(),
+        export = bp.export_stack(),
+    }
+    player.print('[grid-probe] captured: ' .. label)
+    return true
+end
+
+--[[
+The three scripted controls. They run on their own scratch blueprint so that
+nothing here disturbs the one the person is about to edit.
+
+Each is here because it can fail while the hypothesis holds, which is the bar
+docs/method.md sets and the bar PR #222's null-result cases did not clear:
+
+  instrument-repeat   Two captures with nothing changed in between. If these
+                      ever differ, every "the coordinates moved" row below is
+                      worthless, because export is not deterministic.
+  positive-shift      The script moves the blueprint's contents by a known
+                      amount through set_blueprint_entities. These coordinates
+                      *have* to differ. Without it, "nothing moved" is not
+                      evidence of anything - it is equally what reading the
+                      same field twice looks like.
+  rival-field         The script sets `blueprint_position_relative_to_grid`,
+                      the field the earlier fixture measured, on this same rig.
+                      That is what makes the two fields comparable rather than
+                      merely asserted to be different: if the human-driven Grid
+                      position rows and these rows move the same numbers, the
+                      two are one field after all and H2 is back.
+]]
+local function run_controls(player)
+    local inv = player.get_main_inventory()
+    inv.insert { name = 'blueprint', count = 1 }
+
+    local scratch = nil
+    for i = 1, #inv do
+        local s = inv[i]
+        if s.valid_for_read and s.is_blueprint and not s.is_blueprint_setup() then
+            scratch = s
+            break
+        end
+    end
+    if not scratch then
+        player.print('[grid-probe] could not get a scratch blueprint for the controls')
+        return
+    end
+
+    fill_blueprint(scratch, player)
+
+    capture(player, 'control-instrument-repeat-1', 'script', scratch)
+    capture(player, 'control-instrument-repeat-2', 'script', scratch)
+
+    local entities = scratch.get_blueprint_entities()
+    if entities then
+        for _, e in pairs(entities) do
+            e.position.x = e.position.x - 3
+            e.position.y = e.position.y - 4
+        end
+        scratch.set_blueprint_entities(entities)
+        capture(player, 'control-positive-shift', 'script', scratch)
+    end
+
+    -- Rebuild rather than shifting back: set_blueprint_entities drops the
+    -- tiles, so restoring by arithmetic would leave a different blueprint
+    -- under the same name.
+    fill_blueprint(scratch, player)
+    scratch.blueprint_snap_to_grid = { x = 4, y = 4 }
+    scratch.blueprint_absolute_snapping = true
+    scratch.blueprint_position_relative_to_grid = { x = 3, y = 5 }
+    capture(player, 'control-rival-field', 'script', scratch)
+
+    scratch.clear()
+    player.print('[grid-probe] controls done (4 rows)')
+end
+
+local INSTRUCTIONS = {
+    '',
+    '[grid-probe] Layout built, blueprint in your inventory, controls captured.',
+    '',
+    'For each step: do the thing in the blueprint GUI, close it, then run the',
+    'capture command shown. Order matters - later steps build on earlier ones.',
+    '',
+    '  1. /gp-cap untouched',
+    '  2. Open the blueprint GUI. Tick "Snap to grid". Close.  /gp-cap snap-on',
+    '  3. Set Grid position to X=3 Y=5 (shift+left-click in the preview, or',
+    '     type it). Close.                                    /gp-cap gridpos-3-5',
+    '  4. Set Grid position to X=8 Y=9. Close.                 /gp-cap gridpos-8-9',
+    '     (This is the step that separates an absolute target from a nudge.)',
+    '  5. Set Grid position back to X=0 Y=0. Close.            /gp-cap gridpos-0-0',
+    '  6. Pick "Absolute". Set its own X/Y to X=2 Y=6. Close.  /gp-cap abs-2-6',
+    '  7. Untick "Snap to grid". Close.                        /gp-cap snap-off',
+    '',
+    'Use /gp-note <text> if anything surprises you - a value the game refused,',
+    'a field that reset itself, a parity warning. Those are findings.',
+    'Use /gp-reset to rebuild the layout and start over.',
+    '',
+}
+
+local function announce(player)
+    for _, line in pairs(INSTRUCTIONS) do
+        player.print(line)
+    end
+end
+
+local function setup(player)
+    build_layout(player)
+
+    local inv = player.get_main_inventory()
+    inv.insert { name = 'blueprint', count = 1 }
+    local bp = nil
+    for i = 1, #inv do
+        local s = inv[i]
+        if s.valid_for_read and s.is_blueprint and not s.is_blueprint_setup() then
+            bp = s
+            break
+        end
+    end
+    if not bp then
+        player.print('[grid-probe] could not get a blueprint')
+        return
+    end
+    fill_blueprint(bp, player)
+
+    emit {
+        kind = 'setup',
+        layout = LAYOUT,
+        area = AREA,
+        -- Recorded so the analysis never has to guess what was on the ground,
+        -- and so a rebuilt session is comparable with an earlier one.
+        active_mods = script.active_mods,
+    }
+
+    run_controls(player)
+    announce(player)
+end
+
+commands.add_command('gp-cap', 'Capture the blueprint state under a label', function(cmd)
+    local player = game.get_player(cmd.player_index)
+    if not player then
+        return
+    end
+    local label = cmd.parameter
+    if not label or label == '' then
+        player.print('[grid-probe] usage: /gp-cap <label>')
+        return
+    end
+    capture(player, label, 'human')
+end)
+
+commands.add_command('gp-note', 'Record a note in the capture stream', function(cmd)
+    local player = game.get_player(cmd.player_index)
+    if not player then
+        return
+    end
+    emit { kind = 'note', text = cmd.parameter or '', tag = 'human' }
+    player.print('[grid-probe] noted')
+end)
+
+commands.add_command('gp-reset', 'Rebuild the layout and re-run the controls', function(cmd)
+    local player = game.get_player(cmd.player_index)
+    if not player then
+        return
+    end
+    emit { kind = 'reset' }
+    setup(player)
+end)
+
+commands.add_command('gp-help', 'Print the session instructions again', function(cmd)
+    local player = game.get_player(cmd.player_index)
+    if player then
+        announce(player)
+    end
+end)
+
+script.on_event(defines.events.on_player_created, function(event)
+    local player = game.get_player(event.player_index)
+    if not player then
+        return
+    end
+    -- Freeplay drops the player into a cutscene on some versions; leaving it
+    -- first means the GUI and the console are both reachable straight away.
+    if player.controller_type == defines.controllers.cutscene then
+        player.exit_cutscene()
+    end
+    setup(player)
+end)

--- a/tools/oracle/probe-blueprint-grid-position-gui/control.lua
+++ b/tools/oracle/probe-blueprint-grid-position-gui/control.lua
@@ -74,24 +74,30 @@ splits the two edges but not centre from footprint edge, being 1x1 - centre
 
 Three questions, two axes, so one axis has to carry two of them:
 
-  y: half-diagonal-rail at 20   centre 20, footprint edge 19, box edge 17.764
+  y: half-diagonal-rail at 21   centre 21, footprint edge 20, box edge 19.102
   x: stone-path tiles at 2      against the nearest entity reading of 9
 
 That is why the tiles moved to the left and everything else moved down. The
 rail must own the y minimum under all three readings, and the tiles must own x
 under all three while owning y under none - otherwise an axis answers nothing.
 
-The rail is the risk in this layout, and it is a known one. `data.json` carries
-one box orientation and half-diagonal rails only exist at diagonal
-orientations, so if the game stores this one at a direction whose box is
-rotated, the numbers above are wrong. That shows up as a run whose y readings
-do not match any of the three predictions, which the recorded `layout` and the
-per-case `minCornerReadings` make visible rather than mysterious. It is not a
-silent failure mode.
+The rail was the risk in this layout, and it has been measured rather than
+worried about - `probe-rail-box-orientation`, a headless create run, because
+none of it needs a player. It found three things, and all three would have
+corrupted this layout silently:
+
+  - The box does **not** rotate. All 16 directions give one box, folding to
+    stored directions 0/2/4/6. The orientation fear was unfounded.
+  - The rail **snaps**: asking for (20, 20) places it at (21, 21). Hence 21
+    here, and every predicted number above is for that centre.
+  - `data.json` and the runtime **disagree** about this box, 2.236 against
+    1.8984375. Of 155 entities, 139 agree to within one 1/256 step, which is
+    just Factorio's position quantum, and all 16 that do not are rails. So the
+    analyzer's geometry table carries the game's number for this one.
 ]]
 local LAYOUT = {
     entities = {
-        { name = 'half-diagonal-rail', position = { x = 20, y = 20 } },
+        { name = 'half-diagonal-rail', position = { x = 21, y = 21 } },
         { name = 'assembling-machine-1', position = { x = 10.5, y = 30.5 } },
         { name = 'wooden-chest', position = { x = 20.5, y = 30.5 } },
         { name = 'wooden-chest', position = { x = 20.5, y = 36.5 } },

--- a/tools/oracle/probe-blueprint-grid-position-gui/probe.json
+++ b/tools/oracle/probe-blueprint-grid-position-gui/probe.json
@@ -1,10 +1,10 @@
 {
-  "mode": "interactive",
-  "mod": {
-    "name": "bp_grid_position_gui",
-    "version": "0.0.1",
-    "dependencies": ["base"],
-    "control_lua_file": "tools/oracle/probe-blueprint-grid-position-gui/control.lua"
-  },
-  "capture_active_mods": true
+    "mode": "interactive",
+    "mod": {
+        "name": "bp_grid_position_gui",
+        "version": "0.0.1",
+        "dependencies": ["base"],
+        "control_lua_file": "tools/oracle/probe-blueprint-grid-position-gui/control.lua"
+    },
+    "capture_active_mods": true
 }

--- a/tools/oracle/probe-blueprint-grid-position-gui/probe.json
+++ b/tools/oracle/probe-blueprint-grid-position-gui/probe.json
@@ -1,0 +1,10 @@
+{
+  "mode": "interactive",
+  "mod": {
+    "name": "bp_grid_position_gui",
+    "version": "0.0.1",
+    "dependencies": ["base"],
+    "control_lua_file": "tools/oracle/probe-blueprint-grid-position-gui/control.lua"
+  },
+  "capture_active_mods": true
+}

--- a/tools/oracle/probe-rail-box-orientation/README.md
+++ b/tools/oracle/probe-rail-box-orientation/README.md
@@ -1,0 +1,110 @@
+# Does a rail's collision box rotate, and does `data.json` match the game?
+
+A headless probe, written to de-risk run 2 of `probe-blueprint-grid-position-gui`
+before a person spent time on it. It found three things that would each have
+corrupted that run silently, and one that is bigger than the run.
+
+## Why it exists
+
+Run 2 of the grid-position probe puts a `half-diagonal-rail` at one spot and
+depends on it producing three distinct floors on the y axis - centre, tile
+footprint edge, collision box edge. That spread is the only thing separating
+"the corner is the footprint edge" from "the corner is the collision box edge",
+which is the open half of PR #243's finding 15.
+
+The numbers came from `data.json`. Half-diagonal rails exist only at diagonal
+orientations, so a rail stored rotated would put the long extent on the wrong
+axis, collapse the spread, and report no surviving reading - which reads as
+"the rule is wrong" rather than "the instrument was pointed sideways".
+
+None of that needs a player, so this is a `create` run rather than an
+interactive one. `docs/method.md`: ask the cheapest question that settles the
+thing.
+
+## What it found
+
+**The box does not rotate.** All 16 requested directions produce one identical
+bounding box, folding to stored directions 0, 2, 4 and 6. The orientation fear
+was unfounded.
+
+**The rail snaps.** Asked for `(20, 20)`, the game places it at `(21, 21)`. Every
+prediction computed for a centre of 20 was for a position that cannot exist.
+
+**`data.json` and the running game disagree about collision boxes, and only
+about rails.** Across all 155 entities:
+
+|                                 | count  |
+| ------------------------------- | ------ |
+| agree to within one 1/256 step  | 139    |
+| disagree beyond that            | 16     |
+| of those 16, how many are rails | **16** |
+
+The 139 are not a finding: Factorio stores positions in 1/256 of a tile, so a
+runtime box is the declared one snapped to that grid, and the worst deviation
+among them is 0.00375 against a quantum of 0.00390625. Separating the two
+mattered, because lumping them together buries 16 real differences under 139
+uninteresting ones.
+
+The 16 are every rail prototype plus its `dummy-` and `elevated-` variants.
+`legacy-curved-rail` is the worst at 1.45 tiles, and its runtime box is not even
+symmetric where `data.json` says it is:
+
+```
+legacy-curved-rail   data.json [-2, -2, 2, 2]
+                     runtime   [-0.75, -0.546875, 0.75, 1.5976562]
+half-diagonal-rail   data.json [-0.75, -2.236, 0.75, 2.236]
+                     runtime   [-0.75, -1.8984375, 0.75, 1.8984375]
+straight-rail        data.json [-1, -1, 1, 1]
+                     runtime   [-0.6992188, -0.9882812, 0.6992188, 0.9882812]
+```
+
+That is worth knowing beyond this probe. `CLAUDE.md` already records rails as
+the place where the editor's geometry is wrong in both directions (#133, #142);
+this says the editor's own **data** disagrees with the game there too, and
+nowhere else.
+
+## Controls
+
+A control has to be able to fail while the hypothesis holds.
+
+| Control                                          | Fails when                                                                                       |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| every direction produced a placement             | a refused placement is being read as a geometry answer                                           |
+| the sweep covered more than one stored direction | only one orientation was ever placed, which would report a single box and look identically clean |
+| the probe recorded no Lua errors                 | a `pcall` swallowed something                                                                    |
+
+The middle one is the load-bearing one for the "it does not rotate" finding,
+which is otherwise unfalsifiable.
+
+## Running it
+
+```fish
+cd ~/GitHub/factorio-blueprint-editor; and cargo run --quiet --manifest-path ~/GitHub/factorio-oracle/Cargo.toml -- run --probe tools/oracle/probe-rail-box-orientation/probe.json --work-dir /tmp/railbox --factorio ~/GitHub/factorio-oracle/installs/factorio-2.0.77.app --version 2.0.77 >/tmp/railbox-run.json
+```
+
+```fish
+node tools/oracle/analyze-rail-box-orientation.mjs /tmp/railbox/write/script-output/oracle-dump.json --write-fixture
+```
+
+The `cd` is load-bearing: `control_lua_file` is repo-relative and the CLI reads
+it against the shell's working directory.
+
+## One thing that cost two runs
+
+**A `]]` inside a `--[[` Lua comment closes the comment.** This probe's header
+explains a collision box in Lua table notation, whose own brackets terminated
+the comment early, so everything after it parsed as code and the mod silently
+never registered its `on_init`. The failure names nothing useful: the run
+reports "no oracle-dump.json was written", which is the same message a
+`factorio_version` mismatch produces.
+
+Two notes on finding it. What located it was running the CLI's own
+`examples/pumpjack-terminals` probe as a **control** - it passed on the same
+binary and the same command shape, which moved the fault from the environment
+to this file in one step. And the tell in the log is a line that is _absent_:
+a working run prints `Checksum for script __<mod>__/control.lua` and a broken
+one does not, while both print everything else identically.
+
+The header is a level-1 long comment now. Note that the fix has the same trap
+one level up - writing the level-1 terminator inside the comment closes it too,
+which is what broke the first attempt at the fix.

--- a/tools/oracle/probe-rail-box-orientation/control.lua
+++ b/tools/oracle/probe-rail-box-orientation/control.lua
@@ -1,0 +1,147 @@
+--[==[
+Does a `half-diagonal-rail` actually have the collision box `data.json`
+describes, at the orientation the grid-position probe's run 2 layout assumes?
+
+This exists to de-risk that run before a person spends time on it. Run 2 puts a
+half-diagonal rail at (20, 20) and predicts three distinct y readings from it -
+centre 20, tile-footprint edge 19, collision-box edge 17.764 - and that spread
+is the only thing separating "the corner is the footprint edge" from "the
+corner is the collision box edge".
+
+Those numbers come from `data.json`, which carries one box per prototype.
+This header is a level-1 long comment on purpose. The box below is written in
+Lua table notation, and a bare double-close-bracket inside an ordinary long
+comment terminates it, so everything after it parses as code. Same family as
+the backtick-in-a-template-literal trap the other probe carries, and note that
+naming the level-1 terminator in this sentence would close this comment too -
+which is exactly the mistake that cost the first two runs here.
+
+`[[-0.75, -2.236], [0.75, 2.236]]`, tall and narrow. Half-diagonal rails exist
+only at diagonal orientations, so a rail stored at a rotated direction has that
+extent on x instead. Run 2 would then measure nothing and report no surviving
+reading, which reads as "the rule is wrong" rather than "the instrument was
+pointed sideways".
+
+Nothing here needs a player, so it is a `create` run - docs/method.md, "ask the
+cheapest question that settles the thing". The grid-position probe needs a
+person only because its field has no scripting API; this question does not
+touch that field.
+
+Three things are recorded per direction, and the third is the one that matters:
+
+  requested        what was asked for
+  stored_direction what `entity.direction` reads back, since rails normalise
+  bounding_box     the entity's **actual** world box, which is what rotates
+
+`prototype_collision_box` is the control: it is the number the grid-position
+analyzer's GEOMETRY table hardcodes, so if it disagrees with `data.json` the
+exporter has drifted and the comparison is void rather than interesting.
+
+Shaped after `factorio-oracle`'s own pumpjack-terminals example, which is the
+working reference for a create-mode probe: generate the chunks first, because
+the default generated area is small and (20, 20) sits near its edge, and let
+`on_init` return normally after writing rather than raising the sentinel.
+]==]
+
+local function collect()
+    local surface = game.surfaces[1]
+    local force = game.forces.player
+    local NAME = 'half-diagonal-rail'
+    local POS = { x = 20, y = 20 }
+
+    surface.request_to_generate_chunks({ 20, 20 }, 3)
+    surface.force_generate_chunk_requests()
+
+    local proto = prototypes.entity[NAME]
+    local out = {
+        question = 'what box does a half-diagonal-rail actually have, per direction',
+        name = NAME,
+        requested_position = POS,
+        active_mods = script.active_mods,
+        prototype_collision_box = proto.collision_box,
+        prototype_tile_width = proto.tile_width,
+        prototype_tile_height = proto.tile_height,
+        directions = {},
+        errors = {},
+    }
+
+    for dir = 0, 15 do
+        local row = { requested_direction = dir }
+
+        local ok, err = pcall(function()
+            -- Clear first: a rail left from the previous direction would refuse
+            -- the next one and turn a geometry answer into a collision answer.
+            for _, e in pairs(surface.find_entities_filtered { area = { { 10, 10 }, { 30, 30 } } }) do
+                if e.valid and e.type ~= 'character' then
+                    e.destroy()
+                end
+            end
+
+            local e = surface.create_entity {
+                name = NAME,
+                position = POS,
+                direction = dir,
+                force = force,
+            }
+            if not e then
+                row.created = false
+                return
+            end
+            row.created = true
+            row.stored_direction = e.direction
+            row.position = { x = e.position.x, y = e.position.y }
+            local bb = e.bounding_box
+            row.bounding_box = {
+                left_top = { x = bb.left_top.x, y = bb.left_top.y },
+                right_bottom = { x = bb.right_bottom.x, y = bb.right_bottom.y },
+            }
+
+            --[[
+            What the *export* carries, which is the only thing the grid-position
+            analyzer ever sees. It reads positions out of the blueprint string
+            rather than off the entity, and a rail can sit at one direction in
+            the world while serializing as another.
+            ]]
+            local inv = game.create_inventory(1)
+            inv[1].set_stack { name = 'blueprint', count = 1 }
+            inv[1].create_blueprint {
+                surface = surface,
+                force = force,
+                area = { { 10, 10 }, { 30, 30 } },
+                always_include_tiles = false,
+            }
+            row.exported = inv[1].get_blueprint_entities()
+            inv.destroy()
+
+            e.destroy()
+        end)
+
+        if not ok then
+            row.error = tostring(err)
+            out.errors[#out.errors + 1] = 'direction ' .. dir .. ': ' .. tostring(err)
+        end
+        out.directions[#out.directions + 1] = row
+    end
+
+    --[[
+    Every entity's runtime collision box, so the per-rail finding above can be
+    checked against the whole set rather than generalised from one prototype.
+    The editor reads these из data.json, and if that file disagrees with the
+    running game then every footprint the editor computes is suspect, not just
+    this rail's.
+    ]]
+    out.all_collision_boxes = {}
+    for name, ep in pairs(prototypes.entity) do
+        local bb = ep.collision_box
+        out.all_collision_boxes[name] = {
+            bb.left_top.x,
+            bb.left_top.y,
+            bb.right_bottom.x,
+            bb.right_bottom.y,
+        }
+    end
+
+    helpers.write_file('oracle-dump.json', helpers.table_to_json(out), false)
+end
+
+script.on_init(collect)

--- a/tools/oracle/probe-rail-box-orientation/probe.json
+++ b/tools/oracle/probe-rail-box-orientation/probe.json
@@ -1,0 +1,12 @@
+{
+    "mode": "create",
+    "mod": {
+        "name": "rail_box_orientation",
+        "version": "0.0.1",
+        "dependencies": ["base"],
+        "control_lua_file": "tools/oracle/probe-rail-box-orientation/control.lua"
+    },
+    "seed": 1,
+    "timeout_seconds": 180,
+    "capture_active_mods": true
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -207,6 +207,14 @@ export default defineConfig({
             '.superpowers',
             '**/*.yml',
             '**/*.yaml',
+            // Oracle fixtures are machine output, and the two writers disagree
+            // on their canonical form: a generator emits JSON.stringify's
+            // 4-space expansion while oxfmt collapses short arrays onto one
+            // line, so whichever ran last wins and the other reports a
+            // failure. The generator owns these files - "never hand-edit a
+            // fixture to make something pass" applies to a formatter as much
+            // as to a person, since a reformat is a diff no probe produced.
+            'tools/oracle/fixtures',
         ],
     },
     test: {


### PR DESCRIPTION
Measures what the blueprint GUI's **"Grid position"** field does to an exported blueprint, on Factorio **2.0.77** - the version this editor targets. It is the first probe here to run on the shared `factorio-oracle` CLI (#235), and the first to need a person at the keyboard since the zoom one.

## Why it had to be interactive

Nothing in `runtime-api.json` reaches this field. The game exposes three blueprint snapping attributes and none of them is it, and `create_blueprint` takes no anchor parameter. The field writes **no key at all** into the export; it translates the entity and tile coordinates instead. So there is no script that can set it and no dump that can read it back.

## What it found

`survivingReadings: ["entityEdgesAndTiles"]`, with all three controls passing and the three rival readings killed on every scored row.

The rule is `-floor(min corner) = T`, the corner taken over entity **edges** and tiles. It is an **absolute target, not a relative nudge**: setting 8,9 on top of 3,5 moved the corner to -8,-9 rather than -11,-14, which is the only thing separating those two readings and the reason the session asks for a second value on top of a first.

## The apparent contradiction was a name collision

`tools/oracle/fixtures/blueprint-grid-position.json` scores the "grid position moves entities" premise 0 of 2 on this same 2.0.77, and PR #243 rebuilds `getGridPositionDisplay()` on the opposite premise. Both are right. The panel carries **three** X/Y pairs:

```
☑ Snap to grid
  Grid size        Width 12   Height 17    <- snap-to-grid
  Grid position        X 3    Y 5          <- shifts the exported content
  ● Absolute           X 9    Y 10         <- position-relative-to-grid
  ○ Relative
```

The older fixture measured the Absolute row. Two of the three pairs were on screen at once holding different values, which is as direct as that distinction gets. The new fixture carries a `supersedes` block saying the two answer different questions, and `factorio-oracle`'s `docs/method.md` has been corrected: its PR #222 entry read "a blueprint's grid position moves its entities. It does not", which was true of the attribute and read as a refutation of the field.

## One finding for PR #243

`getGridPositionDisplay()` builds its minimum from `e.position.x`, the entity **centre**. The game takes the **edge**, so the formula is off by `floor(size/2)` on whichever axis a multi-tile entity sets the minimum. A belt-edged blueprint agrees; an assembler-edged one is a tile out.

What hides it is that the editor stays self-consistent: `commitGridPosition` solves for the offset that makes `getGridPositionDisplay()` read the target back, using the same formula on both sides, so the box always shows what was typed. Only a comparison against the game exposes it. This is posted on #243 as finding 15.

The measurement **cannot** say whether the game uses the tile footprint edge or the collision box edge, and that decides the fix: for `assembling-machine-1` they are 9.0 and about 9.1, which floor to the same integer. Separating them needs an entity whose collision box is inset by more than the fractional part.

## Also here

- `tools/oracle/fixtures` is exempt from oxfmt. The generator writes `JSON.stringify(x, null, 4)` and oxfmt collapses short arrays, so whichever ran last won and the other reported a failure. "Never hand-edit a fixture to make something pass" applies to a formatter too.
- The analyzer emits `stepsNotCaptured`. An interactive probe ends when the person stops playing, and a fixture that simply omits a step reads as "this step does not exist" rather than "it was not run". This run has `["abs-2-6", "snap-off"]`; neither is load-bearing.
- `SESSION.md`'s run command carries a `cd`. `control_lua_file` in a `probe.json` is repo-relative and the CLI reads it against the shell's cwd, so an absolute `--probe` from elsewhere fails naming the Lua file rather than the cause.
- `SESSION.md` step 6 said to pick Absolute, which is already the default the moment Snap to grid is ticked, and described its pair as the Grid position one.

No production code changes. `vp check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RiP5JRvEpzDXM4AY5ouGN
