### PR TITLE
Keep history transactions consistent after errors

### DIFF
--- a/packages/editor/src/containers/PaintBlueprintContainer.ts
+++ b/packages/editor/src/containers/PaintBlueprintContainer.ts
@@ -193,50 +193,48 @@ export class PaintBlueprintContainer extends PaintContainer {
             ([entity, container]) => [entity, container, container.planPlacement()] as const
         )
 
-        this.bpc.bp.history.startTransaction('Create Entities')
-
-        const oldEntIDToNewEntID = new Map<number, number>()
-        for (const [entity, container, placement] of placements) {
-            const e = container.placeEntityContainer(placement)
-            if (e) {
-                oldEntIDToNewEntID.set(entity.entityNumber, e.entityNumber)
+        this.bpc.bp.history.transaction('Create Entities', () => {
+            const oldEntIDToNewEntID = new Map<number, number>()
+            for (const [entity, container, placement] of placements) {
+                const e = container.placeEntityContainer(placement)
+                if (e) {
+                    oldEntIDToNewEntID.set(entity.entityNumber, e.entityNumber)
+                }
             }
-        }
 
-        // Create wire connections
-        if (oldEntIDToNewEntID.size !== 0) {
-            for (const [oldID] of oldEntIDToNewEntID) {
-                this.bp.wireConnections
-                    .getEntityConnections(oldID)
-                    .flatMap<IConnection>(connection => {
-                        const en0 = oldEntIDToNewEntID.get(connection.cps[0].entityNumber)
-                        const en1 = oldEntIDToNewEntID.get(connection.cps[1].entityNumber)
-                        // only copy a wire when both of its ends were pasted
-                        if (en0 === undefined || en1 === undefined) return []
-                        return [
-                            {
-                                ...connection,
-                                cps: [
-                                    { ...connection.cps[0], entityNumber: en0 },
-                                    { ...connection.cps[1], entityNumber: en1 },
-                                ],
-                            },
-                        ]
-                    })
-                    .forEach(conn => this.bpc.bp.wireConnections.create(conn))
+            // Create wire connections
+            if (oldEntIDToNewEntID.size !== 0) {
+                for (const [oldID] of oldEntIDToNewEntID) {
+                    this.bp.wireConnections
+                        .getEntityConnections(oldID)
+                        .flatMap<IConnection>(connection => {
+                            const en0 = oldEntIDToNewEntID.get(connection.cps[0].entityNumber)
+                            const en1 = oldEntIDToNewEntID.get(connection.cps[1].entityNumber)
+                            // only copy a wire when both of its ends were pasted
+                            if (en0 === undefined || en1 === undefined) return []
+                            return [
+                                {
+                                    ...connection,
+                                    cps: [
+                                        { ...connection.cps[0], entityNumber: en0 },
+                                        { ...connection.cps[1], entityNumber: en1 },
+                                    ],
+                                },
+                            ]
+                        })
+                        .forEach(conn => this.bpc.bp.wireConnections.create(conn))
+                }
             }
-        }
-
-        this.bpc.bp.history.commitTransaction()
+        })
     }
 
     public override removeContainerUnder(): void {
         if (!this.visible) return
 
-        this.bpc.bp.history.startTransaction('Remove Entities')
-        for (const [, c] of this.entities) {
-            c.removeContainerUnder()
-        }
-        this.bpc.bp.history.commitTransaction()
+        this.bpc.bp.history.transaction('Remove Entities', () => {
+            for (const [, c] of this.entities) {
+                c.removeContainerUnder()
+            }
+        })
     }
 }

