### PR TITLE
Measure runtime rail boxes against occupancy

### DIFF
--- a/tools/oracle/analyze-rail-box-orientation.mjs
+++ b/tools/oracle/analyze-rail-box-orientation.mjs
@@ -27,6 +27,7 @@ import { fileURLToPath } from 'node:url'
 const HERE = dirname(fileURLToPath(import.meta.url))
 const FIXTURE = join(HERE, 'fixtures', 'rail-box-orientation.json')
 const OCCUPANCY = join(HERE, 'fixtures', 'rail-occupancy.json')
+const BASELINE = join(HERE, 'fixtures', 'entity-tile-size.json')
 const DATA_JSON = join(HERE, '..', '..', 'packages', 'exporter', 'data', 'output', 'data.json')
 
 /**
@@ -47,10 +48,22 @@ const fd = JSON.parse(readFileSync(DATA_JSON, 'utf8')).entities
 
 const box = b => [b.left_top.x, b.left_top.y, b.right_bottom.x, b.right_bottom.y]
 
-const sizeFromBox = (e, b) => ({
-    x: e.tile_width || Math.ceil(Math.abs(b[0]) + Math.abs(b[2])),
-    y: e.tile_height || Math.ceil(Math.abs(b[1]) + Math.abs(b[3])),
+/** The enclosing rectangle alone, with no declared dimension over the top of it. */
+const rawSizeFromBox = b => ({
+    x: Math.ceil(Math.abs(b[0]) + Math.abs(b[2])),
+    y: Math.ceil(Math.abs(b[1]) + Math.abs(b[3])),
 })
