### PR TITLE
Pin the focus hand-back's non-last-dialog case, and fix three comments that overstate the code

### DIFF
--- a/packages/editor/src/UI/controls/Dialog.ts
+++ b/packages/editor/src/UI/controls/Dialog.ts
@@ -83,8 +83,8 @@ export abstract class Dialog extends Panel {
         this.destroy()
 
         /*
-            Hand the keyboard focus back to the canvas, but only when this
-            close is what orphaned it.
+            Hand the keyboard focus back to the canvas whenever nothing else
+            holds it.
 
             `destroy()` above takes any TextInput this dialog held with it,
             and `TextInput._onRemoved` removes that <input> from
@@ -92,16 +92,30 @@ export abstract class Dialog extends Panel {
             `document.activeElement` to <body>, and nothing else in the app
             ever focuses the canvas back (TextInput's own two calls are the
             only other `.focus()` in the package). Both clipboard listeners in
-            packages/website/src/index.ts open with
-            `if (document.activeElement !== CANVAS) return`, so Ctrl+C and
-            Ctrl+V went silently dead - no toast, no error - from the moment
-            any dialog with a field had been open until the user clicked the
-            canvas (#242 review).
+            packages/website/src/index.ts require the canvas to be holding the
+            focus, so Ctrl+C and Ctrl+V went silently dead - no toast, no
+            error - from the moment any dialog with a field had been open
+            until the user clicked the canvas (#242 review). Described rather
+            than quoted, because that condition has since grown a second half
+            (issue #279) and a copy of it here would go stale without anyone
+            opening this file.
 
             <body> is the whole condition, and reading it is what separates
             "the field that held the focus was just destroyed" from
-            "something else still holds it". An unconditional call took the
-            focus off a live element: the settings pane's BP Book Index box
+            "something else still holds it". Note it cannot separate either of
+            those from "nothing held the focus to begin with", and does not
+            try to: dragging the BP Book Index *slider* rather than typing in
+            its box leaves <body> focused, because dat.gui blurs on mousedown
+            and its track is a plain <div>, and an InventoryDialog owns no
+            <input> at all, so closing one can never orphan anything. Both
+            reach a true condition here and both get a focused canvas, which
+            is the right answer for them anyway. So this is "claim the focus
+            when nothing else wants it", not "detect that I orphaned it" -
+            the subject line of the commit that introduced it says the latter
+            and overstates what the check can see.
+
+            An unconditional call took the focus off a live element: the
+            settings pane's BP Book Index box
             steps on ArrowUp through `changeBookIndex` ->
             `Editor.loadBlueprint` -> `Dialog.closeAll()`, so with any dialog
             open the first arrow closed it and this pulled the focus off the

--- a/tests/quick-actions.spec.ts
+++ b/tests/quick-actions.spec.ts
@@ -42,6 +42,40 @@ import {
       the loaded blueprint's real string without going through
       `navigator.clipboard` on the read side, the same reason ExportDialog
       exists as a fallback for a browser that blocks it.
+
+    Three of the tests here cover the focus hand-back at the end of
+    `Dialog.close()`, and they are a set rather than three takes on one thing.
+    Measured on 2026-08-30 by mutating that one line and running this file plus
+    tests/settings-pane-book-index.spec.ts, 17 tests in all:
+
+      shipped   `if (document.activeElement === document.body) focus()`
+                  -> 17 pass
+
+      A         `if (!Dialog.anyOpen() && ...)`, ie. also requiring this to be
+                the last dialog - the plausible-looking re-addition, since a
+                surviving dialog reads like something that should keep the
+                keyboard
+                  -> only "hands the focus back even while another dialog
+                     stays open" fails. This was the gap #281 was filed for:
+                     before that test existed the whole set went green.
+
+      B         unconditional `focus()`, no guard at all - the first version
+                of the #242 fix
+                  -> "does not take the focus off a field that still has it"
+                     fails here, and so does settings-pane-book-index's
+                     "a dialog closing on the first arrow does not steal the
+                     focus off the index box".
+
+      C         the hand-back deleted outright
+                  -> both hand-back tests here fail; both settings-pane tests
+                     pass, since nothing is being stolen.
+
+    Read down the columns rather than across: A is caught by exactly one test
+    in either file, the one #281 added, and by nothing else anywhere. B is
+    caught by the live-field test here and by the settings-pane treatment.
+    C is caught by the two hand-back tests here and by neither settings-pane
+    test. So the guard's two halves fail in opposite directions and each needs
+    its own test; a set missing any one of the three leaves a mutation green.
 */
 
 type Page = import('@playwright/test').Page
@@ -267,7 +301,9 @@ test('Escape closes ImportDialog and ExportDialog even while the textarea has fo
     expect(await page.evaluate(() => window.__fbe_test.openDialogCount())).toBe(0)
 })
 