--- a/packages/editor/src/core/Blueprint.ts
+++ b/packages/editor/src/core/Blueprint.ts
@@ -414,24 +414,22 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
     }
 
     public removeEntity(entity: Entity): void {
-        this.history.startTransaction('Remove entity')
+        this.history.transaction('Remove entity', () => {
+            this.wireConnections.removeEntityConnections(entity.entityNumber)
 
-        this.wireConnections.removeEntityConnections(entity.entityNumber)
-
-        this.history
-            .updateMap(this.entities, entity.entityNumber, undefined, 'Remove entity')
-            .onDone(this.onCreateOrRemoveEntity.bind(this))
-            .commit()
-
-        this.history.commitTransaction()
+            this.history
+                .updateMap(this.entities, entity.entityNumber, undefined, 'Remove entity')
+                .onDone(this.onCreateOrRemoveEntity.bind(this))
+                .commit()
+        })
     }
 
     public removeEntities(entities: Entity[]): void {
-        this.history.startTransaction('Remove entities')
-        for (const e of entities) {
-            this.removeEntity(e)
-        }
-        this.history.commitTransaction()
+        this.history.transaction('Remove entities', () => {
+            for (const e of entities) {
+                this.removeEntity(e)
+            }
+        })
     }
 
     public fastReplaceEntity(name: string, direction: number, position: IPoint): boolean {
@@ -439,24 +437,22 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
 
         if (!entity) return false
 
-        this.history.startTransaction('Fast replace entity')
+        this.history.transaction('Fast replace entity', () => {
+            const connections = this.wireConnections.getEntityConnections(entity.entityNumber)
 
-        const connections = this.wireConnections.getEntityConnections(entity.entityNumber)
+            this.removeEntity(entity)
 
-        this.removeEntity(entity)
+            this.createEntity({
+                name,
+                direction,
+                position: entity.position,
+                entity_number: entity.entityNumber,
+            }).pasteSettings(entity)
 
-        this.createEntity({
-            name,
-            direction,
-            position: entity.position,
-            entity_number: entity.entityNumber,
-        }).pasteSettings(entity)
-
-        for (const conn of connections) {
-            this.wireConnections.create(conn)
-        }
-
-        this.history.commitTransaction()
+            for (const conn of connections) {
+                this.wireConnections.create(conn)
+            }
+        })
 
         return true
     }
