### PR TITLE
Re-take the vp installer checksum, which rotated under an unchanged VP_VERSION

### DIFF
--- a/.github/actions/setup-vp/action.yml
+++ b/.github/actions/setup-vp/action.yml
@@ -38,8 +38,29 @@ runs:
         # - a mismatch fails the step rather than running a script nobody read -
         # but it does mean a red `Set up Vite+` is not necessarily the fault of
         # the branch it appears on. Re-fetch, read the diff, then re-hash.
+        #
+        # VP_HOME pins the monolithic ~/.vite-plus layout, which the two lines
+        # below hardcode (the PATH entry, and the cache `path:` above). It is a
+        # no-op at 0.2.9 - that is already where the installer puts things - and
+        # it is here for 0.3.0, which moves a default install to XDG paths
+        # (~/.local/share/vite-plus/bin). Measured: with VP_VERSION=0.3.0 and no
+        # VP_HOME, a sandboxed-HOME install lands in XDG and both lines below are
+        # wrong, so every job fails with `vp: command not found` - which reads as
+        # a broken toolchain rather than a wrong path.
+        #
+        # The installer does have a compatibility shim for this, and it does not
+        # cover us: it only fires when GITHUB_ACTION_REPOSITORY is
+        # voidzero-dev/setup-vp, and this is a hand-rolled composite action. What
+        # protects us today is only that a 0.2.9 payload cannot answer
+        # VP_DUMP_DIRS, so the installer falls back to the legacy layout. A 0.3.0
+        # payload can answer, so it will not fall back. And the vite-plus cache
+        # key carries the version with no restore-keys, so a bump is a guaranteed
+        # cache miss with no existing install to reuse - the break would be
+        # certain, not intermittent.
+        #
+        # So this line has to be here BEFORE VP_VERSION moves, not with it.
         curl -fsSL https://vite.plus -o vp-install.sh
         echo "3dd88cedb6d9b2665c305eda5413971417c8f183a819386148131b66a2cc6b2e  vp-install.sh" | sha256sum -c -
-        VP_VERSION=0.2.9 VP_NODE_MANAGER=yes bash vp-install.sh
+        VP_HOME="$HOME/.vite-plus" VP_VERSION=0.2.9 VP_NODE_MANAGER=yes bash vp-install.sh
         echo "$HOME/.vite-plus/bin" >> "$GITHUB_PATH"
         rm -f vp-install.sh

--- a/.github/actions/setup-vp/action.yml
+++ b/.github/actions/setup-vp/action.yml
@@ -26,11 +26,20 @@ runs:
       run: |
         # Pin + verify the installer instead of curl | bash. The vp binary and
         # vite-plus package are already version-pinned (VP_VERSION) and immutable
-        # via the npm registry; this also pins the mutable bootstrap script. Bump
-        # the VP_VERSION (here + the cache key above) and the checksum together
-        # when intentionally upgrading the toolchain.
+        # via the npm registry; this also pins the mutable bootstrap script.
+        #
+        # The two move independently, and this hash has now been bumped for each
+        # reason in turn. A toolchain upgrade bumps VP_VERSION (here + the cache
+        # key above) and usually leaves the hash alone - measured across
+        # 0.2.6 -> 0.2.8, where the script did not change at all. The other
+        # direction is what happened on 2026-08-25: the script rotated on its own
+        # with VP_VERSION untouched, so every job on every branch failed at this
+        # step until the hash was re-taken. That is the pin working, not breaking
+        # - a mismatch fails the step rather than running a script nobody read -
+        # but it does mean a red `Set up Vite+` is not necessarily the fault of
+        # the branch it appears on. Re-fetch, read the diff, then re-hash.
         curl -fsSL https://vite.plus -o vp-install.sh
-        echo "58bb052c6a007e662e99667d65686251b16d6b39aa21155487da6d51280b3d54  vp-install.sh" | sha256sum -c -
+        echo "3dd88cedb6d9b2665c305eda5413971417c8f183a819386148131b66a2cc6b2e  vp-install.sh" | sha256sum -c -
         VP_VERSION=0.2.9 VP_NODE_MANAGER=yes bash vp-install.sh
         echo "$HOME/.vite-plus/bin" >> "$GITHUB_PATH"
         rm -f vp-install.sh


### PR DESCRIPTION
## What is broken

Every job on every branch has failed at `Set up Vite+` since 2026-08-25:

```
sha256sum: WARNING: 1 computed checksum did NOT match
vp-install.sh: FAILED
```

Nothing in the repo changed. `.github/actions/setup-vp/action.yml` pins the bootstrap script at `https://vite.plus`, and that script is versioned independently of the toolchain. vite-plus 0.3.0 shipped on 2026-08-24 and rewrote `install.sh` for a new directory layout, so the pinned hash stopped matching while `VP_VERSION` stayed at 0.2.9.

That is the pin working, not breaking. It failed the step rather than running a script nobody had read.

## Two changes

**1. Re-take the hash.** `58bb052c…` -> `3dd88ced…`, from a fresh fetch, verified with `shasum -a 256 -c -`.

I read the script before re-hashing, since that is the whole point of pinning it. It is the same 1521-line Vite+ installer: the only network hosts are `registry.npmjs.org` (the pinned `VP_VERSION`, immutable on npm) and `registry-bridge.viteplus.dev`, which is reachable only when `VP_PR_VERSION` is set - CI never sets it. No `eval`, and nothing fetched is piped into a shell.

**2. Set `VP_HOME="$HOME/.vite-plus"`.** This is a no-op today and a guard against the next bump.

0.3.0 moves a default install to XDG paths. Measured, with `VP_VERSION=0.3.0` and no `VP_HOME`, a sandboxed-`HOME` install reports:

```
Bin directory:  ~/.local/share/vite-plus/bin
```

This action hardcodes `~/.vite-plus` twice - the `GITHUB_PATH` entry and the cache `path:` - so both would be wrong and every job would fail with `vp: command not found`, which reads as a broken toolchain rather than a wrong path.

Three things make that certain rather than a risk:

- The installer's compatibility shim only fires when `GITHUB_ACTION_REPOSITORY = voidzero-dev/setup-vp`. This is a hand-rolled composite action, so it never fires for us. The release notes' "CI that installs through `setup-vp` keeps the single-root layout automatically" does not cover this repo.
- What protects us today is only that a 0.2.9 payload cannot answer `VP_DUMP_DIRS`, so the installer falls back to the legacy layout. A 0.3.0 payload can answer, so it will not fall back.
- The vite-plus cache key carries the version and has no `restore-keys`, so a version bump is a guaranteed cache miss with no existing install to reuse.

It goes in now rather than with the version bump because Renovate has 0.3.0 awaiting schedule, and its two `customManagers` move `VP_VERSION` and the cache key together - without this line.

## Test plan

- [x] `shasum -a 256 -c -` verifies the new hash against a fresh fetch
- [x] `VP_HOME` verified to pin the monolithic layout at 0.3.0, with no XDG directories created
- [x] CI fully green on the checksum commit alone - all four Playwright shards, `checks`, both Rust jobs
- [x] `vp check` (239 files, 0 errors), `vp test` (180/180) and the full Playwright suite (212 passed) pass locally
- [ ] CI green again with `VP_HOME` added, confirming it is a no-op at 0.2.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RKueZ4oW4T9UnnAmdJZsD