-test('Closing the last dialog hands the keyboard focus back to the canvas', async ({ page }) => {
+test('Closing a dialog whose field held the focus hands the keyboard back to the canvas', async ({
+    page,
+}) => {
     /*
         Ctrl+C and Ctrl+V used to go silently dead after either dialog had
         been open (#242 review). `TextInput._onRemoved` takes the focused
@@ -286,13 +322,63 @@ test('Closing the last dialog hands the keyboard focus back to the canvas', asyn
     await loadBlueprint(page, ONE_CHEST)
     await openExportDialog(page)
 
-    // Load-bearing: the dialog has to actually take the focus off the canvas
-    // first, or what follows would pass on a canvas that never lost it.
+    /*
+        Load-bearing, though not for the reason this used to give: the canvas
+        is not what the field takes the focus from. A fresh page has it on
+        <body> - `waitForEditor` only navigates and `loadBlueprint` runs
+        through `page.evaluate`, so nothing here has ever clicked. What this
+        waits for is the field taking the focus so that destroying it is what
+        *orphans* it, which is the condition `Dialog.close()` reads. Without
+        it the close below could be handing back a focus it never took, and
+        the assertion would say nothing about the guard.
+
+        ExportDialog's focus is also deferred a tick past the render that
+        shows the field (`ExportDialog.ts`), so this is a real barrier rather
+        than a restatement of the line above it.
+    */
     await expect(exportTextarea(page)).toBeFocused()
 
     await page.keyboard.press('Escape')
 
     expect(await page.evaluate(() => window.__fbe_test.openDialogCount())).toBe(0)
+    await expect(page.locator('canvas#editor')).toBeFocused()
+})
+
+test('Closing a dialog hands the focus back even while another dialog stays open', async ({
+    page,
+}) => {
+    /*
+        The case `Dialog.close()`'s comment argues hardest for, and which
+        nothing pinned until #281: the hand-back is deliberately *not* also
+        conditional on this being the last dialog. Measured, every other test
+        touching that guard - the two around this one and both in
+        tests/settings-pane-book-index.spec.ts - passes under
+        `!Dialog.anyOpen() && document.activeElement === document.body` as
+        well, so re-adding that half would go green everywhere it was looked
+        for. See this file's own mutation table above.
+
+        Only ExportDialog focuses its own field; ImportDialog never does. So
+        closing Export out from under an Import nobody has clicked leaves a
+        dialog on screen, `document.activeElement` on <body>, and nothing
+        focused - the same dead keyboard the guard exists to remove, with a
+        dialog still open. That is the one state where the shipped guard and
+        the `!anyOpen()` variant disagree.
+
+        Import is opened first so that Export's field is the one holding the
+        focus, and Export is closed through its own toggle, the same route
+        the test below uses.
+    */
+    await loadBlueprint(page, ONE_CHEST)
+    await openImportDialog(page)
+    await openExportDialog(page)
+
+    // Same barrier and the same reason as the test below - the field has to
+    // hold the focus before the close, or the close orphans nothing.
+    await expect(exportTextarea(page)).toBeFocused()
+
+    await openExportDialog(page)
+
+    expect(await page.evaluate(() => window.__fbe_test.openDialogCount())).toBe(1)
     await expect(page.locator('canvas#editor')).toBeFocused()
 })
 
@@ -316,6 +402,19 @@ test('Closing a dialog does not take the focus off a field that still has it', a
     await loadBlueprint(page, ONE_CHEST)
     await openImportDialog(page)
     await openExportDialog(page)
+
+    /*
+        Barrier, not decoration. ExportDialog's own focus is deferred -
+        `refreshText({ select: true })` schedules `select()` on
+        `G.app.ticker.addOnce` (`ExportDialog.ts`) - so nothing otherwise
+        orders it against the click below. Should the click ever win, the
+        focus lands on Export's field instead, the toggle then destroys a
+        *focused* field, the guard fires exactly as it should, and the last
+        assertion fails on a 60s timeout that reads as a broken guard rather
+        than as a raced test.
+    */
+    await expect(exportTextarea(page)).toBeFocused()
+
     await importTextarea(page).click()
     await expect(importTextarea(page)).toBeFocused()
 

--- a/tests/settings-pane-book-index.spec.ts
+++ b/tests/settings-pane-book-index.spec.ts
@@ -37,12 +37,19 @@ import { loadBlueprint, waitForEditor } from './helpers/fbe-test-api'
     there is nothing here for the suppression to protect against anyway.
 
     The book entries carry a different entity count each, and that is the
-    synchronisation. `setValue` writes the box synchronously and only then
-    starts an async load, so waiting on the box's own value proves nothing
-    about whether the load - and the `closeAll` inside it - has run yet.
-    Pressing the second arrow into that gap passes whatever the guard does.
-    `entityContainerCount()` moves only when a load finishes, and it names
-    *which* entry finished.
+    synchronisation. `entityContainerCount()` moves only when a load finishes,
+    and it names *which* entry finished, which waiting on the box's own value
+    cannot: `setValue` writes the box before `changeBookIndex` is even called.
+
+    There is no gap between the two today, and this header used to say there
+    was. `changeBookIndex` is declared async, but nothing on the path it takes
+    ever yields - `Book.selectBlueprint` is synchronous, and `Editor.loadBlueprint`
+    (Editor.ts) has no `await` in its body, `initBP()` included. So the whole
+    load, and the `Dialog.closeAll()` inside it, runs inside the keydown handler
+    itself, and the second arrow cannot land mid-load however it is timed. The
+    sync point stays: it costs nothing while the load is synchronous, it names
+    the entry rather than merely proving something finished, and it is what
+    keeps the second arrow honest if any step on that path ever starts yielding.
 */
 
 const VERSION = version(2, 0, 55)
@@ -54,14 +61,33 @@ const chests = (n: number): Record<string, unknown>[] =>
         position: { x: i + 0.5, y: 0.5 },
     }))
 
