### PR TITLE
Send a User-Agent on proxied requests

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -15,6 +15,31 @@ const CUSTOM_ORIGIN = 'https://fbe.factorygamefan.com'
 */
 const PASSTHROUGH_RESPONSE_HEADERS = ['content-type']
 
+/*
+    Sent on every outbound fetch, because GitHub's API refuses a request without
+    one: `api.github.com` answers 403 "Request forbidden by administrative rules.
+    Please make sure your request has a User-Agent header." Cloudflare's fetch
+    sends none of its own, so the `gist` source in bpString.ts has been broken
+    since this Worker replaced the Cloudflare Pages deploy in March 2026 - the
+    Pages handler used `new Request(apiUrl, request)`, which copied the browser's
+    User-Agent along with everything else.
+
+    A fixed string rather than the caller's, and that distinction is the whole
+    reason this is one line instead of a header copy. Forwarding the client's
+    headers is what the old handler did, and for a same-origin call those include
+    cookies for fbe.factorygamefan.com - which would then be handed to pastebin.
+
+    Nothing can test this. tests/blueprint-sources.spec.ts covers the gist arm and
+    is green, because it intercepts /corsproxy with page.route and never reaches
+    GitHub; no runner here has network access to it either. The guard in
+    tests/corsproxy.test.ts reads this file instead, which is the same answer
+    tests/spec-modifier-keys.test.ts reached for its own untestable class.
+
+    Measured 2026-08-25: of the eight allowlisted hosts, api.github.com is the
+    only one that answers differently with and without this header.
+*/
+const PROXY_USER_AGENT = 'factorio-blueprint-editor (+https://fbe.factorygamefan.com)'
+
 const textResponse = (status: number, body: string): Response =>
     new Response(`${body}\n`, {
         status,
@@ -63,6 +88,7 @@ async function handleCorsProxy(request: Request, requestUrl: URL): Promise<Respo
         upstream = await fetch(verdict.url.href, {
             method: request.method,
             redirect: 'follow',
+            headers: { 'user-agent': PROXY_USER_AGENT },
         })
     } catch {
         return textResponse(502, 'Could not reach the target')

--- a/tests/corsproxy.test.ts
+++ b/tests/corsproxy.test.ts
@@ -125,3 +125,37 @@ describe('checkProxyTarget - refusals', () => {
         expect(verdict.ok).toBe(false)
     })
 })
+
+/*
+    A source scan rather than a behaviour test, and it is the same answer
+    tests/spec-modifier-keys.test.ts reached for its own class of bug: nothing
+    that runs here can reach api.github.com, so no runner can catch the thing
+    this guards.
+
+    GitHub's API refuses a request with no User-Agent, and Cloudflare's fetch
+    sends none of its own, so dropping this header silently breaks the `gist`
+    source in bpString.ts - and breaks it in a way the whole suite stays green
+    for, because tests/blueprint-sources.spec.ts intercepts /corsproxy with
+    page.route and never leaves the browser. That is exactly how it went
+    unnoticed from March 2026 until it was probed against production.
+*/
+describe('the outbound fetch identifies itself', () => {
+    const worker = fs.readFileSync(
+        path.resolve(process.cwd(), 'packages/worker/src/index.ts'),
+        'utf-8'
+    )
+
+    it('sends a user-agent on the proxied request', () => {
+        const call = worker.match(/upstream = await fetch\([\s\S]*?\n {8}\}\)/)
+        if (call === null) throw new Error('the outbound fetch call could not be located')
+        expect(call[0]).toMatch(/'user-agent':/)
+    })
+
+    it('uses a fixed string that names the project, not the caller’s header', () => {
+        const declared = worker.match(/const PROXY_USER_AGENT = '([^']+)'/)
+        if (declared === null) throw new Error('PROXY_USER_AGENT is not declared')
+        expect(declared[1]).toMatch(/factorio-blueprint-editor/)
+        // Forwarding request.headers would carry our own cookies to the target.
+        expect(worker).not.toMatch(/headers:\s*request\.headers/)
+    })
+})


