### PR TITLE
Register a panel's resize listener when it is shown, not when it is built

### DIFF
--- a/packages/editor/src/UI/controls/Panel.ts
+++ b/packages/editor/src/UI/controls/Panel.ts
@@ -44,7 +44,39 @@ export abstract class Panel extends Container {
         this.addChild(this.m_Background)
 
         this._setPosition = () => this.setPosition()
-        window.addEventListener('resize', this._setPosition)
+
+        /*
+            Registered when the panel joins the display tree, not here.
+
+            This used to be a bare `window.addEventListener` in the constructor,
+            with `destroy()` below as the only thing that ever took it off again.
+            A constructor is the one place a panel cannot safely claim the
+            window from: `super()` runs before any subclass body, so a subclass
+            that throws afterwards leaves a listener for a panel that was never
+            shown and that nothing holds a reference to. It cannot be destroyed,
+            because nothing has it - so the listener stays on `window` for the
+            life of the page, keeps the half-built panel and its whole subtree
+            alive, and calls `setPosition()` on it at every resize (issue #287).
+
+            Exactly the shape of #280 one constructor lower down:
+            `Editor extends Dialog extends Panel`, so every entity editor is a
+            `Panel` and this is the first constructor to run. #280's own
+            measured path - `DisplayPanelEditor` drawing a planet icon - threw
+            well after this line, and #286 records the same for `Recipe.ts`.
+
+            `added`/`removed` rather than `once`, because a panel may leave the
+            tree and come back, and the pair has to stay balanced. Re-adding is
+            safe: the DOM ignores an identical (type, listener) pair, and
+            `_setPosition` is one closure per panel.
+
+            `destroy()` still removes it as well. `removed` covers a panel that
+            is destroyed while in the tree, which is all of them today, but a
+            panel destroyed after being detached would emit nothing - and
+            removing a listener that is not registered is a no-op, so keeping
+            both costs nothing and does not depend on that staying true.
+        */
+        this.on('added', () => window.addEventListener('resize', this._setPosition))
+        this.on('removed', () => window.removeEventListener('resize', this._setPosition))
 
         this.setPosition()
     }

--- a/tests/panel-resize-listener.spec.ts
+++ b/tests/panel-resize-listener.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect } from '@playwright/test'
+import { suppressOverlays } from './helpers/overlays'
+import { waitForEditor } from './helpers/fbe-test-api'
+
+/*
+    `Panel`'s window resize listener, and what happens to it when a subclass
+    constructor throws (issue #287).
+
+    `Panel`'s constructor put the listener on `window` and `destroy()` was the
+    only thing that took it off. A subclass constructor that throws after
+    `super()` returns never hands back the object, so nothing can ever call
+    `destroy()` on it: the listener stayed on `window` for the life of the page,
+    holding the half-built panel and its whole pixi subtree alive, and calling
+    `setPosition()` on that object at every resize.
+
+    Same class of bug as #280's registry leak, one constructor lower down -
+    `Editor extends Dialog extends Panel`, so `Panel`'s constructor is the first
+    to run and the last thing a throwing subclass can undo. The fix is the same
+    move: register when the panel joins the display tree rather than when it is
+    built, and deregister when it leaves.
+
+    Nothing else in tests/ can see any of this. A leaked listener costs no
+    assertion anywhere - the app looks and behaves identically, it simply retains
+    an object forever - so this spec counts listeners directly, by wrapping
+    `window.addEventListener`/`removeEventListener` before the page's own scripts
+    run. It tracks the listener *functions* rather than counting calls, because
+    the DOM dedupes an identical (type, listener) pair and a count of calls would
+    disagree with what is actually registered.
+
+    Where the throwing panel comes from. Every icon site that used to throw in an
+    editor constructor was guarded in #286, so there is no live bug left to
+    borrow - which is the point, and is why `__fbe_test.throwingDialogAttempt`
+    exists. `ThrowingDialog` extends `Dialog`, so it is a `Panel`, and its
+    constructor throws after `super()` has run: exactly the shape this leaks on.
+
+    THE THIRD TEST IS THE ONE TO READ FIRST. A "fix" that simply never registers
+    the listener passes both of the others perfectly - nothing leaks if nothing
+    is ever added - and quietly stops every panel following the window. That is
+    what test 3 is for, and `tests/tools-panel.spec.ts`'s narrow-viewport case
+    would catch it too.
+
+    Runs against the dev server like the rest of tests/ - see CLAUDE.md for the
+    two servers that have to be up.
+*/
+
+type Page = import('@playwright/test').Page
+
+declare global {
+    interface Window {
+        /** How many distinct `resize` listeners are registered right now. */
+        __resizeListeners: () => number
+    }
+}
+
+/*
+    Installed before any page script, so it sees the editor's own registrations
+    as they happen. `addInitScript` rather than an `evaluate` for the reason
+    `suppressOverlays` gives: it has to survive the navigation, and the panels
+    are built during startup.
+*/
+async function countResizeListeners(page: Page): Promise<void> {
+    await page.addInitScript(() => {
+        const live = new Set<unknown>()
+        const add = window.addEventListener.bind(window)
+        const remove = window.removeEventListener.bind(window)
+
+        window.addEventListener = ((type: string, listener: unknown, options: unknown) => {
+            if (type === 'resize') live.add(listener)
+            return add(type as 'resize', listener as EventListener, options as boolean)
+        }) as typeof window.addEventListener
+
+        window.removeEventListener = ((type: string, listener: unknown, options: unknown) => {
+            if (type === 'resize') live.delete(listener)
+            return remove(type as 'resize', listener as EventListener, options as boolean)
+        }) as typeof window.removeEventListener
+
+        window.__resizeListeners = () => live.size
+    })
+}
+
+const listenerCount = (page: Page): Promise<number> =>
+    page.evaluate(() => window.__resizeListeners())
+
+const dialogCount = (page: Page): Promise<number> =>
+    page.evaluate(() => window.__fbe_test.openDialogCount())
+
+async function load(page: Page): Promise<void> {
+    await countResizeListeners(page)
+    await suppressOverlays(page)
+    await waitForEditor(page)
+}
+
+test('a panel constructor that throws leaves no resize listener behind', async ({ page }) => {
+    await load(page)
+    const before = await listenerCount(page)
+
+    /*
+        Twice, and the return value is the control: it says the constructor
+        really threw. Without it a `ThrowingDialog` that quietly stopped throwing
+        would leave the assertion below passing while measuring nothing.
+    */
+    const attempt = (): Promise<boolean> =>
+        page.evaluate(() => window.__fbe_test.throwingDialogAttempt())
+    expect(await attempt()).toBe(true)
+    expect(await attempt()).toBe(true)
+
+    expect(await listenerCount(page)).toBe(before)
+})
+
+test('opening and closing a dialog leaves no resize listener behind', async ({ page }) => {
+    await load(page)
+    const before = await listenerCount(page)
+
+    await page.evaluate(() => window.__fbe_test.openImportDialog())
+    expect(await dialogCount(page)).toBe(1)
+
+    await page.keyboard.press('Escape')
+    expect(await dialogCount(page)).toBe(0)
+
+    expect(await listenerCount(page)).toBe(before)
+})
+
+test('an open dialog still follows a window resize', async ({ page }) => {
+    /*
+        The control for the other two. Deregistering is trivially correct if the
+        listener is never registered at all, and that mistake is invisible to
+        both of them - so this asserts the panel actually moves when the window
+        does, which is the whole reason the listener exists.
+
+        `Dialog.setPosition` centres on `G.app.screen`, so a narrower window puts
+        the dialog at a smaller x. Read through `topDialogBounds`, the same hook
+        chest-editor.spec.ts locates dialog controls with.
+    */
+    await load(page)
+
+    await page.setViewportSize({ width: 1280, height: 720 })
+    await page.evaluate(() => window.__fbe_test.openImportDialog())
+    expect(await dialogCount(page)).toBe(1)
+
+    const wide = await page.evaluate(() => window.__fbe_test.topDialogBounds())
+
+    await page.setViewportSize({ width: 800, height: 720 })
+    /*
+        The resize has to reach pixi's own renderer before the dialog is asked
+        where it is: `setViewportSize` resolves once the browser has resized, not
+        once the page has handled the event. Same race tools-panel.spec.ts
+        documents, and the same fix - wait for the value to settle rather than
+        for a fixed delay.
+    */
+    await expect
+        .poll(async () => (await page.evaluate(() => window.__fbe_test.topDialogBounds())).x)
+        .toBeLessThan(wide.x)
+})