-/** Entry i holds i+1 chests, so entityContainerCount() names the loaded entry. */
+/*
+    Entry i holds i+1 chests, so entityContainerCount() names the loaded entry.
+
+    The hyphen in `blueprint-book` and the `icons` on each entry are both there
+    to keep the load clean rather than to be read by anything. The schema
+    (blueprintSchema.json) pins the hyphen and requires `icons` on a blueprint,
+    and a book missing either takes bpString.ts's `Blueprint had validation
+    warnings (loaded anyway)` path on every run, raising a 10-second warning
+    toast - a state this spec never meant to run in (#281). Both are needed:
+    measured, the underscore reports the `item` const and nothing else, the
+    hyphen on its own reports the missing `icons` and nothing else, and only
+    with both does the load report no warning at all.
+*/
+const ICONS = [{ index: 1, signal: { type: 'item', name: 'wooden-chest' } }]
+
 const BOOK = encodeBook({
-    item: 'blueprint_book',
+    item: 'blueprint-book',
     version: VERSION,
     active_index: 0,
     blueprints: [0, 1, 2].map(index => ({
         index,
-        blueprint: { item: 'blueprint', version: VERSION, entities: chests(index + 1) },
+        blueprint: {
+            item: 'blueprint',
+            version: VERSION,
+            icons: ICONS,
+            entities: chests(index + 1),
+        },
     })),
 })
 


### PR DESCRIPTION
Closes #281.

Four follow-ups from #242, grouped because they are one commit's tail. Only the
first adds coverage; the rest are a wrong fixture and wording that says more
than the code does.

## 1. The untested case, which is the point of this PR

`Dialog.close()`'s comment spends a paragraph on why the hand-back is
deliberately **not** also conditional on this being the last dialog. Nothing
pinned that. Measured, every existing test passes under
`!Dialog.anyOpen() && document.activeElement === document.body` as well, so
re-adding that half would go green everywhere a person would look for it.

New test: open Import, open Export, wait for Export's field to take focus, close
Export through its own toggle, then assert one dialog is still open **and** the
canvas is focused.

