### PR TITLE
Fix the three PR #249 review findings that arrived after the merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -594,7 +594,17 @@ file rather than the cause; the `SESSION.md` command carries the `cd`. An
 interactive probe **ends when the person stops playing**, so the analyzer emits
 `stepsNotCaptured` - a fixture that simply omits a step reads as "this step does
 not exist" rather than "it was not run", which is the silent cap the method
-warns about. And **a `]]` inside a `--[[` Lua comment closes it**: a probe
+warns about. **That field then re-created the silent cap it was written to
+prevent**, which is the part worth remembering. The game refuses some grid
+positions, so the session says to substitute the nearest accepted value, and the
+analyzer suppressed the asked-for label so a substitution would not read as a
+skipped step. It did that with one boolean covering the whole `gridpos-` class,
+so two substitutions excused **three** missing steps and `gridpos-0-0` - the row
+that establishes the non-default check, and genuinely skipped - vanished from a
+list whose only job is to name what was skipped. A suppression rule needs to be
+as narrow as the thing it excuses: one substitution now excuses one missing step,
+counted rather than assumed. Found by review on PR #249, and only after the
+merge, so it shipped. And **a `]]` inside a `--[[` Lua comment closes it**: a probe
 header explaining a collision box in Lua table notation silently turned the
 rest of the file into code, so the mod never registered its `on_init` and the
 run reported "no oracle-dump.json was written" - the same message a