@@ -476,33 +472,29 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
     }
 
     public createTiles(name: string, positions: IPoint[]): void {
-        this.history.startTransaction('Create tiles')
-
-        for (const p of positions) {
-            const tile = new Tile(name, p.x, p.y)
-            this.history
-                .updateMap(this.tiles, tile.hash, tile, 'Create tile')
-                .onDone(this.onCreateOrRemoveTile.bind(this))
-                .commit()
-        }
-
-        this.history.commitTransaction()
+        this.history.transaction('Create tiles', () => {
+            for (const p of positions) {
+                const tile = new Tile(name, p.x, p.y)
+                this.history
+                    .updateMap(this.tiles, tile.hash, tile, 'Create tile')
+                    .onDone(this.onCreateOrRemoveTile.bind(this))
+                    .commit()
+            }
+        })
     }
 
     public removeTiles(positions: IPoint[]): void {
-        this.history.startTransaction('Remove tiles')
-
-        positions
-            .map(p => this.tiles.get(`${p.x},${p.y}`))
-            .filter(tile => !!tile)
-            .forEach(tile => {
-                this.history
-                    .updateMap(this.tiles, tile.hash, undefined, 'Remove tile')
-                    .onDone(this.onCreateOrRemoveTile.bind(this))
-                    .commit()
-            })
-
-        this.history.commitTransaction()
+        this.history.transaction('Remove tiles', () => {
+            positions
+                .map(p => this.tiles.get(`${p.x},${p.y}`))
+                .filter(tile => !!tile)
+                .forEach(tile => {
+                    this.history
+                        .updateMap(this.tiles, tile.hash, undefined, 'Remove tile')
+                        .onDone(this.onCreateOrRemoveTile.bind(this))
+                        .commit()
+                })
+        })
     }
 
     private onCreateOrRemoveTile(newValue: Tile | undefined, oldValue: Tile | undefined): void {
@@ -653,58 +645,59 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
 
         // Apply Changes
         this.history.logging = false
-        this.history.startTransaction('Generate Oil Outpost')
+        try {
+            this.history.transaction('Generate Oil Outpost', () => {
+                for (const pipe of GP.pipes) {
+                    this.createEntity(pipe)
+                }
+                const e = FD.entities['beacon']
+                const inventory = getModuleInventoryIndex(e)
+                if (inventory === null) {
+                    throw new Error('beacon has no module inventory')
+                }
+                const beacon_module_slots = (hasModuleFunctionality(e) && e.module_slots) || 0
+                const items: BlueprintInsertPlan[] = []
+                const in_inventory: InventoryPosition[] = []
+                for (let i = 0; i < beacon_module_slots; i++) {
+                    in_inventory.push({
+                        inventory,
+                        stack: i,
+                    })
+                }
+                items.push({
+                    id: { name: BEACON_MODULE },
+                    items: { in_inventory },
+                })
+                for (const beacon of beacons) {
+                    this.createEntity({
+                        ...beacon,
+                        items,
+                    })
+                }
+                for (const pole of GPO.poles) {
+                    this.createEntity(pole)
+                }
 
-        for (const pipe of GP.pipes) {
-            this.createEntity(pipe)
-        }
-        const e = FD.entities['beacon']
-        const inventory = getModuleInventoryIndex(e)
-        if (inventory === null) {
-            throw new Error('beacon has no module inventory')
-        }
-        const beacon_module_slots = (hasModuleFunctionality(e) && e.module_slots) || 0
-        const items: BlueprintInsertPlan[] = []
-        const in_inventory: InventoryPosition[] = []
-        for (let i = 0; i < beacon_module_slots; i++) {
-            in_inventory.push({
-                inventory,
-                stack: i,
+                this.wireConnections.generatePowerPoleWires()
+
+                for (const p of GP.pumpjacksToRotate) {
+                    // Created by this same method a few lines up, so its absence would
+                    // mean the generator returned a number we never placed.
+                    const entity = this.entities.get(p.entity_number)
+                    if (entity === undefined) {
+                        throw new Error(`generator returned unknown entity ${p.entity_number}`)
+                    }
+                    entity.direction = p.direction
+                    if (PUMPJACK_MODULE !== 'none') {
+                        entity.modules = Array.from<string>({ length: entity.moduleSlots }).fill(
+                            PUMPJACK_MODULE
+                        )
+                    }
+                }
             })
+        } finally {
+            this.history.logging = true
         }
-        items.push({
-            id: { name: BEACON_MODULE },
-            items: { in_inventory },
-        })
-        for (const beacon of beacons) {
-            this.createEntity({
-                ...beacon,
-                items,
-            })
-        }
-        for (const pole of GPO.poles) {
-            this.createEntity(pole)
-        }
-
-        this.wireConnections.generatePowerPoleWires()
-
-        for (const p of GP.pumpjacksToRotate) {
-            // Created by this same method a few lines up, so its absence would
-            // mean the generator returned a number we never placed.
-            const entity = this.entities.get(p.entity_number)
-            if (entity === undefined) {
-                throw new Error(`generator returned unknown entity ${p.entity_number}`)
-            }
-            entity.direction = p.direction
-            if (PUMPJACK_MODULE !== 'none') {
-                entity.modules = Array.from<string>({ length: entity.moduleSlots }).fill(
-                    PUMPJACK_MODULE
-                )
-            }
-        }
-
-        this.history.commitTransaction()
-        this.history.logging = true
 
         // Create visualizations
         if (!DEBUG) return

--- a/packages/editor/src/core/Entity.ts
+++ b/packages/editor/src/core/Entity.ts
@@ -369,24 +369,22 @@ export class Entity extends EventEmitter<EntityEvents> {
     public set recipe(recipe: string | undefined) {
         if (this.m_rawEntity.recipe === recipe) return
 
-        this.m_BP.history.startTransaction()
+        this.m_BP.history.transaction(undefined, () => {
+            this.m_BP.history
+                .updateValue(this.m_rawEntity, 'recipe', recipe, 'Change recipe')
+                .onDone(r => this.emit('recipe', r))
+                .commit()
 
-        this.m_BP.history
-            .updateValue(this.m_rawEntity, 'recipe', recipe, 'Change recipe')
-            .onDone(r => this.emit('recipe', r))
-            .commit()
-
-        // Some modules on the entity may not be compatible with the new selected recipe, filter those out
-        if (recipe !== undefined) {
-            this.modules = this.modules.map(m => {
-                if (!m) return
-                const module = getModule(m)
-                if (!recipeSupportsModule(recipe, module)) return
-                return m
-            })
-        }
-
-        this.m_BP.history.commitTransaction()
+            // Some modules on the entity may not be compatible with the new selected recipe, filter those out
+            if (recipe !== undefined) {
+                this.modules = this.modules.map(m => {
+                    if (!m) return
+                    const module = getModule(m)
+                    if (!recipeSupportsModule(recipe, module)) return
+                    return m
+                })
+            }
+        })
     }
 
     /** Recipes this entity can accept */
@@ -669,23 +667,21 @@ export class Entity extends EventEmitter<EntityEvents> {
     public set splitterOutputPriority(priority: FilterPriority | undefined) {
         if (this.m_rawEntity.output_priority === priority) return
 
-        this.m_BP.history.startTransaction()
+        this.m_BP.history.transaction(undefined, () => {
+            this.m_BP.history
+                .updateValue(
+                    this.m_rawEntity,
+                    'output_priority',
+                    priority,
+                    'Change splitter output priority'
+                )
+                .onDone(() => this.emit('splitterOutputPriority', this.splitterOutputPriority))
+                .commit()
 
-        this.m_BP.history
-            .updateValue(
-                this.m_rawEntity,
-                'output_priority',
-                priority,
-                'Change splitter output priority'
-            )
-            .onDone(() => this.emit('splitterOutputPriority', this.splitterOutputPriority))
-            .commit()
-
-        if (priority === undefined) {
-            this.filters = undefined
-        }
-
-        this.m_BP.history.commitTransaction()
+            if (priority === undefined) {
+                this.filters = undefined
+            }
+        })
     }
 
     /** Splitter filter */
@@ -703,25 +699,23 @@ export class Entity extends EventEmitter<EntityEvents> {
         const filter = filters?.[0]?.name
         if (this.m_rawEntity.filter === filter) return
 
-        this.m_BP.history.startTransaction()
+        this.m_BP.history.transaction(undefined, () => {
+            // used to write { name: undefined } when clearing, which serialized as an
+            // empty filter object rather than as no filter at all
+            const f = filter === undefined ? undefined : { name: filter }
 
-        // used to write { name: undefined } when clearing, which serialized as an
-        // empty filter object rather than as no filter at all
-        const f = filter === undefined ? undefined : { name: filter }
+            this.m_BP.history
+                .updateValue(this.m_rawEntity, 'filter', f, 'Change splitter filter')
+                .onDone(() => this.emit('splitterFilter'))
+                .onDone(() => this.emit('filters'))
+                .commit()
 
-        this.m_BP.history
-            .updateValue(this.m_rawEntity, 'filter', f, 'Change splitter filter')
-            .onDone(() => this.emit('splitterFilter'))
-            .onDone(() => this.emit('filters'))
-            .commit()
-
-        if (filter !== undefined) {
-            if (this.splitterOutputPriority === undefined) {
-                this.splitterOutputPriority = 'left'
+            if (filter !== undefined) {
+                if (this.splitterOutputPriority === undefined) {
+                    this.splitterOutputPriority = 'left'
+                }
             }
-        }
-
-        this.m_BP.history.commitTransaction()
+        })
     }
 
     public get filterMode(): FilterMode {
@@ -1310,32 +1304,32 @@ export class Entity extends EventEmitter<EntityEvents> {
 
         if (newDir === this.direction) return
 
-        this.m_BP.history.startTransaction('Rotate entity')
-
-        if (this.type === 'underground-belt' || this.type === 'loader') {
-            if (rotateOpposingUB) {
-                const opposingEntityNumber = this.m_BP.entityPositionGrid.getOpposingEntity(
-                    this.name,
-                    this.direction,
-                    this.position,
-                    this.directionType === 'input' ? this.direction : (this.direction + 8) % 16,
-                    isUndergroundBelt(this.entityData) ? this.entityData.max_distance : undefined
-                )
-                const otherEntity =
-                    opposingEntityNumber === undefined
-                        ? undefined
-                        : this.m_BP.entities.get(opposingEntityNumber)
-                if (otherEntity) {
-                    otherEntity.rotate()
+        this.m_BP.history.transaction('Rotate entity', () => {
+            if (this.type === 'underground-belt' || this.type === 'loader') {
+                if (rotateOpposingUB) {
+                    const opposingEntityNumber = this.m_BP.entityPositionGrid.getOpposingEntity(
+                        this.name,
+                        this.direction,
+                        this.position,
+                        this.directionType === 'input' ? this.direction : (this.direction + 8) % 16,
+                        isUndergroundBelt(this.entityData)
+                            ? this.entityData.max_distance
+                            : undefined
+                    )
+                    const otherEntity =
+                        opposingEntityNumber === undefined
+                            ? undefined
+                            : this.m_BP.entities.get(opposingEntityNumber)
+                    if (otherEntity) {
+                        otherEntity.rotate()
+                    }
                 }
+
+                this.directionType = this.directionType === 'input' ? 'output' : 'input'
             }
 
-            this.directionType = this.directionType === 'input' ? 'output' : 'input'
-        }
-
-        this.direction = newDir
-
-        this.m_BP.history.commitTransaction()
+            this.direction = newDir
+        })
     }
 
     public canPasteSettings(sourceEntity: Entity): boolean {
@@ -1402,34 +1396,33 @@ export class Entity extends EventEmitter<EntityEvents> {
     public pasteSettings(sourceEntity: Entity): void {
         if (!this.canPasteSettings(sourceEntity)) return
 
-        this.m_BP.history.startTransaction('Paste settings to entity')
+        this.m_BP.history.transaction('Paste settings to entity', () => {
+            // PASTE RECIPE
+            let tRecipe = this.recipe
+            const aR = this.acceptedRecipes
+            if (aR.length > 0 && sourceEntity.acceptedRecipes) {
+                tRecipe =
+                    sourceEntity.recipe !== undefined && aR.includes(sourceEntity.recipe)
+                        ? sourceEntity.recipe
+                        : undefined
+                this.recipe = tRecipe
+            }
 
-        // PASTE RECIPE
-        let tRecipe = this.recipe
-        const aR = this.acceptedRecipes
-        if (aR.length > 0 && sourceEntity.acceptedRecipes) {
-            tRecipe =
-                sourceEntity.recipe !== undefined && aR.includes(sourceEntity.recipe)
-                    ? sourceEntity.recipe
-                    : undefined
-            this.recipe = tRecipe
-        }
+            // PASTE DIRECTION (only for type assembling_machine)
+            if (
+                this.type === 'assembling-machine' &&
+                this.name !== 'assembling-machine' &&
+                tRecipe &&
+                FD.recipes[tRecipe].category === 'crafting-with-fluid'
+            ) {
+                this.direction = sourceEntity.direction
+            }
 
-        // PASTE DIRECTION (only for type assembling_machine)
-        if (
-            this.type === 'assembling-machine' &&
-            this.name !== 'assembling-machine' &&
-            tRecipe &&
-            FD.recipes[tRecipe].category === 'crafting-with-fluid'
-        ) {
-            this.direction = sourceEntity.direction
-        }
-
-        // PASTE MODULES
-        const aM = this.acceptedModules
-        if (aM.length > 0 && sourceEntity.acceptedModules) {
-            if (sourceEntity.modules && sourceEntity.modules.length > 0) {
-                /*
+            // PASTE MODULES
+            const aM = this.acceptedModules
+            if (aM.length > 0 && sourceEntity.acceptedModules) {
+                if (sourceEntity.modules && sourceEntity.modules.length > 0) {
+                    /*
                     map, not filter. `modules` is positional - one entry per
                     slot, undefined for an empty one - so dropping the entries
                     rather than blanking them slid every module behind a gap
@@ -1438,44 +1431,44 @@ export class Entity extends EventEmitter<EntityEvents> {
                     target will not accept still goes, it just leaves its slot
                     empty instead of closing it.
                 */
-                this.modules = sourceEntity.modules
-                    .map(m => (m !== undefined && aM.includes(m) ? m : undefined))
-                    .slice(0, this.moduleSlots)
-            } else {
-                this.modules = []
+                    this.modules = sourceEntity.modules
+                        .map(m => (m !== undefined && aM.includes(m) ? m : undefined))
+                        .slice(0, this.moduleSlots)
+                } else {
+                    this.modules = []
+                }
             }
-        }
 
-        // PASTE SPLITTER SETTINGS (Has to be before filters as otherwise business logic will overwrite)
-        if (this.type === 'splitter' && sourceEntity.type === 'splitter') {
-            this.splitterInputPriority = sourceEntity.splitterInputPriority
-            this.splitterOutputPriority = sourceEntity.splitterOutputPriority
-        }
+            // PASTE SPLITTER SETTINGS (Has to be before filters as otherwise business logic will overwrite)
+            if (this.type === 'splitter' && sourceEntity.type === 'splitter') {
+                this.splitterInputPriority = sourceEntity.splitterInputPriority
+                this.splitterOutputPriority = sourceEntity.splitterOutputPriority
+            }
 
-        // PASTE FILTERS
-        const aF = this.acceptedFilters
-        if (aF.length > 0 && sourceEntity.acceptedFilters) {
-            if (sourceEntity.filters && sourceEntity.filters.length > 0) {
-                /*
+            // PASTE FILTERS
+            const aF = this.acceptedFilters
+            if (aF.length > 0 && sourceEntity.acceptedFilters) {
+                if (sourceEntity.filters && sourceEntity.filters.length > 0) {
+                    /*
                     Capped by what the target can hold, not by what its dialog
                     draws. This read `filterSlots`, so a requester or buffer
                     chest silently dropped everything past the 30th filter -
                     a UI layout constant deciding how much data survived a copy.
                 */
-                this.filters = sourceEntity.filters
-                    .filter(f => aF.includes(f.name))
-                    .slice(0, this.maxFilters)
-            } else {
-                this.filters = []
+                    this.filters = sourceEntity.filters
+                        .filter(f => aF.includes(f.name))
+                        .slice(0, this.maxFilters)
+                } else {
+                    this.filters = []
+                }
             }
-        }
 
-        // PASTE REQUESTER CHEST SETTINGS
-        if (this.name === 'requester-chest' && sourceEntity.name === 'requester-chest') {
-            this.requestFromBufferChest = sourceEntity.requestFromBufferChest
-        }
+            // PASTE REQUESTER CHEST SETTINGS
+            if (this.name === 'requester-chest' && sourceEntity.name === 'requester-chest') {
+                this.requestFromBufferChest = sourceEntity.requestFromBufferChest
+            }
 
-        /*
+            /*
             The rest of the same-type pairs from #94's TODO. What each one
             carries was measured against the game rather than taken from the
             list: a source and a blank target placed headless, `copy_settings`
@@ -1491,17 +1484,17 @@ export class Entity extends EventEmitter<EntityEvents> {
             the cross-type half of #94 will have to relax.
         */
 
-        // PASTE TRAIN STOP SETTINGS
-        if (this.type === 'train-stop' && sourceEntity.type === 'train-stop') {
-            this.station = sourceEntity.station
-            this.color = sourceEntity.color
-            this.manualTrainsLimit = sourceEntity.manualTrainsLimit
-        }
+            // PASTE TRAIN STOP SETTINGS
+            if (this.type === 'train-stop' && sourceEntity.type === 'train-stop') {
+                this.station = sourceEntity.station
+                this.color = sourceEntity.color
+                this.manualTrainsLimit = sourceEntity.manualTrainsLimit
+            }
 
-        // PASTE LOCOMOTIVE SETTINGS
-        if (this.type === 'locomotive' && sourceEntity.type === 'locomotive') {
-            this.color = sourceEntity.color
-            /*
+            // PASTE LOCOMOTIVE SETTINGS
+            if (this.type === 'locomotive' && sourceEntity.type === 'locomotive') {
+                this.color = sourceEntity.color
+                /*
                 Schedule included, which is issue #115 and the last item of the
                 2019 TODO #94 worked through. Measured rather than assumed: the
                 game's own copy carries records, interrupts and the schedule
@@ -1511,33 +1504,36 @@ export class Entity extends EventEmitter<EntityEvents> {
                 source having one. See
                 `tools/oracle/fixtures/copy-settings-schedule.json`.
             */
-            this.schedule = sourceEntity.schedule
-        }
+                this.schedule = sourceEntity.schedule
+            }
 
-        // PASTE CARGO WAGON SETTINGS
-        if (this.type === 'cargo-wagon' && sourceEntity.type === 'cargo-wagon') {
-            // bar and filters together, since a wagon nests them in one field
-            this.wagonInventory = sourceEntity.wagonInventory
-        }
+            // PASTE CARGO WAGON SETTINGS
+            if (this.type === 'cargo-wagon' && sourceEntity.type === 'cargo-wagon') {
+                // bar and filters together, since a wagon nests them in one field
+                this.wagonInventory = sourceEntity.wagonInventory
+            }
 
-        // PASTE CONTAINER INVENTORY LIMIT
-        if (CONTAINER_TYPES.has(this.type) && CONTAINER_TYPES.has(sourceEntity.type)) {
-            this.inventoryBar = sourceEntity.inventoryBar
-        }
+            // PASTE CONTAINER INVENTORY LIMIT
+            if (CONTAINER_TYPES.has(this.type) && CONTAINER_TYPES.has(sourceEntity.type)) {
+                this.inventoryBar = sourceEntity.inventoryBar
+            }
 
-        // PASTE PROGRAMMABLE SPEAKER SETTINGS
-        if (this.type === 'programmable-speaker' && sourceEntity.type === 'programmable-speaker') {
-            this.speakerParameters = sourceEntity.speakerParameters
-            this.speakerAlertParameters = sourceEntity.speakerAlertParameters
-        }
+            // PASTE PROGRAMMABLE SPEAKER SETTINGS
+            if (
+                this.type === 'programmable-speaker' &&
+                sourceEntity.type === 'programmable-speaker'
+            ) {
+                this.speakerParameters = sourceEntity.speakerParameters
+                this.speakerAlertParameters = sourceEntity.speakerAlertParameters
+            }
 
-        // PASTE ROCKET SILO SETTINGS
-        if (this.type === 'rocket-silo' && sourceEntity.type === 'rocket-silo') {
-            this.launchToOrbitAutomatically = sourceEntity.launchToOrbitAutomatically
-            this.useTransitionalRequests = sourceEntity.useTransitionalRequests
-        }
+            // PASTE ROCKET SILO SETTINGS
+            if (this.type === 'rocket-silo' && sourceEntity.type === 'rocket-silo') {
+                this.launchToOrbitAutomatically = sourceEntity.launchToOrbitAutomatically
+                this.useTransitionalRequests = sourceEntity.useTransitionalRequests
+            }
 
-        /*
+            /*
             The cross-type pairs, which `canPasteSettings` refused outright until
             now. Each one was measured against the game rather than taken from
             #94's TODO - see `CROSS_TYPE_PASTE` and
@@ -1550,43 +1546,42 @@ export class Entity extends EventEmitter<EntityEvents> {
             its work rather than special-cased here.
         */
 
-        // PASTE A MACHINE'S INGREDIENTS ONTO A LOGISTIC CHEST AS REQUESTS
-        if (sourceEntity.type === 'assembling-machine' && this.type === 'logistic-container') {
-            const requests = sourceEntity.recipeIngredientRequests
-            if (requests.length > 0) {
-                this.filters = requests.slice(0, this.maxFilters)
+            // PASTE A MACHINE'S INGREDIENTS ONTO A LOGISTIC CHEST AS REQUESTS
+            if (sourceEntity.type === 'assembling-machine' && this.type === 'logistic-container') {
+                const requests = sourceEntity.recipeIngredientRequests
+                if (requests.length > 0) {
+                    this.filters = requests.slice(0, this.maxFilters)
+                }
             }
-        }
 
-        // PASTE A MACHINE'S INGREDIENTS ONTO AN INSERTER AS FILTERS
-        if (sourceEntity.type === 'assembling-machine' && this.type === 'inserter') {
-            const ingredients = sourceEntity.recipeIngredientRequests
-            if (ingredients.length > 0) {
-                /*
+            // PASTE A MACHINE'S INGREDIENTS ONTO AN INSERTER AS FILTERS
+            if (sourceEntity.type === 'assembling-machine' && this.type === 'inserter') {
+                const ingredients = sourceEntity.recipeIngredientRequests
+                if (ingredients.length > 0) {
+                    /*
                     Names only. The game writes an inserter's filters without
                     counts - the thirty-seconds arithmetic is a chest's business,
                     and an inserter filter has nowhere to put a number.
                 */
-                this.filters = ingredients
-                    .map(({ index, name }) => ({ index, name }))
-                    .slice(0, this.maxFilters)
+                    this.filters = ingredients
+                        .map(({ index, name }) => ({ index, name }))
+                        .slice(0, this.maxFilters)
+                }
             }
-        }
 
-        // PASTE COLOUR BETWEEN A TRAIN STOP AND A LOCOMOTIVE
-        if (
-            (sourceEntity.type === 'train-stop' && this.type === 'locomotive') ||
-            (sourceEntity.type === 'locomotive' && this.type === 'train-stop')
-        ) {
-            /*
+            // PASTE COLOUR BETWEEN A TRAIN STOP AND A LOCOMOTIVE
+            if (
+                (sourceEntity.type === 'train-stop' && this.type === 'locomotive') ||
+                (sourceEntity.type === 'locomotive' && this.type === 'train-stop')
+            ) {
+                /*
                 Colour only, in both directions. A stop's name stays its own -
                 measured: a locomotive copied onto a train stop left the stop's
                 `station` untouched.
             */
-            this.color = sourceEntity.color
-        }
-
-        this.m_BP.history.commitTransaction()
+                this.color = sourceEntity.color
+            }
+        })
 
         /*
             TODO:

--- a/packages/editor/src/core/History.test.ts
+++ b/packages/editor/src/core/History.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { History } from './History'
+
+describe('History transactions', () => {
+    it('clears an empty transaction', () => {
+        const history = new History()
+
+        expect(history.startTransaction('empty')).toBe(true)
+        expect(history.commitTransaction()).toBe(false)
+        expect(history.startTransaction('next')).toBe(true)
+        expect(history.commitTransaction()).toBe(false)
+    })
+
+    it('records applied actions before a transaction callback throws', () => {
+        const history = new History()
+        const target = { value: 0 }
+
+        expect(() =>
+            history.transaction('update', () => {
+                history.updateValue(target, 'value', 1, 'Set value').commit()
+                throw new Error('boom')
+            })
+        ).toThrow('boom')
+        expect(target.value).toBe(1)
+        expect(history.undo()).toBe(true)
+        expect(target.value).toBe(0)
+    })
+
+    it('closes an action transaction when an apply callback throws', () => {
+        const history = new History()
+        const broken = { value: 0 }
+        const next = { value: 0 }
+
+        expect(() =>
+            history.transaction('broken update', () => {
+                history
+                    .updateValue(broken, 'value', 1, 'Set broken value')
+                    .onDone(() => {
+                        throw new Error('boom')
+                    })
+                    .commit()
+            })
+        ).toThrow('boom')
+
+        history.updateValue(next, 'value', 1, 'Set next value').commit()
+        expect(history.undo()).toBe(true)
+        expect(next.value).toBe(0)
+    })
+})

--- a/packages/editor/src/core/History.ts
+++ b/packages/editor/src/core/History.ts
@@ -47,10 +47,13 @@ class Action<V> {
      * This allows for emits to be set up first
      */
     public commit(): this {
-        if (this.applyImmediate) {
-            this.apply()
+        try {
+            if (this.applyImmediate) {
+                this.apply()
+            }
+        } finally {
+            this.history.commitTransaction()
         }
-        this.history.commitTransaction()
 
         return this
     }
@@ -177,10 +180,10 @@ class Transaction {
  *
  * // Transaction of 2 actions and naming of transaction
  * const o = { firstName: 'test first name', lastName: 'test last name'}
- * history.startTransaction('Update 2 values')
- * history.updateValue(o, ['firstName'], 'update first name').commit()
- * history.updateValue(o, ['lastName'], 'update last name').commit()
- * history.commitTransaction()
+ * history.transaction('Update 2 values', () => {
+ *     history.updateValue(o, ['firstName'], 'update first name').commit()
+ *     history.updateValue(o, ['lastName'], 'update last name').commit()
+ * })
  *
  * // Emit function after action execution
  * const o = { name: 'test name'}
@@ -321,6 +324,16 @@ export class History {
         }
     }
 
+    /** Runs a transaction and closes it even when the callback throws. */
+    public transaction<T>(text: string | undefined, fn: () => T): T {
+        this.startTransaction(text)
+        try {
+            return fn()
+        } finally {
+            this.commitTransaction()
+        }
+    }
+
     /**
      * Commits the active transaction and pushes it into the history
      * @returns `false` if `transactionCount` is not 0 or transaction is empty
@@ -329,29 +342,40 @@ export class History {
         this.transactionCount -= 1
 
         if (this.transactionCount === 0) {
-            if (this.openTransaction.empty()) return false
-            while (this.transactionHistory.length > this.historyIndex) {
-                this.transactionHistory.pop()
+            const transaction = this.openTransaction
+            if (transaction.empty()) {
+                this.activeTransaction = undefined
+                return false
             }
 
-            this.openTransaction.apply()
-            this.transactionHistory.push(this.openTransaction)
-            if (this.logging) {
-                if (this.historyIndex !== 0 && this.historyIndex % 20 === 0) {
-                    console.clear()
+            try {
+                while (this.transactionHistory.length > this.historyIndex) {
+                    this.transactionHistory.pop()
                 }
-                this.openTransaction.log()
+
+                transaction.apply()
+                this.transactionHistory.push(transaction)
+                if (this.logging) {
+                    if (this.historyIndex !== 0 && this.historyIndex % 20 === 0) {
+                        console.clear()
+                    }
+                    transaction.log()
+                }
+
+                if (this.historyIndex > this.MAX_HISTORY_LENGTH) {
+                    this.transactionHistory.splice(
+                        0,
+                        this.MAX_HISTORY_LENGTH - this.MIN_HISTORY_LENGTH
+                    )
+                    this.historyIndex = this.transactionHistory.length
+                }
+
+                this.historyIndex += 1
+
+                return true
+            } finally {
+                this.activeTransaction = undefined
             }
-            this.activeTransaction = undefined
-
-            if (this.historyIndex > this.MAX_HISTORY_LENGTH) {
-                this.transactionHistory.splice(0, this.MAX_HISTORY_LENGTH - this.MIN_HISTORY_LENGTH)
-                this.historyIndex = this.transactionHistory.length
-            }
-
-            this.historyIndex += 1
-
-            return true
         }
 
         return false


### PR DESCRIPTION
## Summary

Keep `History` usable when a transaction is empty or code inside it throws.

`commitTransaction()` previously returned from an empty transaction before clearing `activeTransaction`, leaving its count and active object out of sync. Separately, callers manually paired `startTransaction()` and `commitTransaction()`, so any exception between them left `transactionCount` permanently above zero. Later edits still applied but never reached undo/redo history.

## Changes

- Clear the active transaction on empty commits.
- Clear it in a `finally` around non-empty commits, including deferred apply/logging failures.
- Add `History.transaction(label, fn)` to own start/commit pairing with `try/finally`.
- Make `Action.commit()` close its nested transaction even when apply or an `onDone` callback throws.
- Migrate live transaction scopes in `Blueprint`, `Entity`, and `PaintBlueprintContainer` to the safe wrapper.
- Restore oil-outpost history logging in a `finally`.
- Add focused unit coverage for empty transactions, callback throws, and action callback throws.

The constructor-only manual pair remains harmless: a constructor exception discards that `Blueprint` and its `History`, while its empty path now clears normally.

## Verification

- `vp check --fix`
- `vp test` — 15 files, 187 tests passed
- 32 relevant Playwright tests passed:
  - keybinds
  - entity/cross-type/module settings paste
  - blueprint placement
  - tiles
- `git diff --check`

Closes #255