Mutation table, measured across `quick-actions.spec.ts` + `settings-pane-book-index.spec.ts`
(17 tests), changing only `Dialog.ts:126`:

| guard | result |
| --- | --- |
| shipped, `activeElement === document.body` | 17 passed |
| **A** `!Dialog.anyOpen() && activeElement === document.body` | 1 failed - **only the new test** |
| **B** unconditional `focus()` | 2 failed - the live-field test here, and settings-pane's treatment |
| **C** hand-back deleted | 2 failed - the two hand-back tests here; both settings-pane tests pass |

Read down the columns: each mutation is caught by a different test and A by
exactly one, which is the gap. The table is now in the spec's file header, which
is where someone looks before deleting a test that seems to always pass.

## 2. The fixture was wrong, and one character was not enough

`settings-pane-book-index.spec.ts` had `item: 'blueprint_book'` where the schema
pins `blueprint-book`. Fixing that left the spec **still** warning, because
`definitions/blueprint` also requires `icons` and the fixture had none:

| fixture | validation |
| --- | --- |
| `blueprint_book`, no icons | `/blueprint_book/item must be equal to constant` |
| `blueprint-book`, no icons | `.../blueprint must have required property 'icons'` |
| `blueprint-book` with icons | clean - the only toast is the success one |

Confirmed against the committed fixture with a throwaway probe reading both the
console and `.toasts-toast`, then removed. **This is repo-wide, not local to
this spec** - `quick-actions.spec.ts`'s own `ONE_CHEST` and
`book-serialize.spec.ts`'s book warn for the same missing-`icons` reason. Left
alone here as outside the issue, but worth its own pass.

## 3. A dropped barrier

The test at `quick-actions.spec.ts:299` opened ExportDialog and went straight to
clicking Import's field. Export's focus is deferred through
`G.app.ticker.addOnce`, so nothing forced the ordering. If the click ever won,
the toggle would destroy a focused field and the final assertion would fail
after the 60s expect timeout - reading as "the guard is broken". Barrier
restored.

## 4. Three comments that say something untrue

- The barrier comment claimed the assertion was there so the canvas would lose
  focus first. On a fresh page the focus is already on `<body>` - `waitForEditor`
  only navigates and `loadBlueprint` runs through `page.evaluate`, so nothing
  ever clicked. It is load-bearing for a different reason: the field has to hold
  the focus so that destroying it orphans it.
- A test title still said "Closing the **last** dialog" when the rule is no
  longer about last.
- The settings-pane header claimed `setValue` starts an async load with a gap
  the second arrow could race into. Checked: `Editor.loadBlueprint` has no
  `await` in its body and `initBP()` is synchronous, so the whole load and its
  `Dialog.closeAll()` run inside the keydown handler and no such gap exists.
- **`Dialog.close()`'s own comment** opened with "only when this close is what
  orphaned it", and the merged #242 subject says the same. The check cannot see
  that - it reads whether anything holds the focus right now, which has a third
  answer: nothing held it to begin with. Dragging the BP Book Index *slider*
  leaves `<body>` focused (dat.gui blurs on mousedown, its track is a `<div>`),
  and an `InventoryDialog` owns no `<input>` so closing one can never orphan
  anything. Both reach a true condition and both get a focused canvas, which is
  right for them. The guard is fine; the sentence was not.

That comment also quoted the clipboard listeners' condition verbatim. #279 gives
it a second half, so the copy would have gone stale with nobody opening this
file - it now says what the listeners require rather than how they spell it.
**Comment only; the executable line is untouched.**

## Not done

The issue's optional item - widening `=== document.body` to also accept `null`
and `documentElement` - is deliberately skipped. The e2e job is Chromium only,
where those arms are unreachable, so they would be untestable speculation. The
assumption and its failure direction (closed and silent, no worse than before
#242) are worth documenting if anyone adds a second browser.

## Test plan

- [x] `vp check .` - 0 warnings, lint or type errors across 187 files
- [x] `vp test` - 221 passed
- [x] `quick-actions.spec.ts` + `settings-pane-book-index.spec.ts` - 17 passed
- [x] Mutations A, B and C each measured, `Dialog.ts` restored and verified byte-identical afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7dF9eT5yMLqdJZ2rwytCz