### PR TITLE
Pass a factorioprints API url through untouched, as factorio.school already is

### DIFF
--- a/packages/editor/src/core/bpString.ts
+++ b/packages/editor/src/core/bpString.ts
@@ -298,6 +298,22 @@ function getBlueprintOrBookFromSource(source: string): Promise<Blueprint | Book>
                         r.text()
                     )
                 case 'factorioprints':
+                    /*
+                        The same fork as the factorio.school arm below, and for
+                        the same reason. `factorioprints.xyz` is the same API
+                        under a factorioprints domain, and a link to one
+                        blueprint *inside a book* is an
+                        `/api/blueprintData/<sha>/position/<i>` URL. The firebase
+                        record holds the whole book and nothing else, so
+                        rewriting to it would silently drop the position and open
+                        the book instead of the blueprint that was linked -
+                        `pathParts[1]` of an API path is `blueprintData`, not a
+                        blueprint key, so in practice the fetch fails outright.
+                    */
+                    if (pathParts[0] === 'api') {
+                        return fetchData(url.href).then(r => r.text())
+                    }
+
                     return fetchData(
                         `https://facorio-blueprints.firebaseio.com/blueprints/${pathParts[1]}.json`
                     )

--- a/packages/worker/src/proxyTarget.ts
+++ b/packages/worker/src/proxyTarget.ts
@@ -36,6 +36,7 @@ export const ALLOWED_HOSTS: ReadonlySet<string> = new Set([
     'facorio-blueprints.firebaseio.com',
     'www.factorio.school',
     'factorio.school',
+    'factorioprints.xyz',
     'factoriobin.com',
     'docs.google.com',
 ])

--- a/tests/blueprint-sources.spec.ts
+++ b/tests/blueprint-sources.spec.ts
@@ -122,6 +122,19 @@ test('factorioprints reads blueprintString off the firebase record', async ({ pa
     expect(r.entities).toBe(2)
 })
 
+/*
+    The same fork inside the factorioprints arm. factorioprints links a blueprint
+    inside a book by its position in the API URL, and the firebase record the
+    /view/ shape rewrites to holds only the whole book - so a rewrite here would
+    load the book and lose the position, with the request still looking right.
+*/
+test('a factorioprints API url is passed through unchanged and read as text', async ({ page }) => {
+    const source = 'https://factorioprints.xyz/api/blueprintData/xyz321/position/1.0'
+    const r = await fetchThrough(page, source, BP)
+    expect(r.target).toBe(source)
+    expect(r.entities).toBe(2)
+})
+
 test('factorio.school reads the doubly nested blueprintString', async ({ page }) => {
     const r = await fetchThrough(page, 'https://www.factorio.school/view/xyz321', schoolBody)
     expect(r.target).toBe('https://www.factorio.school/api/blueprint/xyz321')

--- a/tests/corsproxy.test.ts
+++ b/tests/corsproxy.test.ts
@@ -64,6 +64,22 @@ describe('checkProxyTarget - the editor’s own sources', () => {
         }
     })
 
+    /*
+        The other direction of the same guard, for the arms that fetch `url.href`
+        rather than a URL they build: their hosts appear nowhere in bpString.ts
+        as a literal, so the scan above cannot see them, and dropping one to the
+        catch-all would go unnoticed.
+    */
+    it('allowlists the hosts the pass-through arms fetch', () => {
+        const passThrough = ['factorio.school', 'www.factorio.school', 'factorioprints.xyz']
+
+        for (const host of passThrough) {
+            expect(ALLOWED_HOSTS.has(host), `${host} is passed through but not allowlisted`).toBe(
+                true
+            )
+        }
+    })
+
     // The allowlist is checked before the catch-all guards, so a named host is
     // exempt from the port rule. Pinned because it is a consequence of the
     // ordering rather than a decision anyone would find by reading the guards.


### PR DESCRIPTION
Factorio Prints is about to link every blueprint in a book straight into this editor, the way factorio.school already does. Those links address one blueprint inside a book by its position:

```
https://fbe.factorygamefan.com/?source=https://factorioprints.xyz/api/blueprintData/<sha>/position/1.0
```

`factorioprints.xyz` is the same API as `www.factorio.school`, under a factorioprints domain — same paths, same responses.

Today that URL loads nothing. The switch in `bpString.ts` keys on the first label of the hostname, so `factorioprints.xyz` takes the firebase arm and is rewritten to `blueprints/blueprintData.json` — `pathParts[1]` of an API path is `blueprintData`, not a blueprint key. And even read correctly, the firebase record only ever holds the whole book, so the position would be dropped.

`factorio.school` already has the fork this needs: an `/api/` path is passed through untouched and read as text. This does the same inside the `factorioprints` arm, which is why the two arms now read alike.

Also adds `factorioprints.xyz` to the corsproxy allowlist. The catch-all would relay it anyway, so nothing depends on this — it is the same reasoning that already puts bare `factorio.school` on the list: a pass-through arm's host appears nowhere in `bpString.ts` as a literal, so the "covers every host bpString.ts builds a URL for" scan cannot see it, and the entry is what says the host is expected rather than merely tolerated.

Note on the other domain: `factorioprints.com` is the site, not the API — `factorioprints.com/api/...` answers the SPA's `index.html` at status 200. It is deliberately not on the allowlist, and the `/view/` shape it does serve keeps going to firebase exactly as before.

## Tests

- `tests/blueprint-sources.spec.ts` — a factorioprints API url is passed through unchanged and read as text. Checked red: without the change it fails on the rewritten target.
- `tests/corsproxy.test.ts` — the hosts the pass-through arms fetch are allowlisted, in the other direction from the existing scan.

`vp check`, `vp test` (221) and the full `blueprint-sources` spec (12) pass locally.

## Checked against production

```
$ curl -s -o /dev/null -w '%{http_code}\n' \
  'https://fbe.factorygamefan.com/corsproxy?url=https%3A%2F%2Ffactorioprints.xyz%2Fapi%2FblueprintData%2F9030bab1975b1b0b0d07de628f0b032286394e37%2Fposition%2F1.0'
200
```

That sha is a real book whose entry 1 is a nested book, so `1.0` exercises the nested path. The proxy already relays it; only the editor-side rewrite is in the way.