### PR DESCRIPTION
**Stacked on #289** (`fix/286`), which it needs for the `throwingDialogAttempt`
hook. Review that one first; this targets it rather than the base branch.

## The bug

`Panel`'s constructor put a `resize` listener on `window`:

```ts
this._setPosition = () => this.setPosition()
window.addEventListener('resize', this._setPosition)
```

and `destroy()` was the only thing that ever took it off. A subclass constructor
that throws after `super()` returns never hands back the object, so nothing can
call `destroy()` on it. The listener stays on `window` for the life of the page,
holds the half-built panel and its whole pixi subtree alive, and calls
`setPosition()` on that object at every resize.

The same shape as #280, one constructor lower down. `Editor extends Dialog
extends Panel`, so every entity editor is a `Panel` and this is the first
constructor to run - #280's own measured path (`DisplayPanelEditor` drawing a
planet icon) and #286's (`Recipe.ts`) both throw well after that line.

It costs nothing visible, which is what makes it worth a test: `Dialog
.setPosition()` reads `G.app.screen` and the background sprite the constructor
did finish building, so the orphaned callback runs cleanly and silently forever.

## The fix

Registration moves onto the pixi `added` event and comes off on `removed` - the
move #285 made for the dialog registry.

`added`/`removed` rather than `once`, so a panel that leaves the tree and comes
back stays balanced. Re-adding is safe: the DOM ignores an identical
(type, listener) pair, and `_setPosition` is one closure per panel. `destroy()`
still removes it as well, for a panel destroyed while already detached.

## Coverage

`tests/panel-resize-listener.spec.ts`. Nothing else in `tests/` can see any of
this - a leaked listener changes no behaviour at all, it only retains an object -
so the spec counts listeners directly, wrapping
`addEventListener`/`removeEventListener` in an init script before the page's own
scripts run. It tracks the listener *functions* rather than counting calls,
because the DOM dedupes an identical pair and a call count would disagree with
what is actually registered.

Measured before the fix: two throwing constructors, **12 listeners against 10**.

**The third test is the one to read.** A "fix" that simply never registers the
listener passes the other two perfectly - nothing leaks if nothing is added - and
quietly stops every panel following the window. Mutation checked by deleting the
`added` line alone:

| | result |
| --- | --- |
| test 1, nothing leaks after a throw | passes |
| test 2, nothing leaks on open/close | passes |
| test 3, an open dialog follows a resize | **fails** |
| `tools-panel.spec.ts` narrow viewport (x2) | **fail** |

The throwing panel comes from `ThrowingDialog`, added in #289. There is no live
bug left to borrow for it, which is the point - #286 guarded all six sites that
used to throw in an editor constructor.

## Verification

- `vp check` - 0 warnings, lint errors or type errors across 191 files
- `vp test` - 221 passed
- `npx playwright test` - **236 passed**, full suite

Closes #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZkWutgXP9XeVoh2RaAX3S