+
+/**
+ * `getEntitySize`: the enclosing rectangle, unless `data.json` declares a
+ * dimension, in which case the declared one wins. Reported separately from
+ * `rawSizeFromBox` because the two answer different questions - see
+ * `maskedByDeclaredDimension` below.
+ */
+const sizeFromBox = (e, b) => {
+    const raw = rawSizeFromBox(b)
+    return { x: e.tile_width || raw.x, y: e.tile_height || raw.y }
+}
 
 const swapForDirection = (type, dir, size) => {
     if (size.x === size.y) return size
@@ -69,6 +82,43 @@ const keyedCells = (size, position) => {
         for (let y = y0; y < y0 + size.y; y++)
             cells.add(`${x - Math.floor(position.x)},${y - Math.floor(position.y)}`)
     return cells
+}
+
+/**
+ * The transcription control.
+ *
+ * Both arms below run through the same `sizeFromBox`, `swapForDirection` and
+ * `keyedCells`, all three transcribed out of the editor by hand. A mistake in
+ * any of them moves both arms together, so the comparison the fixture reports
+ * would still look sound while every number in it was wrong. Nothing else here
+ * can catch that.
+ *
+ * `fixtures/entity-tile-size.json` can. `probe-entity-tile-size.mjs` transcribed
+ * the same three rules separately for #142, ran them over the same occupancy
+ * fixture against the same wooden-chest reference, and committed the answer for
+ * the arm the two runs share - what the editor keys today. Reproducing that
+ * number is a real risk of failure while the hypothesis under test still holds,
+ * which is the bar `tools/oracle/README.md` sets for a control.
+ */
+const baselineControl = (today, orientations) => {
+    const baseline = JSON.parse(
+        readFileSync(BASELINE, 'utf8')
+    ).proposedChangeAgainstMeasuredOccupancy
+    const theirs = baseline?.arms?.today
+    // Comparable only if the other run scored the same rails against the same
+    // reference. Otherwise the numbers could agree for no reason worth trusting.
+    const comparable =
+        theirs !== undefined &&
+        baseline.reference === 'wooden-chest' &&
+        baseline.orientations === orientations
+    const ok = comparable && today.missed === theirs.missed && today.empty === theirs.empty
+    return {
+        name: "the today arm reproduces #142's independent transcription",
+        ok,
+        detail: comparable
+            ? `${today.missed} missed and ${today.empty} empty here against ${theirs.missed} and ${theirs.empty} in entity-tile-size.json, over ${orientations} orientations`
+            : 'entity-tile-size.json has no comparable today arm to check against',
+    }
 }
 
 const scoreAgainstMeasuredOccupancy = disagreements => {
@@ -111,13 +161,31 @@ const scoreAgainstMeasuredOccupancy = disagreements => {
             rows[key]?.runtimeBoxes.missed === 0 &&
             rows[key]?.runtimeBoxes.empty === 0
     )
-    const footprintChanges = disagreements
-        .map(d => ({
-            name: d.name,
-            today: sizeFromBox(fd[d.name], d.dataJson),
-            runtime: sizeFromBox(fd[d.name], d.runtime),
-        }))
-        .filter(x => x.today.x !== x.runtime.x || x.today.y !== x.runtime.y)
+    const footprints = disagreements.map(d => ({
+        name: d.name,
+        today: sizeFromBox(fd[d.name], d.dataJson),
+        runtime: sizeFromBox(fd[d.name], d.runtime),
+        rawToday: rawSizeFromBox(d.dataJson),
+        rawRuntime: rawSizeFromBox(d.runtime),
+        declared: {
+            tile_width: fd[d.name].tile_width ?? null,
+            tile_height: fd[d.name].tile_height ?? null,
+        },
+    }))
+    const changed = f => f.today.x !== f.runtime.x || f.today.y !== f.runtime.y
+    const rawChanged = f => f.rawToday.x !== f.rawRuntime.x || f.rawToday.y !== f.rawRuntime.y
+    const footprintChanges = footprints.filter(changed)
+    /*
+        The middle case, which "rounds to the same footprint or is masked by a
+        declared dimension" folded in with the benign one. These rails really do
+        enclose a different rectangle; the only reason the editor computes the
+        same footprint either way is that `data.json` declares `tile_height` for
+        them and the declared value wins. That is a field #142 measured to be a
+        centring parity rather than a size, so the agreement rests on something
+        that does not mean what its name says. Named here rather than counted,
+        because a reader checking this finding needs to know which rails they are.
+    */
+    const maskedByDeclaredDimension = footprints.filter(f => !changed(f) && rawChanged(f))
     const controls = [
         {
             name: 'every measured orientation was scored',
@@ -129,6 +197,7 @@ const scoreAgainstMeasuredOccupancy = disagreements => {
             ok: aligned,
             detail: aligned ? '0 missed and 0 empty in both arms' : 'alignment row differs',
         },
+        baselineControl(arms.today, rails.length),
     ]
 
     return {
@@ -139,6 +208,8 @@ const scoreAgainstMeasuredOccupancy = disagreements => {
         controlsAllPassed: controls.every(c => c.ok),
         collisionBoxDisagreements: disagreements.length,
         footprintChanges,
+        maskedByDeclaredDimension,
+        unchangedFootprints: footprints.filter(f => !changed(f) && !rawChanged(f)).length,
         changedMeasuredOrientations,
         arms,
         adoptingRuntimeBoxesIsImprovement:

--- a/tools/oracle/analyze-rail-box-orientation.mjs
+++ b/tools/oracle/analyze-rail-box-orientation.mjs
@@ -15,6 +15,9 @@
  *
  * Usage:
  *   node tools/oracle/analyze-rail-box-orientation.mjs <dump.json> [--write-fixture]
+ *
+ * Pass the committed fixture as <dump.json> to recompute only the proposed
+ * change against the already-captured rail occupancy measurements.
  */
 
 import { readFileSync, writeFileSync } from 'node:fs'
@@ -23,6 +26,7 @@ import { fileURLToPath } from 'node:url'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const FIXTURE = join(HERE, 'fixtures', 'rail-box-orientation.json')
+const OCCUPANCY = join(HERE, 'fixtures', 'rail-occupancy.json')
 const DATA_JSON = join(HERE, '..', '..', 'packages', 'exporter', 'data', 'output', 'data.json')
 
 /**
@@ -38,10 +42,133 @@ if (dumpPath === undefined || dumpPath.startsWith('--')) {
     console.error('usage: analyze-rail-box-orientation.mjs <dump.json> [--write-fixture]')
     process.exit(2)
 }
-const dump = JSON.parse(readFileSync(dumpPath, 'utf8'))
+const input = JSON.parse(readFileSync(dumpPath, 'utf8'))
 const fd = JSON.parse(readFileSync(DATA_JSON, 'utf8')).entities
 
 const box = b => [b.left_top.x, b.left_top.y, b.right_bottom.x, b.right_bottom.y]
+
+const sizeFromBox = (e, b) => ({
+    x: e.tile_width || Math.ceil(Math.abs(b[0]) + Math.abs(b[2])),
+    y: e.tile_height || Math.ceil(Math.abs(b[1]) + Math.abs(b[3])),
+})
+
+const swapForDirection = (type, dir, size) => {
+    if (size.x === size.y) return size
+    const dd =
+        type === 'curved-rail-a' || type === 'curved-rail-b'
+            ? Math.floor((dir % 8) / 4) * 4
+            : (Math.round(dir / 4) * 4) % 16
+    return dd === 4 || dd === 12 ? { x: size.y, y: size.x } : size
+}
+
+const keyedCells = (size, position) => {
+    const x0 = Math.round(position.x - size.x / 2)
+    const y0 = Math.round(position.y - size.y / 2)
+    const cells = new Set()
+    for (let x = x0; x < x0 + size.x; x++)
+        for (let y = y0; y < y0 + size.y; y++)
+            cells.add(`${x - Math.floor(position.x)},${y - Math.floor(position.y)}`)
+    return cells
+}
+
+const scoreAgainstMeasuredOccupancy = disagreements => {
+    const occupancy = JSON.parse(readFileSync(OCCUPANCY, 'utf8'))
+    const runtimeBoxes = Object.fromEntries(disagreements.map(d => [d.name, d]))
+    const rails = Object.values(occupancy.rails)
+    const arms = { today: { missed: 0, empty: 0 }, runtimeBoxes: { missed: 0, empty: 0 } }
+    const rows = {}
+    let changedMeasuredOrientations = 0
+
+    for (const r of rails) {
+        const measured = runtimeBoxes[r.name]
+        const chest = Object.values(r.references).find(x => x.reference === 'wooden-chest')
+        if (measured === undefined || chest === undefined) continue
+        const blocked = new Set(Object.values(chest.blocked ?? {}).map(c => `${c.x},${c.y}`))
+        const e = fd[r.name]
+        const sizes = {
+            today: swapForDirection(e.type, r.direction, sizeFromBox(e, measured.dataJson)),
+            runtimeBoxes: swapForDirection(e.type, r.direction, sizeFromBox(e, measured.runtime)),
+        }
+        if (sizes.today.x !== sizes.runtimeBoxes.x || sizes.today.y !== sizes.runtimeBoxes.y)
+            changedMeasuredOrientations++
+
+        const row = {}
+        for (const [arm, size] of Object.entries(sizes)) {
+            const cells = keyedCells(size, r.position)
+            const missed = [...blocked].filter(c => !cells.has(c)).length
+            const empty = [...cells].filter(c => !blocked.has(c)).length
+            arms[arm].missed += missed
+            arms[arm].empty += empty
+            row[arm] = { missed, empty }
+        }
+        rows[`${r.name}@${r.direction}`] = row
+    }
+
+    const aligned = ['straight-rail@0', 'straight-rail@4'].every(
+        key =>
+            rows[key]?.today.missed === 0 &&
+            rows[key]?.today.empty === 0 &&
+            rows[key]?.runtimeBoxes.missed === 0 &&
+            rows[key]?.runtimeBoxes.empty === 0
+    )
+    const footprintChanges = disagreements
+        .map(d => ({
+            name: d.name,
+            today: sizeFromBox(fd[d.name], d.dataJson),
+            runtime: sizeFromBox(fd[d.name], d.runtime),
+        }))
+        .filter(x => x.today.x !== x.runtime.x || x.today.y !== x.runtime.y)
+    const controls = [
+        {
+            name: 'every measured orientation was scored',
+            ok: Object.keys(rows).length === rails.length,
+            detail: `${Object.keys(rows).length} of ${rails.length}`,
+        },
+        {
+            name: 'the coordinate systems align on cardinal straight rails',
+            ok: aligned,
+            detail: aligned ? '0 missed and 0 empty in both arms' : 'alignment row differs',
+        },
+    ]
+
+    return {
+        note: 'Computed from fixtures/rail-occupancy.json against the wooden-chest reference. Runtime boxes reduce false positives but increase occupied tiles the editor would not key, so replacing data.json is not an improvement.',
+        orientations: rails.length,
+        reference: 'wooden-chest',
+        controls,
+        controlsAllPassed: controls.every(c => c.ok),
+        collisionBoxDisagreements: disagreements.length,
+        footprintChanges,
+        changedMeasuredOrientations,
+        arms,
+        adoptingRuntimeBoxesIsImprovement:
+            arms.runtimeBoxes.missed <= arms.today.missed &&
+            arms.runtimeBoxes.empty <= arms.today.empty,
+    }
+}
+
+const writeResult = result => {
+    const json = JSON.stringify(result, null, 4)
+    if (process.argv.includes('--write-fixture')) {
+        writeFileSync(FIXTURE, json + '\n')
+        console.log(`wrote ${FIXTURE}`)
+    } else {
+        console.log(json)
+    }
+}
+
+if (input.dataJsonVersusRuntime !== undefined) {
+    input.issue =
+        '#251; originally captured while de-risking run 2 of probe-blueprint-grid-position-gui'
+    input.proposedChangeAgainstMeasuredOccupancy = scoreAgainstMeasuredOccupancy(
+        input.dataJsonVersusRuntime.disagreements
+    )
+    writeResult(input)
+    if (!input.proposedChangeAgainstMeasuredOccupancy.controlsAllPassed) process.exit(1)
+    process.exit(0)
+}
+
+const dump = input
 
 const placed = dump.directions.filter(d => d.created)
 const boxes = placed.map(d => JSON.stringify(box(d.bounding_box)))
@@ -86,7 +213,7 @@ const fixture = {
         "Does a half-diagonal-rail's collision box rotate with direction, and does data.json agree with the running game about collision boxes?",
     probe: 'probe-rail-box-orientation/control.lua',
     runner: 'factorio-oracle run --probe tools/oracle/probe-rail-box-orientation/probe.json',
-    issue: 'de-risking run 2 of probe-blueprint-grid-position-gui; bears on PR #243 finding 15',
+    issue: '#251; originally captured while de-risking run 2 of probe-blueprint-grid-position-gui',
     provenance: {
         capturedOn: new Date().toISOString().slice(0, 10),
         method: 'headless create run; no player needed, so no interactive session',
@@ -125,16 +252,14 @@ const fixture = {
         allDisagreementsAreRails: disagreements.every(d => d.name.includes('rail')),
         disagreements,
     },
+    proposedChangeAgainstMeasuredOccupancy: scoreAgainstMeasuredOccupancy(disagreements),
 }
 
-const json = JSON.stringify(fixture, null, 4)
-if (process.argv.includes('--write-fixture')) {
-    writeFileSync(FIXTURE, json + '\n')
-    console.log(`wrote ${FIXTURE}`)
-} else {
-    console.log(json)
-}
-if (!fixture.controlsAllPassed) {
+writeResult(fixture)
+if (
+    !fixture.controlsAllPassed ||
+    !fixture.proposedChangeAgainstMeasuredOccupancy.controlsAllPassed
+) {
     console.error('\nA control failed. The numbers above are void rather than a finding.')
     process.exit(1)
 }

--- a/tools/oracle/analyze-rail-box-orientation.test.mjs
+++ b/tools/oracle/analyze-rail-box-orientation.test.mjs
@@ -1,0 +1,82 @@
+import { test } from 'vite-plus/test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Runs the analyzer's rescore path over the committed fixture.
+ *
+ * The analyzer is a script rather than a module - it reads `process.argv` at
+ * the top level and ends in `process.exit` - so this spawns it the way a person
+ * would. Feeding it the committed fixture recomputes the occupancy comparison
+ * against `fixtures/rail-occupancy.json` without needing Factorio, which is the
+ * whole reason that path exists.
+ *
+ * Without this file the analyzer's three controls ran only by hand. They exist
+ * to catch a transcription error in `sizeFromBox`, `swapForDirection` or
+ * `keyedCells`, and a control nothing invokes reports nothing.
+ */
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ANALYZER = join(HERE, 'analyze-rail-box-orientation.mjs')
+const FIXTURE = join(HERE, 'fixtures', 'rail-box-orientation.json')
+
+let cached
+const rescore = () => {
+    cached ??= execFileSync(process.execPath, [ANALYZER, FIXTURE], {
+        encoding: 'utf8',
+        maxBuffer: 32 * 1024 * 1024,
+    })
+    return cached
+}
+
+test('every control on the occupancy comparison passes', () => {
+    const scored = JSON.parse(rescore()).proposedChangeAgainstMeasuredOccupancy
+    // Named rather than counted, so a failure says which control voided the
+    // numbers instead of only that one did.
+    assert.deepEqual(
+        scored.controls.filter(c => !c.ok).map(c => `${c.name}: ${c.detail}`),
+        []
+    )
+    assert.equal(scored.controlsAllPassed, true)
+})
+
+test('the committed fixture is what the analyzer produces from it', () => {
+    // The analyzer is deterministic on this path, so any drift in
+    // packages/exporter/data/output/data.json or in either fixture it reads
+    // shows up here as a diff rather than silently restating a stale finding.
+    assert.equal(rescore(), readFileSync(FIXTURE, 'utf8'))
+})
+
+test('the runtime boxes trade one error for another rather than improving', () => {
+    const scored = JSON.parse(rescore()).proposedChangeAgainstMeasuredOccupancy
+    assert.deepEqual(scored.arms, {
+        today: { missed: 180, empty: 96 },
+        runtimeBoxes: { missed: 220, empty: 56 },
+    })
+    assert.equal(scored.adoptingRuntimeBoxesIsImprovement, false)
+})
+
+test('the 16 disagreements split 12 unchanged, 3 masked and 1 changed', () => {
+    const scored = JSON.parse(rescore()).proposedChangeAgainstMeasuredOccupancy
+    assert.equal(scored.collisionBoxDisagreements, 16)
+    assert.equal(scored.unchangedFootprints, 12)
+    assert.deepEqual(
+        scored.maskedByDeclaredDimension.map(f => f.name),
+        ['half-diagonal-rail', 'dummy-elevated-half-diagonal-rail', 'elevated-half-diagonal-rail']
+    )
+    assert.deepEqual(
+        scored.footprintChanges.map(f => f.name),
+        ['legacy-curved-rail']
+    )
+    // The masking is the finding, not the equality: these three enclose
+    // different rectangles and only agree because data.json declares a
+    // tile_height for them. Assert the raw sizes so that stays visible.
+    for (const f of scored.maskedByDeclaredDimension) {
+        assert.deepEqual(f.rawToday, { x: 2, y: 5 })
+        assert.deepEqual(f.rawRuntime, { x: 2, y: 4 })
+        assert.equal(f.declared.tile_height, 2)
+        assert.deepEqual(f.today, f.runtime)
+    }
+})

--- a/tools/oracle/fixtures/rail-box-orientation.json
+++ b/tools/oracle/fixtures/rail-box-orientation.json
@@ -2,7 +2,7 @@
     "question": "Does a half-diagonal-rail's collision box rotate with direction, and does data.json agree with the running game about collision boxes?",
     "probe": "probe-rail-box-orientation/control.lua",
     "runner": "factorio-oracle run --probe tools/oracle/probe-rail-box-orientation/probe.json",
-    "issue": "de-risking run 2 of probe-blueprint-grid-position-gui; bears on PR #243 finding 15",
+    "issue": "#251; originally captured while de-risking run 2 of probe-blueprint-grid-position-gui",
     "provenance": {
         "capturedOn": "2026-08-21",
         "method": "headless create run; no player needed, so no interactive session",
@@ -333,5 +333,49 @@
                 ]
             }
         ]
+    },
+    "proposedChangeAgainstMeasuredOccupancy": {
+        "note": "Computed from fixtures/rail-occupancy.json against the wooden-chest reference. Runtime boxes reduce false positives but increase occupied tiles the editor would not key, so replacing data.json is not an improvement.",
+        "orientations": 38,
+        "reference": "wooden-chest",
+        "controls": [
+            {
+                "name": "every measured orientation was scored",
+                "ok": true,
+                "detail": "38 of 38"
+            },
+            {
+                "name": "the coordinate systems align on cardinal straight rails",
+                "ok": true,
+                "detail": "0 missed and 0 empty in both arms"
+            }
+        ],
+        "controlsAllPassed": true,
+        "collisionBoxDisagreements": 16,
+        "footprintChanges": [
+            {
+                "name": "legacy-curved-rail",
+                "today": {
+                    "x": 4,
+                    "y": 4
+                },
+                "runtime": {
+                    "x": 2,
+                    "y": 3
+                }
+            }
+        ],
+        "changedMeasuredOrientations": 8,
+        "arms": {
+            "today": {
+                "missed": 180,
+                "empty": 96
+            },
+            "runtimeBoxes": {
+                "missed": 220,
+                "empty": 56
+            }
+        },
+        "adoptingRuntimeBoxesIsImprovement": false
     }
 }

--- a/tools/oracle/fixtures/rail-box-orientation.json
+++ b/tools/oracle/fixtures/rail-box-orientation.json
@@ -348,6 +348,11 @@
                 "name": "the coordinate systems align on cardinal straight rails",
                 "ok": true,
                 "detail": "0 missed and 0 empty in both arms"
+            },
+            {
+                "name": "the today arm reproduces #142's independent transcription",
+                "ok": true,
+                "detail": "180 missed and 96 empty here against 180 and 96 in entity-tile-size.json, over 38 orientations"
             }
         ],
         "controlsAllPassed": true,
