### PR TITLE
Give the Claude workflows a toolchain, so a review can run the gates

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,24 @@ jobs:
         with:
           fetch-depth: 1
 
+      # A review that cannot run anything can only reason about the diff. That
+      # is a real limit and it showed: reviewing PR #265 the run said outright
+      # that it had no `vp` and no `node_modules`, so it accepted a moved
+      # `blueprint-round-trip.spec.ts` fixed point on the strength of the
+      # argument rather than by re-running the corpus. These two steps are what
+      # the `checks` job in ci.yml does, and they cost it about 1m20s with both
+      # caches warm.
+      #
+      # Deliberately not the Playwright half. That needs browsers and both dev
+      # servers, and would put the e2e job's 3-4 minutes on every review
+      # including the automatic one on every push. `vp check` and `vp test`
+      # cover what a reviewer most often wants to confirm.
+      - name: Set up Vite+
+        uses: ./.github/actions/setup-vp
+
+      - name: Install dependencies
+        run: vp install --frozen-lockfile
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,24 @@ jobs:
         with:
           fetch-depth: 1
 
+      # A review that cannot run anything can only reason about the diff. That
+      # is a real limit and it showed: reviewing PR #265 the run said outright
+      # that it had no `vp` and no `node_modules`, so it accepted a moved
+      # `blueprint-round-trip.spec.ts` fixed point on the strength of the
+      # argument rather than by re-running the corpus. These two steps are what
+      # the `checks` job in ci.yml does, and they cost it about 1m20s with both
+      # caches warm.
+      #
+      # Deliberately not the Playwright half. That needs browsers and both dev
+      # servers, and would put the e2e job's 3-4 minutes on every review
+      # including the automatic one on every push. `vp check` and `vp test`
+      # cover what a reviewer most often wants to confirm.
+      - name: Set up Vite+
+        uses: ./.github/actions/setup-vp
+
+      - name: Install dependencies
+        run: vp install --frozen-lockfile
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Why

A review that cannot run anything can only reason about the diff. That limit showed on #265, where the run said so itself:

> I didn't have `vp` or an installed `node_modules` in this environment, so I wasn't able to run `vp check`, `vp test`, or the Playwright suite myself - the analysis above is from reading the diff and tracing call sites/consumers directly rather than from re-executing the verification numbers quoted in the PR body.

It then accepted a moved `blueprint-round-trip.spec.ts` fixed point on the strength of the argument. It was right, and it was right for a reason nobody could check from inside the review.

## What

Both workflows now do what the `checks` job in `ci.yml` already does:

```yaml
- name: Set up Vite+
  uses: ./.github/actions/setup-vp

- name: Install dependencies
  run: vp install --frozen-lockfile
```

`setup-vp` writes `~/.vite-plus/bin` to `$GITHUB_PATH`, so `vp` is on PATH for the `claude-code-action` step that follows. Both caches are shared with `ci.yml`.

**Measured on this PR's own `claude-review` run**, rather than estimated: `Set up Vite+` took **6s** and `Install dependencies` **9s**, so **15 seconds** total. An earlier draft of this description said about 1m20s, which was wrong - that is the whole `checks` job including `vp check` and `vp test`, and a review only pays for those if it chooses to run them.

## Not the Playwright half

That needs browsers and both dev servers, and would put the `e2e` job's 3-4 minutes on **every** review, including the automatic one on every push. `vp check` and `vp test` cover what a reviewer most often wants to confirm, and answer in seconds once installed.

## Two things this does not settle

Stated rather than asserted, because I have not measured them:

- **`claude.yml`** places no `--allowedTools` restriction, and is the path the #265 review actually ran on. That is the case this addresses.
- **`claude-code-review.yml`** restricts `--allowedTools` to the inline-comment MCP tool. Whether that is additive to a default tool set or exclusive is untested. If it is exclusive, the install is inert there and that line needs the gates added to it explicitly. I would rather find that out from a run than guess at the argument syntax.
- **`claude.yml` also fires on issue comments**, where a toolchain is often not wanted. That cost is accepted rather than special-cased, since an `@claude` question about code is exactly when being able to run a gate helps.

## Verification

Both files re-parsed as YAML after the edit, and the step order is `Checkout -> Set up Vite+ -> Install dependencies -> Run Claude`.

The mechanical half is confirmed on this PR: in its own `claude-review` job, `Set up Vite+` and `Install dependencies` both completed successfully before `Run Claude Code Review` started. So the toolchain is present. Whether the *agent* is permitted to invoke it is the separate `--allowedTools` question above, and an `@claude` run has been asked to answer it by trying.

Note fork PRs skip `claude-review` entirely as of #263, so this only ever runs on in-repo branches - the same trust level as CI running the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018N3pm7fQQDv6HTVz1TEpmE
