### PR TITLE
Cost an unknown icon name the icon, not the whole dialog

### DIFF
--- a/packages/editor/src/UI/EntityInfoPanel.ts
+++ b/packages/editor/src/UI/EntityInfoPanel.ts
@@ -64,6 +64,33 @@ const roundToFour = (n: number): number => Math.round(n * 10000) / 10000
  * Extends Panel (from /controls/panel, which extends Container).
  * @see instantiation in /index.ts - event in /containers/entity.ts
  */
+/**
+ * A module's prototype, or undefined for a name the data does not have.
+ *
+ * `getModule` throws rather than answering undefined, which issue #55 made
+ * deliberate so that an absent item and a present non-module item could be told
+ * apart. The names reaching here come out of a blueprint, and this panel is
+ * redrawn from `EntityContainer.pointerOverEventHandler` - so an unknown module
+ * threw on **hover**, before any click, and took the hover with it (issue #286).
+ *
+ * Skipping the module is the right answer rather than a fallback effect: a
+ * module whose prototype cannot be read contributes nothing to the totals, which
+ * is the same arithmetic as the empty slot the loop above already skips.
+ *
+ * `console.warn` rather than `G.logger`, which is the toast: this runs on every
+ * hover, so a toast would raise one per pointer move across the entity. The
+ * editor's own module slots draw the same name through `F.SafeIcon` and do raise
+ * one, once, when the dialog opens.
+ */
+function readModule(name: string): ReturnType<typeof getModule> | undefined {
+    try {
+        return getModule(name)
+    } catch (e) {
+        console.warn(`Could not read the "${name}" module:`, e)
+        return undefined
+    }
+}
+
 export class EntityInfoPanel extends Panel {
     private title: Text
     private m_EntityName: Text
@@ -137,7 +164,8 @@ export class EntityInfoPanel extends Panel {
             for (const module of entity.modules) {
                 if (!module) continue
 
-                const moduleData = getModule(module)
+                const moduleData = readModule(module)
+                if (!moduleData) continue
                 if (moduleData.effect.productivity) {
                     productivity += moduleData.effect.productivity
                 }
@@ -158,7 +186,8 @@ export class EntityInfoPanel extends Panel {
                 for (const module of beacon.modules) {
                     if (!module) continue
 
-                    const moduleData = getModule(module)
+                    const moduleData = readModule(module)
+                    if (!moduleData) continue
                     if (moduleData.effect.productivity) {
                         productivity +=
                             moduleData.effect.productivity * beaconData.distribution_effectivity

--- a/packages/editor/src/UI/editors/components/DisplayPanelIcon.ts
+++ b/packages/editor/src/UI/editors/components/DisplayPanelIcon.ts
@@ -36,7 +36,8 @@ export class DisplayPanelIcon extends Slot<undefined> {
                 this.content = undefined
             }
         } else {
-            this.content = F.CreateIcon(icon.name)
+            const name = icon.name
+            this.content = F.SafeIcon(name, () => F.CreateIcon(name))
         }
         this.emit('changed')
     }

--- a/packages/editor/src/UI/editors/components/Filters.ts
+++ b/packages/editor/src/UI/editors/components/Filters.ts
@@ -218,11 +218,13 @@ export class Filters extends Container<Slot<number>> {
                     slot.content = undefined
                 }
             } else {
-                if (
-                    slot.content === undefined ||
-                    slot.iconName !== slotFilter.name ||
-                    this.m_Amount
-                ) {
+                /*
+                    Read into a local: TypeScript drops a narrowing of
+                    `slotFilter.name` inside the callbacks below, since it
+                    cannot prove the property does not change in between.
+                */
+                const name = slotFilter.name
+                if (slot.content === undefined || slot.iconName !== name || this.m_Amount) {
                     if (this.m_Amount) {
                         if (slot.content !== undefined) {
                             const text = slot.children[1] as Text
@@ -238,19 +240,23 @@ export class Filters extends Container<Slot<number>> {
                                 slot.content = undefined
                             }
                         }
-                        const container = new Container()
-                        F.CreateIconWithAmount(
-                            container,
-                            -16,
-                            -16,
-                            slotFilter.name,
-                            slotFilter.count
-                        )
-                        slot.content = container
+                        /*
+                            `CreateIconWithAmount` fills a container rather than
+                            answering one, so the container is built here and
+                            handed back from the callback. A throw part way
+                            through leaves a half-filled container behind, which
+                            is why `SafeIcon`'s empty one is used instead of the
+                            local.
+                        */
+                        slot.content = F.SafeIcon(name, () => {
+                            const container = new Container()
+                            F.CreateIconWithAmount(container, -16, -16, name, slotFilter.count)
+                            return container
+                        })
                     } else {
-                        slot.content = F.CreateIcon(slotFilter.name)
+                        slot.content = F.SafeIcon(name, () => F.CreateIcon(name))
                     }
-                    slot.iconName = slotFilter.name
+                    slot.iconName = name
                 }
             }
         }

--- a/packages/editor/src/UI/editors/components/Modules.ts
+++ b/packages/editor/src/UI/editors/components/Modules.ts
@@ -37,7 +37,7 @@ export class Modules extends Container<Slot<number>> {
             // from the test to the use.
             const module = this.m_Modules[slotIndex]
             if (module !== undefined) {
-                slot.content = F.CreateIcon(module)
+                slot.content = F.SafeIcon(module, () => F.CreateIcon(module))
             }
             this.addChild(slot)
         }
@@ -65,7 +65,7 @@ export class Modules extends Container<Slot<number>> {
                 slot.content = undefined
             }
         } else {
-            slot.content = F.CreateIcon(module)
+            slot.content = F.SafeIcon(module, () => F.CreateIcon(module))
         }
         this.emit('changed')
     }

--- a/packages/editor/src/UI/editors/components/Preview.ts
+++ b/packages/editor/src/UI/editors/components/Preview.ts
@@ -94,9 +94,27 @@ export class Preview extends Container {
             this.m_Size / 2 + offset.y * 32 * SCALE
         )
 
-        const o = OverlayContainer.createEntityInfo(this.m_Entity, { x: 0, y: 0 })
-        if (o !== undefined) {
-            entityParts.addChild(o)
+        /*
+            The same guard `OverlayContainer`'s own instance `createEntityInfo`
+            puts around this call, which this site did not have.
+
+            The overlay draws icons for names the blueprint chose - a recipe, a
+            module, a filter - and `F.CreateIcon` throws for a name FD does not
+            have. `Preview` is built by `Editor`'s base constructor, and
+            `UIContainer.createEditor` has no `try` above it on purpose, so a
+            throw here cost the user the whole dialog for *every* editor rather
+            than one preview: clicking the entity did nothing at all. The icon
+            slots below the preview draw the same names through `F.SafeIcon`, so
+            they are what tells the user which name is bad; this only has to stop
+            the dialog dying. Issue #286.
+        */
+        try {
+            const o = OverlayContainer.createEntityInfo(this.m_Entity, { x: 0, y: 0 })
+            if (o !== undefined) {
+                entityParts.addChild(o)
+            }
+        } catch (e) {
+            console.warn(`Failed to create the preview overlay for ${this.m_Entity.name}:`, e)
         }
 
         return entityParts

--- a/packages/editor/src/UI/editors/components/Recipe.ts
+++ b/packages/editor/src/UI/editors/components/Recipe.ts
@@ -35,7 +35,7 @@ export class Recipe extends Slot<undefined> {
                 this.content = undefined
             }
         } else {
-            this.content = F.CreateIcon(recipe)
+            this.content = F.SafeIcon(recipe, () => F.CreateIcon(recipe))
         }
         this.emit('changed')
     }

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -16,6 +16,7 @@ import { EntityContainer } from './containers/EntityContainer'
 import { Entity } from './core/Entity'
 import { EntitySprite } from './containers/EntitySprite'
 import { EntityInfoPanel } from './UI/EntityInfoPanel'
