### PR TITLE
Handle blueprints without generated icons

### DIFF
--- a/packages/editor/src/core/Blueprint.test.ts
+++ b/packages/editor/src/core/Blueprint.test.ts
@@ -1,0 +1,46 @@
+import { beforeAll, describe, expect, it } from 'vite-plus/test'
+import { Blueprint } from './Blueprint'
+import { loadData } from './factorioData'
+
+beforeAll(() => {
+    loadData(
+        JSON.stringify({
+            items: {},
+            fluids: {},
+            signals: {},
+            recipes: {},
+            entities: {
+                'space-platform-hub': {
+                    type: 'space-platform-hub',
+                    name: 'space-platform-hub',
+                    collision_box: [
+                        [-1, -1],
+                        [1, 1],
+                    ],
+                },
+            },
+            tiles: {},
+            inventoryLayout: [],
+            utilitySprites: {},
+            utilityConstants: {},
+            guiStyle: {},
+            defines: {},
+        })
+    )
+})
+
+describe('Blueprint icon generation', () => {
+    it('serializes without icons when every entity is non-minable', () => {
+        const blueprint = new Blueprint({
+            entities: [
+                {
+                    entity_number: 1,
+                    name: 'space-platform-hub',
+                    position: { x: 0, y: 0 },
+                },
+            ],
+        })
+
+        expect(blueprint.serialize().icons).toEqual([])
+    })
+})

--- a/packages/editor/src/core/Blueprint.test.ts
+++ b/packages/editor/src/core/Blueprint.test.ts
@@ -1,8 +1,11 @@
 import { beforeAll, describe, expect, it } from 'vite-plus/test'
 import { Blueprint } from './Blueprint'
+import { encode, getAndClearLoadWarnings, getBlueprintOrBookFromSource } from './bpString'
 import { loadData } from './factorioData'
 
 beforeAll(() => {
+    // loadData permanently replaces FD's accessors. Vitest's per-file module
+    // isolation keeps this synthetic dataset from leaking into other test files.
     loadData(
         JSON.stringify({
             items: {},
@@ -30,7 +33,7 @@ beforeAll(() => {
 })
 
 describe('Blueprint icon generation', () => {
-    it('serializes without icons when every entity is non-minable', () => {
+    it('round-trips with an entity icon when every entity is non-minable', async () => {
         const blueprint = new Blueprint({
             entities: [
                 {
@@ -41,6 +44,17 @@ describe('Blueprint icon generation', () => {
             ],
         })
 
-        expect(blueprint.serialize().icons).toEqual([])
+        const icons = [
+            {
+                index: 1,
+                signal: { type: 'entity' as const, name: 'space-platform-hub' },
+            },
+        ]
+        expect(blueprint.serialize().icons).toEqual(icons)
+
+        const roundTripped = await getBlueprintOrBookFromSource(await encode(blueprint))
+
+        expect(getAndClearLoadWarnings()).toEqual([])
+        expect(roundTripped.serialize().icons).toEqual(icons)
     })
 })

--- a/packages/editor/src/core/Blueprint.ts
+++ b/packages/editor/src/core/Blueprint.ts
@@ -769,6 +769,7 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
                 (a, b) => getItemScore(b) - getItemScore(a)
             )
 
+            if (iconPairs.length === 0) return
             this.icons.set(1, iconPairs[0][0])
             if (
                 iconPairs[1] &&
@@ -782,6 +783,7 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
                 (a, b) => b[1] - a[1]
             )
 
+            if (iconPairs.length === 0) return
             this.icons.set(1, iconPairs[0][0])
         }
     }

--- a/packages/editor/src/core/Blueprint.ts
+++ b/packages/editor/src/core/Blueprint.ts
@@ -762,7 +762,10 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
                 (a, b) => getItemScore(b) - getItemScore(a)
             )
 
-            if (iconPairs.length === 0) return
+            if (iconPairs.length === 0) {
+                this.icons.set(1, this.entities.valuesArray()[0].name)
+                return
+            }
             this.icons.set(1, iconPairs[0][0])
             if (
                 iconPairs[1] &&
@@ -776,6 +779,8 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
                 (a, b) => b[1] - a[1]
             )
 
+            // Defensive only: every current tile has an item, and Factorio has
+            // no tile signal type to use as a schema-valid fallback.
             if (iconPairs.length === 0) return
             this.icons.set(1, iconPairs[0][0])
         }


### PR DESCRIPTION
## Summary

Fix blueprint export when automatic icon generation has no item-backed candidate, while keeping the serialized blueprint valid against the editor schema.

A blueprint containing only non-minable entities, such as `space-platform-hub`, produces an empty item-icon candidate list. `generateIcons()` previously dereferenced the first missing candidate and threw before the blueprint string reached the clipboard.

## Changes

- Guard both entity and tile icon-candidate lists before their indexed reads.
- When an entity blueprint has no item-backed icon, use the first entity's own name as an `entity`-type signal. For `space-platform-hub`, this serializes as `{ index: 1, signal: { type: entity, name: space-platform-hub } }`.
- Keep the tile guard defensive and document why: every tile in current data has an item, and Factorio has no tile signal type for a schema-valid prototype-name fallback.
- Replace the empty-icon assertion with a full export/re-import regression test that confirms the icon survives and no validation warning is produced.
- Document why the test's synthetic `loadData()` call is isolated safely by Vitest's per-file module state.

## Verification

- Focused `Blueprint.test.ts` — 1 test passed
- `vp check --fix` — 179 files, no warnings, lint errors, or type errors
- `vp test` — 16 files, 188 tests passed
- `git diff --check`

Closes #254