### PR TITLE
Remove unreachable blueprint error handling

### DIFF
--- a/packages/editor/src/core/bpString.ts
+++ b/packages/editor/src/core/bpString.ts
@@ -1,4 +1,4 @@
-import Ajv, { ErrorObject, KeywordDefinition } from 'ajv'
+import Ajv, { KeywordDefinition } from 'ajv'
 import * as pako from 'pako'
 import { IBlueprint, IBlueprintBook, IBlueprintBookEntry } from '../types'
 import G from '../common/globals'
@@ -60,20 +60,6 @@ class CorruptedBlueprintStringError {
 
 class BookWithNoBlueprintsError {
     public error = 'Blueprint book contains no blueprints!'
-}
-
-class ModdedBlueprintError {
-    public errors: ErrorObject[]
-    public constructor(errors: ErrorObject[]) {
-        this.errors = errors
-    }
-}
-
-class TrainBlueprintError {
-    public errors: ErrorObject[]
-    public constructor(errors: ErrorObject[]) {
-        this.errors = errors
-    }
 }
 
 const keywords: KeywordDefinition[] = [
@@ -344,8 +330,6 @@ function getBlueprintOrBookFromSource(source: string): Promise<Blueprint | Book>
 }
 
 export {
-    ModdedBlueprintError,
-    TrainBlueprintError,
     CorruptedBlueprintStringError,
     BookWithNoBlueprintsError,
     encode,

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -6,8 +6,6 @@ import EDITOR, {
     Editor,
     Blueprint,
     Book,
-    TrainBlueprintError,
-    ModdedBlueprintError,
     CorruptedBlueprintStringError,
     BookWithNoBlueprintsError,
     encode,
@@ -768,29 +766,8 @@ function createErrorMessage(text: string, error: unknown, timeout = 10000): void
     })
 }
 function createBPImportError(
-    error:
-        | Error
-        | TrainBlueprintError
-        | ModdedBlueprintError
-        | CorruptedBlueprintStringError
-        | BookWithNoBlueprintsError
+    error: Error | CorruptedBlueprintStringError | BookWithNoBlueprintsError
 ): void {
-    if (error instanceof TrainBlueprintError) {
-        createErrorMessage(
-            'Blueprint with train entities not supported yet. If you think this is a mistake:',
-            error.errors
-        )
-        return
-    }
-
-    if (error instanceof ModdedBlueprintError) {
-        createErrorMessage(
-            'Blueprint with modded items not supported yet. If you think this is a mistake:',
-            error.errors
-        )
-        return
-    }
-
     if (error instanceof CorruptedBlueprintStringError) {
         createErrorMessage(
             'Blueprint string might be corrupted. If you think this is a mistake:',


### PR DESCRIPTION
## Summary

Remove two blueprint error types and website branches that became unreachable when blueprint validation was made lenient.

`ModdedBlueprintError` and `TrainBlueprintError` have no producers anywhere in the repository. Their only remaining uses were declarations, exports, imports, type-union members, and `instanceof` branches, so the handler advertised failures that can no longer occur.

## Why removal is correct

Commit `0ce97bdc` deliberately replaced rejection of train and modded blueprints with lenient validation, warning logs, and removal of unknown entities. The old error consumers were left behind during that behavior change; restoring their throws would reverse the intended leniency.

## Changes

- Remove both unused error classes and exports from `bpString.ts`.
- Remove their imports, union members, and unreachable website error branches.
- Drop the now-unused AJV `ErrorObject` import.

## Verification

- `vp check --fix` — 177 files, no warnings, lint errors, or type errors
- `vp test` — 14 files, 184 tests passed
- `git diff --check`
- Repository-wide search confirms neither error type remains

Closes #250