+import { Dialog } from './UI/controls/Dialog'
 import { getSpriteData, SPRITE_GENERATION_FAILED } from './core/spriteDataBuilder'
 
 export * from './core/bpString'
@@ -42,6 +43,13 @@ export {
     // For the entityFilters/setEntityFilters test hooks in packages/website,
     // which look an entity up by number and need to name what they got back.
     Entity,
+    // For the throwingDialogAttempt hook in packages/website, which
+    // tests/dialog-registry-leak.spec.ts uses to construct a dialog whose
+    // constructor throws. That spec used to reach a throwing constructor
+    // through a live bug - an editor drawing an icon the data did not have -
+    // and #286 guarded every one of those, so the only remaining way to make a
+    // constructor throw is to write one that does.
+    Dialog,
     EntitySprite,
     EntityInfoPanel,
     getSpriteData,

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -20,6 +20,7 @@ import EDITOR, {
     getSpriteData,
     SPRITE_GENERATION_FAILED,
     type QuickActions,
+    Dialog,
 } from '@fbe/editor'
 import { initToasts } from './toasts'
 import { initSettingsPane } from './settingsPane'
@@ -388,6 +389,28 @@ document.addEventListener('paste', (e: ClipboardEvent) => {
     up under load or on a cold start - as two to five random specs failing per
     full run, each passing in isolation.
 */
+
+/*
+    A dialog whose constructor throws after `super()` has run, and nothing else.
+
+    `tests/dialog-registry-leak.spec.ts` needs one to prove that `Dialog`
+    registers on the pixi `added` event rather than in its constructor - a
+    phantom entry in `Dialog.s_openDialogs` is invisible to `openDialogCount`,
+    which counts pixi children, so the only thing that can see one is the `E`
+    keybind branching on `Dialog.anyOpen()`.
+
+    It used to reach a throwing constructor through a live bug instead, an editor
+    drawing an icon the data did not have. #286 guarded every one of those, so
+    that fixture is gone - and a test that needs a bug to stay unfixed is a test
+    that argues against fixing it. This is the fixture written down instead.
+*/
+class ThrowingDialog extends Dialog {
+    public constructor() {
+        super(300, 200, 'never shown')
+        throw new Error('deliberate: a dialog constructor that throws after super()')
+    }
+}
+
 const testApi = {
     getBlueprintOrBookFromSource,
     loadBp,
@@ -567,6 +590,24 @@ const testApi = {
         refuses from one it accepts and then writes nothing for.
     */
     copyCursorBoxVisible: () => editor.copyCursorBoxVisible,
+    /*
+        Constructs a dialog whose constructor throws, and answers whether it did.
+        Never added to the display tree, so with registration on the `added`
+        event it leaves nothing behind; with the pre-#280 constructor push it
+        leaves a phantom that the next `E` press is swallowed by.
+
+        The return value is the control: it says the constructor really threw,
+        which a spec cannot otherwise tell from the throw being swallowed
+        somewhere. See tests/dialog-registry-leak.spec.ts.
+    */
+    throwingDialogAttempt: () => {
+        try {
+            new ThrowingDialog()
+            return false
+        } catch {
+            return true
+        }
+    },
     openDialogCount: () => editor.openDialogCount,
     topDialogBounds: () => editor.topDialogBounds,
     toolsPanelBounds: () => editor.toolsPanelBounds,

--- a/tests/dialog-registry-leak.spec.ts
+++ b/tests/dialog-registry-leak.spec.ts
@@ -16,6 +16,12 @@ import { suppressOverlays } from './helpers/overlays'
     throw cost the whole dialog: clicking the panel did nothing at all. The fix
     is `F.SafeIcon`, so the cost is the one icon and a warning naming it.
 
+    Both cases here set `connect_to_logistic_network: true`, which is what puts
+    the editor down its read-only conditions branch - where those two guarded
+    sites are. A third icon site sits past that branch's `return`, on the
+    ordinary unconnected panel, and is covered by
+    tests/editor-icon-guards.spec.ts along with the rest of the class (#286).
+
     The GENERAL half is `Dialog`'s registry. `Dialog`'s constructor used to push
     `this` onto the static `s_openDialogs`, and `super()` runs before any
     subclass body, so a subclass that threw afterwards left an entry for a
@@ -25,13 +31,24 @@ import { suppressOverlays } from './helpers/overlays'
     Registration moved to the `added` event, which a constructor that throws
     never reaches.
 
-    Why the general half needs its own case, and its own entity. Once the narrow
-    half is in, no display panel can reach the throw any more, so the registry
-    fix would have nothing to prove. The third test uses an assembling machine
-    carrying a recipe name FD does not have, which is the same class of input -
-    a name out of the blueprint, reaching an unguarded `F.CreateIcon`, this time
-    through `Editor`'s own `Recipe` slot. That editor is still broken and this
-    spec does not fix it; it is the fixture precisely because it is broken.
+    Why the general half needs its own case, and where its fixture comes from.
+    Once the narrow half is in, no display panel can reach the throw any more, so
+    the registry fix would have nothing to prove. This spec used to borrow a live
+    bug for that - an assembling machine carrying a recipe name FD does not have,
+    which threw in `Editor`'s `Recipe` slot - and said so: "that editor is still
+    broken and this spec does not fix it; it is the fixture precisely because it
+    is broken."
+
+    Issue #286 guarded that site and five others, so the borrowed fixture is
+    gone. It should not be replaced by another one. **A test that needs a bug to
+    stay unfixed is a test that argues against fixing it**, and the next person
+    to guard an icon would have hit this same wall. The fixture is written down
+    instead: `window.__fbe_test.throwingDialogAttempt()` constructs a
+    `ThrowingDialog` - a `Dialog` subclass whose constructor throws after
+    `super()` and does nothing else - and answers whether it threw. It is never
+    added to the display tree, which is the whole point: registration hangs off
+    the `added` event, so a dialog that is constructed and dropped registers
+    nothing.
 
     What can and cannot be observed. `window.__fbe_test.openDialogCount()` reads
     the pixi child count of `dialogsContainer`, so it cannot see a phantom
@@ -60,7 +77,8 @@ import { suppressOverlays } from './helpers/overlays'
 
     2. `this.once('added', () => Dialog.s_openDialogs.push(this))` ->
        `Dialog.s_openDialogs.push(this)` in `Dialog.ts` (the general half
-       reverted, `F.SafeIcon` kept):
+       reverted, `F.SafeIcon` kept). RE-MEASURED against the ThrowingDialog
+       fixture, since the entity this used to borrow is fixed:
          - test 3 FAILS: `expect(received).toBe(expected)` on the dialog count
            after `E`, 0 against 1. Both phantoms are still queued, so the first
            `E` closes one instead of opening the inventory.
@@ -68,25 +86,29 @@ import { suppressOverlays } from './helpers/overlays'
            leaks.
 
     3. Both reverted (the pre-fix code):
-         - all three FAIL, each with its own message above.
+         - all three FAILED when this spec was written. Not re-measured: the
+           narrow half's own fixture has since moved to
+           tests/editor-icon-guards.spec.ts, so 1 and 2 above are the two halves
+           that still meet here.
 
     So neither half covers for the other, and neither test can pass for the
     wrong reason.
 
-    4. The alternative the issue offers, measured rather than argued: the
-       registry push left in the constructor, and a bare try/catch wrapped
-       around `UIContainer.createEditor` instead (`F.SafeIcon` kept).
-         - test 3 FAILS, and it fails at the CONTROL rather than at the keybind:
-           `expect(received).toHaveLength(expected)`, 2 against 0, on the
-           page-error filter that opens test 3. Swallowing the throw is all
-           that catch does. The phantom entries are still queued and the `E`
-           press after them still goes to the wrong branch; the test never
-           gets that far, because the constructor's failure has stopped being
-           visible at all. That is the whole objection to it, written down in
-           `UIContainer.createEditor`'s own comment: it does not clear the
-           registry - `s_openDialogs` is `protected`, so clearing it from there
-           would need a new public escape hatch on `Dialog` - and it buys the
-           silence of every future broken editor for nothing.
+    4. The alternative the issue offers: the registry push left in the
+       constructor, and a bare try/catch wrapped around
+       `UIContainer.createEditor` instead. Measured against the OLD fixture,
+       when test 3 opened an editor through `createEditor` - it failed at that
+       test's page-error CONTROL, 2 against 0, because swallowing the throw is
+       all that catch does while the phantom entries stay queued.
+
+       That exact reading no longer applies and is kept for the reasoning
+       rather than the numbers: the ThrowingDialog fixture constructs a dialog
+       directly and never goes through `createEditor`, so a try/catch there
+       cannot affect this spec either way. The objection to it stands and is
+       written down in `UIContainer.createEditor`'s own comment: it does not
+       clear the registry - `s_openDialogs` is `protected`, so clearing it from
+       there would need a new public escape hatch on `Dialog` - and it buys the
+       silence of every future broken editor for nothing.
 
     Runs against the dev server like the rest of tests/ - see CLAUDE.md for the
     two servers that have to be up.
@@ -146,26 +168,6 @@ const PLANET_CONDITION = displayPanel([
         },
     },
 ])
-
-/*
-    An assembling machine naming a recipe FD does not have. Decodes and loads -
-    the schema's `recipeName` keyword only warns - and then `Editor`'s `Recipe`
-    slot calls `F.CreateIcon` on it with nothing catching, so the constructor
-    throws after `super()` has run. The fixture for the registry half.
-*/
-const UNKNOWN_RECIPE = encode({
-    item: 'blueprint',
-    version: version(2, 0, 55),
-    icons: [{ index: 1, signal: { type: 'item', name: 'assembling-machine-1' } }],
-    entities: [
-        {
-            entity_number: 1,
-            name: 'assembling-machine-1',
-            position: { x: 1.5, y: 1.5 },
-            recipe: 'totally-not-a-recipe',
-        },
-    ],
-})
 
 async function load(page: Page, source: string): Promise<string[]> {
     const errors: string[] = []
@@ -243,23 +245,24 @@ test('a condition signal naming a planet costs that icon, not the dialog', async
     expect(await dialogCount(page)).toBe(0)
 })
 
-test('an editor constructor that throws leaves the E keybind alone', async ({ page }) => {
-    const errors = await load(page, UNKNOWN_RECIPE)
+test('a dialog constructor that throws leaves the E keybind alone', async ({ page }) => {
+    await load(page, PLANET_ROW_ICON)
 
     /*
-        Twice. One phantom entry costs one `E` press, so a single failed open
-        would still let the second press through and a spec pressing twice would
-        pass against the leak. Two failed opens against one press cannot.
-    */
-    await clickEntity(page, 1)
-    await clickEntity(page, 1)
+        Twice. One phantom entry costs one `E` press, so a single failed
+        construction would still let a second press through and a spec pressing
+        twice would pass against the leak. Two against one press cannot.
 
-    /*
-        The control for this whole test: the constructor really did throw, twice.
-        Without it a change that quietly made the machine editor open would leave
-        the assertion below passing while measuring nothing about the registry.
+        The return value is the control for this whole test: it says the
+        constructor really did throw. Without it, a `ThrowingDialog` that quietly
+        stopped throwing would leave the assertions below passing while measuring
+        nothing about the registry at all.
     */
-    expect(errors.filter(e => e.includes('totally-not-a-recipe'))).toHaveLength(2)
+    const attempt = (): Promise<boolean> =>
+        page.evaluate(() => window.__fbe_test.throwingDialogAttempt())
+    expect(await attempt()).toBe(true)
+    expect(await attempt()).toBe(true)
+
     expect(await dialogCount(page)).toBe(0)
 
     // Nothing is open, so E opens the inventory. A leaked entry sends it to

--- a/tests/editor-icon-guards.spec.ts
+++ b/tests/editor-icon-guards.spec.ts
@@ -1,0 +1,220 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprint as encode, packVersion as version } from './helpers/encode-blueprint'
+import { suppressOverlays } from './helpers/overlays'
+
+/*
+    Every editor slot that draws an icon the blueprint named, and what it costs
+    when that name is one FD does not have (issue #286).
+
+    `F.CreateIcon` ends in a bare `throw` when the name is in none of
+    `FD.items`, `FD.fluids`, `FD.recipes`, `FD.signals` or `FD.inventoryLayout`.
+    Every name below comes out of a blueprint, and `UIContainer.createEditor` is
+    a bare call with no `try` above it - on purpose, see the comment there - so
+    an unguarded call costs the user the **whole dialog**: clicking the entity
+    does nothing at all. `F.SafeIcon` is the fix, and the cost becomes one icon
+    and a warning naming it.
+
+    This is the same narrow half `tests/dialog-registry-leak.spec.ts` covers for
+    two of `DisplayPanelEditor`'s three icon sites. It is a separate spec because
+    that one is about #280's registry, and because the sites here are spread
+    across four components that no single editor reaches.
+
+    Why the display panel is here at all, when #280 was supposed to have closed
+    it. `DisplayPanelEditor` has two branches and PR #285 guarded one of them.
+    `if (connected)` draws the read-only conditions list, which is where the two
+    guarded sites are; the `return` at the end of that branch means an
+    unconnected panel instead reaches `new DisplayPanelIcon(entity)` further
+    down, whose `F.CreateIcon` is bare. Both display panel specs on record set
+    `connect_to_logistic_network: true`, so both take the guarded branch and
+    neither can see this. An unconnected panel is the ordinary one.
+
+    Reading the warning. It reaches the user as a **toast**, not a console line -
+    `G.logger` is wired to the website's toasts at `index.ts` - so a probe
+    listening on `page.on('console')` sees nothing and reads a working guard as a
+    silent skip.
+
+    Two of the six guards are not icon slots at all, and neither was in the
+    issue. Running the first draft of this spec found them.
+
+    - `Preview.generatePreview` called the **static**
+      `OverlayContainer.createEntityInfo` with no `try` around it, where
+      `OverlayContainer`'s own instance method wraps the identical call
+      (`OverlayContainer.ts:493`). `Preview` is built by `Editor`'s base
+      constructor, so that one throw cost *every* editor its dialog, not one
+      entity type - it is why guarding `Recipe.ts` alone left the machine editor
+      still refusing to open.
+    - `EntityInfoPanel.updateVisualization` calls `getModule`, which throws by
+      design (`factorioData.ts:255`, issue #55, to tell an absent item from a
+      present non-module one). It runs from `pointerOverEventHandler`, so an
+      unknown module threw on **hover**, before any click - no dialog involved.
+
+    Both warn with `console.warn` rather than `G.logger`, which is the toast.
+    They sit on paths that repeat - every hover, every preview redraw - so a
+    toast each would be a stream of them. The icon slots raise the toast instead,
+    once, when the dialog opens, which is what the assertions below read.
+
+    MUTATION RECORD - each guard reverted in turn against this spec, measured
+    rather than reasoned. Baseline 5 passed.
+
+      Recipe.ts                 -> 1 fails: the recipe test
+      DisplayPanelIcon.ts       -> 1 fails: the display panel test
+      Modules.ts (both sites)   -> 1 fails: the module test
+      Filters.ts (both sites)   -> 2 fail:  the chest and splitter tests
+      Preview.ts try/catch      -> 3 fail:  recipe, module and chest
+      EntityInfoPanel.readModule-> 1 fails: the module test
+
+    So no guard is invisible, and the two Filters arms need both the chest test
+    (`CreateIconWithAmount`, amounts on) and the splitter test (`CreateIcon`,
+    amounts off) - one alone leaves the other arm unmeasured.
+
+    Runs against the dev server like the rest of tests/ - see CLAUDE.md for the
+    two servers that have to be up.
+*/
+
+type Page = import('@playwright/test').Page
+
+/** Not a recipe, module, item or signal in `data.json`. Distinct per case so a warning cannot be attributed to the wrong one. */
+const NO_SUCH_RECIPE = 'totally-not-a-recipe'
+const NO_SUCH_MODULE = 'totally-not-a-module'
+const NO_SUCH_FILTER_ITEM = 'totally-not-a-filter-item'
+const NO_SUCH_SPLITTER_ITEM = 'totally-not-a-splitter-item'
+
+/** `defines.inventory.crafter_modules`, read off data.json rather than guessed. */
+const MODULE_INVENTORY = 4
+
+function blueprint(entity: Record<string, unknown>): string {
+    return encode({
+        item: 'blueprint',
+        version: version(2, 0, 55),
+        icons: [{ index: 1, signal: { type: 'item', name: 'assembling-machine-1' } }],
+        entities: [{ entity_number: 1, position: { x: 1.5, y: 1.5 }, ...entity }],
+    })
+}
+
+/** `Editor`'s Recipe slot, via MachineEditor. The site issue #286 names. */
+const UNKNOWN_RECIPE = blueprint({
+    name: 'assembling-machine-2',
+    recipe: NO_SUCH_RECIPE,
+})
+
+/*
+    `DisplayPanelIcon`, via the branch #285 did not reach. No
+    `connect_to_logistic_network` and no wire, so `Entity.generateConnector` is
+    false and the editor falls past the conditions branch to the icon slot.
+    `Entity.displayPanelIcon` reads `m_rawEntity.icon` first, which is where the
+    GUI puts the icon a user picks.
+*/
+const UNKNOWN_PANEL_ICON = blueprint({
+    name: 'display-panel',
+    icon: { type: 'space-location', name: 'nauvis' },
+    text: 'home',
+})
+
+/** `Modules`, via MachineEditor. An assembling-machine-3 has four module slots. */
+const UNKNOWN_MODULE = blueprint({
+    name: 'assembling-machine-3',
+    items: [
+        {
+            id: { name: NO_SUCH_MODULE },
+            items: { in_inventory: [{ inventory: MODULE_INVENTORY, stack: 0 }] },
+        },
+    ],
+})
+
+/** `Filters` with amounts on, via ChestEditor - the `CreateIconWithAmount` arm. */
+const UNKNOWN_CHEST_FILTER = blueprint({
+    name: 'requester-chest',
+    request_filters: {
+        sections: [
+            {
+                index: 1,
+                filters: [{ index: 1, name: NO_SUCH_FILTER_ITEM, count: 5, comparator: '=' }],
+            },
+        ],
+    },
+})
+
+/** `Filters` with amounts off, via SplitterEditor - the `CreateIcon` arm beside it. */
+const UNKNOWN_SPLITTER_FILTER = blueprint({
+    name: 'fast-splitter',
+    filter: { name: NO_SUCH_SPLITTER_ITEM },
+})
+
+async function load(page: Page, source: string): Promise<string[]> {
+    const errors: string[] = []
+    page.on('pageerror', e => errors.push(String(e)))
+
+    await suppressOverlays(page)
+    await page.goto('/')
+    await page.waitForFunction(() => window.__fbe_test !== undefined, { timeout: 60_000 })
+    await page.evaluate(async (src: string) => {
+        const t = window.__fbe_test
+        await t.loadBp(await t.getBlueprintOrBookFromSource(src))
+    }, source)
+    return errors
+}
+
+/*
+    Hover then click, which is `openEntityGUI`. Steps away first because hovering
+    is driven by GridData's `update32` and only fires when the pointer crosses a
+    tile boundary - moving to a point it already occupies emits nothing. Same
+    reason as dialog-registry-leak.spec.ts and chest-editor.spec.ts.
+*/
+async function clickEntity(page: Page, entityNumber: number): Promise<void> {
+    const at = await page.evaluate(
+        (n: number) => window.__fbe_test.entityScreenPosition(n),
+        entityNumber
+    )
+    if (!at) throw new Error(`no entity ${entityNumber} in the loaded blueprint`)
+
+    await page.mouse.move(at.x, at.y + 240)
+    await page.mouse.move(at.x, at.y)
+    expect(await page.evaluate(() => window.__fbe_test.editorMode())).toBe('EDIT')
+
+    await page.mouse.down()
+    await page.mouse.up()
+}
+
+const dialogCount = (page: Page): Promise<number> =>
+    page.evaluate(() => window.__fbe_test.openDialogCount())
+
+/*
+    The shared shape of every case: the editor opens, nothing reaches the page
+    error handler, and the unknown name is named in a warning the user can see.
+
+    All three assertions carry weight. The dialog count is the bug; the empty
+    error list is what tells a guard from a swallowed throw somewhere higher; and
+    the toast is what stops a "fix" that simply drops the icon silently, which
+    would pass the first two and leave the user with no idea why the slot is
+    blank.
+*/
+async function expectIconCostsOnlyTheIcon(page: Page, source: string, name: string): Promise<void> {
+    const errors = await load(page, source)
+    expect(await dialogCount(page)).toBe(0)
+
+    await clickEntity(page, 1)
+
+    expect(errors, `page errors: ${errors.join(' | ')}`).toEqual([])
+    expect(await dialogCount(page)).toBe(1)
+    await expect(page.locator('.toasts-warning', { hasText: name })).toBeVisible()
+}
+
+test('a machine naming a recipe the data lacks still opens its editor', async ({ page }) => {
+    await expectIconCostsOnlyTheIcon(page, UNKNOWN_RECIPE, NO_SUCH_RECIPE)
+})
+
+test('an unconnected display panel with a planet icon still opens its editor', async ({ page }) => {
+    await expectIconCostsOnlyTheIcon(page, UNKNOWN_PANEL_ICON, 'nauvis')
+})
+
+test('a machine holding a module the data lacks still opens its editor', async ({ page }) => {
+    await expectIconCostsOnlyTheIcon(page, UNKNOWN_MODULE, NO_SUCH_MODULE)
+})
+
+test('a chest filtering on an item the data lacks still opens its editor', async ({ page }) => {
+    await expectIconCostsOnlyTheIcon(page, UNKNOWN_CHEST_FILTER, NO_SUCH_FILTER_ITEM)
+})
+
+test('a splitter filtering on an item the data lacks still opens its editor', async ({ page }) => {
+    await expectIconCostsOnlyTheIcon(page, UNKNOWN_SPLITTER_FILTER, NO_SUCH_SPLITTER_ITEM)
+})

--- a/tests/helpers/fbe-test-api.ts
+++ b/tests/helpers/fbe-test-api.ts
@@ -213,6 +213,16 @@ export interface FbeTestApi {
      * tests/inserter-throughput.spec.ts.
      */
     entityInfoText: (entityNumber: number) => string
+    /**
+     * Constructs a dialog whose constructor throws after `super()`, without
+     * adding it to the display tree, and answers whether it threw.
+     *
+     * The only way left to make a dialog constructor throw. It exists because
+     * `openDialogCount` counts pixi children and so cannot see a phantom entry
+     * in `Dialog.s_openDialogs` at all - only the `E` keybind, which branches on
+     * `Dialog.anyOpen()`, can. See tests/dialog-registry-leak.spec.ts.
+     */
+    throwingDialogAttempt: () => boolean
     /** How many dialogs are open. See tests/chest-editor.spec.ts. */
     openDialogCount: () => number
     /**


### PR DESCRIPTION
`F.CreateIcon` ends in a bare `throw` for a name FD does not have, and those
names come out of the blueprint. `UIContainer.createEditor` has no `try` above
it on purpose, so an unguarded call cost the user the **whole editor**: clicking
the entity did nothing at all.

#286 names one site. Measured, there are six.

## The four icon slots

`F.SafeIcon` at each, which #285 added for exactly this - it warns naming the
icon and returns an empty container.

| site | reached by | blueprint field |
| --- | --- | --- |
| `Recipe.ts:38` | `MachineEditor`, `TempEditor` | `recipe` |
| `DisplayPanelIcon.ts:39` | `DisplayPanelEditor` | `icon` |
| `Modules.ts:40`, `:68` | `Editor.addModules` | `items` |
| `Filters.ts:242`, `:251` | `ChestEditor`, `SplitterEditor`, `InserterEditor` | `request_filters`, `filter` |

**The display panel one is the half #285 did not reach.** That editor has two
branches: `if (connected)` draws the read-only conditions list and holds the two
sites #285 guarded, then `return`s. An **unconnected** panel - the ordinary one -
falls past it to `new DisplayPanelIcon(entity)`, which was still bare. Both
display panel specs on record set `connect_to_logistic_network: true`, so both
take the guarded branch and neither could see it.

## The two that are not icon slots

These are why guarding `Recipe.ts` alone does not make the machine editor open,
and neither is findable by grepping `CreateIcon`.

**`Preview.generatePreview`** called the *static*
`OverlayContainer.createEntityInfo` with nothing around it, while
`OverlayContainer`'s own instance method wraps the identical call at
`OverlayContainer.ts:493`. `Preview` is built by `Editor`'s base constructor, so
this one throw cost **every** editor its dialog, not one entity type.

**`EntityInfoPanel.updateVisualization`** calls `getModule`, which throws by
design (`factorioData.ts:255`, added in #55 to tell an absent item from a present
non-module one). It runs from `pointerOverEventHandler`, so an entity holding an
unknown module threw on **hover**, before any click, with no dialog involved.

Both warn with `console.warn` rather than `G.logger`, which is the toast: they
sit on paths that repeat - every hover, every preview redraw - so a toast each
would be a stream of them. The icon slots raise the toast instead, once, when the
dialog opens.

## Coverage

`tests/editor-icon-guards.spec.ts`, one case per site. Every assertion carries
weight: the dialog count is the bug, the empty page-error list tells a guard from
a throw swallowed higher up, and the toast stops a "fix" that drops the icon
silently.

Mutation checked, each guard reverted in turn against the spec:

| reverted | tests failing |
| --- | --- |
| `Recipe.ts` | 1 - the recipe test |
| `DisplayPanelIcon.ts` | 1 - the display panel test |
| `Modules.ts` (both) | 1 - the module test |
| `Filters.ts` (both) | 2 - the chest and splitter tests |
| `Preview.ts` try/catch | 3 - recipe, module and chest |
| `EntityInfoPanel.readModule` | 1 - the module test |

No guard is invisible, and the two `Filters` arms need both the chest case
(`CreateIconWithAmount`, amounts on) and the splitter case (`CreateIcon`, amounts
off) - either alone leaves the other arm unmeasured.

## The registry spec's fixture

`tests/dialog-registry-leak.spec.ts` borrowed the machine editor's throw as the
fixture for its registry half, and its header said so: "that editor is still
broken and this spec does not fix it; it is the fixture precisely because it is
broken."

This removes that fixture. Replacing it with another live bug would only move the
wall one file over - **a test that needs a bug to stay unfixed is a test that
argues against fixing it**. So the fixture is written down instead:
`throwingDialogAttempt()` constructs a `ThrowingDialog`, a `Dialog` subclass whose
constructor throws after `super()` and does nothing else, and answers whether it
threw. It is never added to the display tree, which is the point - registration
hangs off the `added` event.

Re-measured rather than assumed: reverting the registry fix still fails that test
at the keybind assertion, 0 against 1, while the other two pass. The mutation
record's stale entries are corrected in place, including one whose reading no
longer applies at all.

`Dialog` is now exported from the editor package for that hook, alongside the four
classes already exported only for specs.

## Verification

- `vp check` - 0 warnings, lint errors or type errors across 190 files
- `vp test` - 221 passed
- `npx playwright test` - **233 passed**, full suite

Closes #286.
Closes #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZkWutgXP9XeVoh2RaAX3S