--- a/tools/oracle/analyze-blueprint-grid-position-gui.mjs
+++ b/tools/oracle/analyze-blueprint-grid-position-gui.mjs
@@ -218,8 +218,16 @@ const EXPECTED = {
  * so following that instruction produced an unscored row and a session that
  * measured nothing. Negative values are allowed: `gridpos--3-5` is x=-3, y=5.
  */
+/**
+ * The one place a `gridpos-` label is recognised. Named rather than repeated,
+ * because `stepsNotCaptured` below has to agree with `expectedFor` about what
+ * counts as one, and a rule written down twice is a rule that drifts - the
+ * looser copy silently wins. Its first casualty is in the note there.
+ */
+const GRIDPOS_LABEL = /^gridpos-(-?\d+)-(-?\d+)$/
+
 function expectedFor(label) {
-    const m = /^gridpos-(-?\d+)-(-?\d+)$/.exec(label)
+    const m = GRIDPOS_LABEL.exec(label)
     if (m) return { gridPosition: { x: Number(m[1]), y: Number(m[2]) } }
     return EXPECTED[label]
 }
@@ -392,15 +400,29 @@ function main() {
     // steps do not exist" rather than "these steps were not run" - the silent
     // cap docs/method.md warns about. Named here so a reader can tell a gap
     // from a finding.
-    const substituted = cases.some(
-        c => c.label.startsWith('gridpos-') && EXPECTED[c.label] === undefined
-    )
+    // A refused value means the operator captured `gridpos-4-6` in place of
+    // `gridpos-3-5`. Reporting the asked-for label as "not captured" would read
+    // as a skipped step rather than a substituted one.
+    //
+    // Nothing records *which* asked-for step a substitution replaced, so this
+    // counts instead: each substitution excuses exactly one missing `gridpos-`
+    // step, spent in `EXPECTED` key order, which is the order SESSION.md walks
+    // them. It was a bare boolean suppressing the whole `gridpos-` class, and
+    // that hid a real gap in this probe's own fixture - two substitutions
+    // (2,6 and 8,10) excused all three missing steps, so `gridpos-0-0`, the one
+    // genuinely skipped and the one that establishes the non-default check,
+    // vanished from `stepsNotCaptured` rather than being named. Exactly the
+    // silent cap the note below warns about, in the code written to prevent it.
+    // Found by review on PR #249, posted after the merge.
+    let substitutionCredits = cases.filter(
+        c => GRIDPOS_LABEL.test(c.label) && EXPECTED[c.label] === undefined
+    ).length
     const stepsNotCaptured = Object.keys(EXPECTED).filter(label => {
         if (cases.some(c => c.label === label)) return false
-        // A refused value means the operator captured `gridpos-4-6` in place of
-        // `gridpos-3-5`. Reporting the asked-for label as "not captured" would
-        // read as a skipped step rather than a substituted one.
-        if (substituted && label.startsWith('gridpos-')) return false
+        if (GRIDPOS_LABEL.test(label) && substitutionCredits > 0) {
+            substitutionCredits -= 1
+            return false
+        }
         return true
     })
 

--- a/tools/oracle/analyze-rail-box-orientation.mjs
+++ b/tools/oracle/analyze-rail-box-orientation.mjs
@@ -103,7 +103,16 @@ const fixture = {
         requestedPosition: dump.requested_position,
         actualPosition: placed[0]?.position,
         storedDirections: [...new Set(placed.map(d => d.stored_direction))].sort((a, b) => a - b),
-        runtimeCollisionBox: box(dump.directions.find(d => d.created).bounding_box),
+        // Guarded, because the empty case is exactly the one the controls above
+        // exist to report: no direction placed anything, or the Lua pcall raised
+        // before `created` was ever set. Reading `.bounding_box` off the
+        // `undefined` that `find` answers throws here, and `controlsAllPassed`
+        // is not consulted until after this whole literal is built - so the
+        // total-failure case exited with a TypeError naming neither the probe
+        // nor the failed control. `actualPosition` two lines up already guarded
+        // the same emptiness; this was the one read that did not. Found by
+        // review on PR #249, posted after the merge.
+        runtimeCollisionBox: placed[0] !== undefined ? box(placed[0].bounding_box) : null,
         prototypeCollisionBox: dump.prototype_collision_box,
     },
     dataJsonVersusRuntime: {

--- a/tools/oracle/fixtures/blueprint-grid-position-gui.json
+++ b/tools/oracle/fixtures/blueprint-grid-position-gui.json
@@ -116,6 +116,7 @@
     "scoredRows": 2,
     "stepsNotCaptured": [
         "untouched",
+        "gridpos-0-0",
         "abs-2-6",
         "snap-off"
     ],

--- a/tools/oracle/probe-blueprint-grid-position-gui/README.md
+++ b/tools/oracle/probe-blueprint-grid-position-gui/README.md
@@ -63,13 +63,28 @@ could not say is **which** edge - a tile footprint edge or a `collision_box`
 edge - because for every entity it placed the two floor to the same integer.
 `assembling-machine-1` is 9.0 against 9.3.
 
-**Run 2** replaces the assembling machine with a `half-diagonal-rail`, which is
-close to the only entity that can settle it:
+**Run 2** adds a `half-diagonal-rail` alongside the assembling machine, which
+moves out of the way rather than leaving. The rail is close to the only entity
+that can settle it:
 
 | Axis | Decided by                     | Separates                                                  |
 | ---- | ------------------------------ | ---------------------------------------------------------- |
-| y    | a `half-diagonal-rail` at y=20 | centre **20**, footprint edge **19**, box edge **17.764**  |
+| y    | a `half-diagonal-rail` at y=21 | centre **21**, footprint edge **20**, box edge **19.102**  |
 | x    | stone-path tiles at x=2        | whether tiles count, against the nearest entity reading, 9 |
+
+This table read `y=20` and a box edge of `17.764` until review caught it, and
+it was wrong for two compounding reasons - both of them things
+`probe-rail-box-orientation` measured and this file had not caught up with.
+The rail sits at **21**, not the 20 it is asked for, because a rail requested
+at (20, 20) is placed at (21, 21). And its box edge comes from the **runtime**
+box, `-1.8984375`, giving `21 - 1.8984375 = 19.102`; `data.json` says `-2.236`,
+which the game disagrees with, rails being the only entities the two disagree
+about at all (issue #251). The old figure took the wrong box from the wrong
+position: `20 - 2.236`.
+
+Getting either wrong matters here, because this README is what an operator
+reads while the run is in front of them, and the note below says a bad
+prediction "is not silent". It is not - but it looks identical to a bad run.
 
 The editor derives a footprint by _ceiling_ the collision box
 (`factorioData.ts:617`), so a box cannot escape its own footprint unless a


### PR DESCRIPTION
PR #249 drew seven review findings. Four arrived while it was open and were fixed in `2809e8d6`. The other three were posted at `22:47:0x`, three minutes and thirty-nine seconds after the squash merge at `22:43:28Z`, so they shipped unaddressed. This is those three.

No production code. `vp check` is clean, and both touched fixtures regenerate byte for byte from their original capture streams.

## The unguarded read that would hide its own control

`analyze-rail-box-orientation.mjs` read `.bounding_box` off `dump.directions.find(d => d.created)`. `find` answers `undefined` when no direction placed anything - every `create_entity` failing, or the Lua `pcall` raising before `created` is set - and that is precisely the case the "every direction produced a placement" and "the probe recorded no Lua errors" controls exist to report.

Instead it threw a `TypeError` while building the fixture literal, and `controlsAllPassed` is not consulted until after that literal is built. So a total failure exited with a stack trace naming neither the probe nor the failed control. `actualPosition` two lines above already guarded the same emptiness with `placed[0]?.position`; this was the one read that did not.

Regenerating `rail-box-orientation.json` from the original dump produces a byte-identical file, so the guard is confirmed to change nothing on real data.

## A suppression rule wider than the thing it excused

The game refuses some grid positions - run 2's layout rejected 3,5 on the parity rule after run 1 accepted it - so `SESSION.md` tells the operator to substitute the nearest accepted value. `analyze-blueprint-grid-position-gui.mjs` suppressed the asked-for label from `stepsNotCaptured` so a substitution would not read as a skipped step.

It did that with a single boolean over every `gridpos-` label. Two substitutions therefore excused **three** missing steps, and `gridpos-0-0` vanished - a step genuinely never run, and the one that establishes the non-default check, disappearing from the list whose only job is to name what was skipped.

That is the silent cap `stepsNotCaptured` was written to prevent, reproduced inside the code written to prevent it. One substitution now excuses one missing step, counted and spent in the order `SESSION.md` walks them. The `gridpos-` pattern also moves into a named `GRIDPOS_LABEL` constant: `expectedFor` matched `/^gridpos-(-?\d+)-(-?\d+)$/` while this filter used a bare `startsWith`, and the looser copy was the one in charge.

The fixture is **regenerated** from the original run's capture stream, not edited. It reproduces byte for byte apart from the one restored entry:

```
 "stepsNotCaptured": [
     "untouched",
+    "gridpos-0-0",
     "abs-2-6",
     "snap-off"
 ]
```

One note on the review that found this: it cited a case labelled `gridpos-3-5-saved` as live evidence. That label is real, but it belongs to **run 1** - it was in the fixture from `e165d3a4` through `6f1ed55a` and was replaced twelve minutes before the review posted, when run 2's fixture landed in `55533bda`. The mechanism was live regardless, through `gridpos-0-0` instead.

## A README predicting numbers the probe had already corrected

`probe-blueprint-grid-position-gui/README.md` still described run 2 with pre-measurement figures:

| It said | The code says |
| --- | --- |
| Run 2 "replaces the assembling machine" | `LAYOUT` keeps `assembling-machine-1`, moves it to (10.5, 30.5) and **adds** the rail as a fourth entity |
| rail at **y=20**, box edge **17.764** | `control.lua:100` places it at **y=21**; its own header at line 77 predicts box edge **19.102** |

Both errors compound. The rail sits at 21 because `probe-rail-box-orientation` measured that one requested at (20, 20) is placed at (21, 21). Its box edge is `21 - 1.8984375 = 19.102` off the measured runtime box; `data.json` says `-2.236`, which the game disagrees with, rails being the only entities the two disagree about at all (#251). The old 17.764 took the wrong box from the wrong position: `20 - 2.236`.

This matters because the README is what an operator reads while the run is in front of them, and it promises that a wrong prediction "is not silent". It is not - but it looks identical to a bad run, and all three predictions would have missed.

`analyze-blueprint-grid-position-gui.mjs:63` and `control.lua:77` already carried 19.102; the README was the last file with the old number.

## CLAUDE.md

The `stepsNotCaptured` paragraph gains the worked example, because the failure is more instructive than the field: a suppression rule has to be as narrow as the thing it excuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SHoE9cH9kd6vtpHM1PzZ1