@@ -362,9 +367,93 @@
                 "runtime": {
                     "x": 2,
                     "y": 3
+                },
+                "rawToday": {
+                    "x": 4,
+                    "y": 4
+                },
+                "rawRuntime": {
+                    "x": 2,
+                    "y": 3
+                },
+                "declared": {
+                    "tile_width": null,
+                    "tile_height": null
                 }
             }
         ],
+        "maskedByDeclaredDimension": [
+            {
+                "name": "half-diagonal-rail",
+                "today": {
+                    "x": 2,
+                    "y": 2
+                },
+                "runtime": {
+                    "x": 2,
+                    "y": 2
+                },
+                "rawToday": {
+                    "x": 2,
+                    "y": 5
+                },
+                "rawRuntime": {
+                    "x": 2,
+                    "y": 4
+                },
+                "declared": {
+                    "tile_width": null,
+                    "tile_height": 2
+                }
+            },
+            {
+                "name": "dummy-elevated-half-diagonal-rail",
+                "today": {
+                    "x": 2,
+                    "y": 2
+                },
+                "runtime": {
+                    "x": 2,
+                    "y": 2
+                },
+                "rawToday": {
+                    "x": 2,
+                    "y": 5
+                },
+                "rawRuntime": {
+                    "x": 2,
+                    "y": 4
+                },
+                "declared": {
+                    "tile_width": null,
+                    "tile_height": 2
+                }
+            },
+            {
+                "name": "elevated-half-diagonal-rail",
+                "today": {
+                    "x": 2,
+                    "y": 2
+                },
+                "runtime": {
+                    "x": 2,
+                    "y": 2
+                },
+                "rawToday": {
+                    "x": 2,
+                    "y": 5
+                },
+                "rawRuntime": {
+                    "x": 2,
+                    "y": 4
+                },
+                "declared": {
+                    "tile_width": null,
+                    "tile_height": 2
+                }
+            }
+        ],
+        "unchangedFootprints": 12,
         "changedMeasuredOrientations": 8,
         "arms": {
             "today": {

--- a/tools/oracle/probe-rail-box-orientation/README.md
+++ b/tools/oracle/probe-rail-box-orientation/README.md
@@ -66,10 +66,26 @@ nowhere else.
 ## Should `data.json` adopt the runtime boxes?
 
 No. Running both sets of boxes through `getEntitySize` changes only
-`legacy-curved-rail`, from 4x4 to 2x3; the other 15 differences round to the
-same footprint or are masked by a declared dimension. Against the 38
-orientations in `fixtures/rail-occupancy.json`, the runtime boxes trade one
-error for another rather than improving the result:
+`legacy-curved-rail`, from 4x4 to 2x3. The other 15 split two ways, and they are
+worth keeping apart:
+
+- **Twelve round to the same footprint.** Both boxes enclose the same rectangle
+  once `ceil` is applied, with nothing propping that up. These are the benign
+  ones.
+- **Three are masked by a declared dimension**: `half-diagonal-rail` and its
+  `elevated-` and `dummy-elevated-` variants. Their boxes really do enclose
+  different rectangles - 2x5 from `data.json` against 2x4 from the game - and
+  the editor computes the same footprint either way only because `data.json`
+  declares `tile_height: 2` for all three and the declared value wins. #142
+  measured that field to be a **centring parity rather than a size**, so the
+  agreement rests on something that does not mean what its name says. Drop or
+  regenerate that declaration and these three join `legacy-curved-rail` as real
+  footprint changes.
+
+The fixture records the three buckets as `maskedByDeclaredDimension`,
+`footprintChanges` and `unchangedFootprints` rather than leaving them as prose.
+Against the 38 orientations in `fixtures/rail-occupancy.json`, the runtime boxes
+trade one error for another rather than improving the result:
 
 | boxes       | occupied but not keyed | keyed but empty |
 | ----------- | ---------------------- | --------------- |
@@ -94,6 +110,25 @@ A control has to be able to fail while the hypothesis holds.
 
 The middle one is the load-bearing one for the "it does not rotate" finding,
 which is otherwise unfalsifiable.
+
+The occupancy scoring above carries three more, recorded in the fixture under
+`proposedChangeAgainstMeasuredOccupancy.controls`:
+
+| Control                                                   | Fails when                                                                                               |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| every measured orientation was scored                     | a rail was skipped, so the totals are over a smaller sweep than the header claims                        |
+| the coordinate systems align on cardinal straight rails   | the analyzer's cells and the measured cells are not in the same frame, which inflates both arms together |
+| the today arm reproduces #142's independent transcription | `sizeFromBox`, `swapForDirection` or `keyedCells` was transcribed wrong                                  |
+
+The third one is the only thing here that can catch a transcription error. Both
+arms run through the same three functions, so a mistake in any of them moves the
+two together and leaves a comparison that still reads as sound.
+`probe-entity-tile-size.mjs` transcribed the same rules separately for #142 and
+committed its answer for the arm the two runs share, so this control just checks
+that the two independent readings agree: 180 occupied-but-not-keyed and 96
+keyed-but-empty. Checked by deliberately dropping the declared-dimension
+override from `sizeFromBox`, which the first two controls pass unchanged while
+this one reports 168 and 108 and exits non-zero.
 
 ## Running it
 

--- a/tools/oracle/probe-rail-box-orientation/README.md
+++ b/tools/oracle/probe-rail-box-orientation/README.md
@@ -130,6 +130,14 @@ keyed-but-empty. Checked by deliberately dropping the declared-dimension
 override from `sizeFromBox`, which the first two controls pass unchanged while
 this one reports 168 and 108 and exits non-zero.
 
+All three run in `vp test`, through `analyze-rail-box-orientation.test.mjs`,
+which rescores the committed fixture the same way the command above does. A
+control nothing invokes reports nothing, and until that file existed these ran
+only when somebody ran the analyzer by hand. It also asserts the rescore
+reproduces the committed fixture byte for byte, so drift in `data.json` or in
+either fixture the analyzer reads shows up as a failure rather than as a stale
+finding restated with fresh confidence.
+
 ## Running it
 
 ```fish

--- a/tools/oracle/probe-rail-box-orientation/README.md
+++ b/tools/oracle/probe-rail-box-orientation/README.md
@@ -63,6 +63,25 @@ the place where the editor's geometry is wrong in both directions (#133, #142);
 this says the editor's own **data** disagrees with the game there too, and
 nowhere else.
 
+## Should `data.json` adopt the runtime boxes?
+
+No. Running both sets of boxes through `getEntitySize` changes only
+`legacy-curved-rail`, from 4x4 to 2x3; the other 15 differences round to the
+same footprint or are masked by a declared dimension. Against the 38
+orientations in `fixtures/rail-occupancy.json`, the runtime boxes trade one
+error for another rather than improving the result:
+
+| boxes       | occupied but not keyed | keyed but empty |
+| ----------- | ---------------------- | --------------- |
+| `data.json` | 180                    | 96              |
+| runtime     | 220                    | 56              |
+
+The committed fixture can recompute this comparison without rerunning Factorio:
+
+```fish
+node tools/oracle/analyze-rail-box-orientation.mjs tools/oracle/fixtures/rail-box-orientation.json
+```
+
 ## Controls
 
 A control has to be able to fail while the hypothesis holds.


### PR DESCRIPTION
Closes #251. Extends the existing rail-box analyzer to score the captured Factorio 2.0.77 runtime boxes against the committed 38-orientation rail occupancy fixture. Only legacy-curved-rail changes editor footprint (4x4 to 2x3), producing 180 to 220 occupied-but-not-keyed cells while reducing keyed-but-empty cells from 96 to 56, so the runtime boxes are not adopted. Adds coverage and coordinate-alignment controls and records the result in the generated fixture and probe documentation. Checks: vp check --fix; vp test (194 passed); fixture rescore controls passed.