### PR DESCRIPTION
## The bug

The `gist` blueprint source is broken in production. `api.github.com` answers
403 to any request with no `User-Agent`:

> Request forbidden by administrative rules. Please make sure your request has a
> User-Agent header.

Cloudflare's `fetch` sends none of its own, so every gist load fails. In the
editor that surfaces as a corrupt-blueprint error naming nothing about GitHub,
because `fetchData` in `bpString.ts` rejects on `!response.ok` and stops there.

**Found by probing production after #272 deployed, not by any test.**

## Not a regression from #272, but probably one from the Pages migration

The pre-#272 Worker called `fetch(target, { method: request.method })` - no
headers either, so the call shape is identical in this respect and #272 changed
nothing here.

The dead `functions/corsproxy.js` that #272 deleted used
`new Request(apiUrl, request)`, which copies the browser's headers including
`User-Agent`. So gist very likely worked under Cloudflare Pages and broke when
the Worker replaced it in March 2026 (`b91ce5ac`). That part is inference from
the code rather than measurement - the Pages handler cannot be run any more.

## Scope, measured

All eight allowlisted hosts, through the live proxy versus a direct fetch
carrying a `User-Agent`:

| Host | Via proxy | Direct with UA | |
| --- | --- | --- | --- |
| pastebin.com | 404 | 404 | same |
| hastebin.com | 401 | 401 | same |
| **api.github.com** | **403** | **404** | **differs** |
| gitlab.com | 403 | 403 | same |
| facorio-blueprints.firebaseio.com | 200 | 200 | same |
| www.factorio.school | 200 | 200 | same |
| factoriobin.com | 200 | 200 | same |
| docs.google.com | 200 | 200 | same |

`api.github.com` is the only one affected. The status codes are whatever those
endpoints return for the placeholder paths used - what matters is the column
comparison, not the codes themselves.

## The fix

One header on the outbound fetch, from a fixed constant:

```ts
const PROXY_USER_AGENT = 'factorio-blueprint-editor (+https://fbe.factorygamefan.com)'
```

**A fixed string, not the caller's.** Forwarding the client's headers is what
the old Pages handler did, and for a same-origin call those include cookies for
`fbe.factorygamefan.com` - which would then be handed to pastebin. That was the
reason #272 declined to port `new Request(apiUrl, request)`, and it still holds;
the UA is the one piece of that request worth reconstructing deliberately.

## Testing

**No runner can catch this class**, which is why it survived from March.
`tests/blueprint-sources.spec.ts` covers the gist arm and is green, because it
intercepts `/corsproxy` with `page.route` and never leaves the browser. Nothing
in CI has network access to GitHub either.

So the guard reads the source, the same answer `tests/spec-modifier-keys.test.ts`
reached for its own untestable class (a macOS-only chord bug that passes on
every `ubuntu-latest` shard). Two cases added to `tests/corsproxy.test.ts`: the
outbound fetch call must carry a `user-agent` key, and `PROXY_USER_AGENT` must
be a fixed string naming the project, with `headers: request.headers` explicitly
rejected.

Mutation-checked three ways, **all three killed**:

| Mutation | Result |
| --- | --- |
| Delete the user-agent header from the fetch | killed |
| Blank the user-agent string | killed |
| Forward the caller's headers instead | killed |

## Verification

- `vp check .` - 232 formatted, 0 errors across 180 files
- `vp test` - 17 files, 220 tests (up 2)
- `npx tsc --noEmit -p packages/worker/tsconfig.json` - exit 0

The fix itself cannot be verified before deploy, for the same reason nothing
tests it. Worth re-probing `?url=https://api.github.com/gists/<id>` against
production once this lands.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iNrgVVJgjUwbRSTvHMEpZ
