### PR TITLE
Scope the factorioprints API passthrough to the host that serves the API

### DIFF
--- a/packages/editor/src/core/bpString.ts
+++ b/packages/editor/src/core/bpString.ts
@@ -299,18 +299,30 @@ function getBlueprintOrBookFromSource(source: string): Promise<Blueprint | Book>
                     )
                 case 'factorioprints':
                     /*
-                        The same fork as the factorio.school arm below, and for
-                        the same reason. `factorioprints.xyz` is the same API
-                        under a factorioprints domain, and a link to one
-                        blueprint *inside a book* is an
-                        `/api/blueprintData/<sha>/position/<i>` URL. The firebase
-                        record holds the whole book and nothing else, so
-                        rewriting to it would silently drop the position and open
-                        the book instead of the blueprint that was linked -
-                        `pathParts[1]` of an API path is `blueprintData`, not a
-                        blueprint key, so in practice the fetch fails outright.
+                        A pass-through like the factorio.school arm below, but a
+                        narrower one: that arm keys on the path alone, this arm
+                        has to check the host as well. `factorioprints.xyz` is
+                        the API, and a link to one blueprint *inside a book* is
+                        an `/api/blueprintData/<sha>/position/<i>` URL. The
+                        firebase record below holds the whole book and nothing
+                        else, so rewriting to it would drop the position and open
+                        the book instead of the blueprint that was linked.
+
+                        The host check is what keeps `factorioprints.com` out.
+                        This arm is reached by first label alone, so
+                        `factorioprints` under *any* TLD lands here, and `.com`
+                        is the site rather than the API: `factorioprints.com/api/
+                        ...` answers the SPA's index.html at status 200, which
+                        would reach `decode` as a page of HTML. Sending it down
+                        the firebase rewrite instead is not a fix - that request
+                        200s with a body of `null` and `data.blueprintString`
+                        throws - so both routes fail for a `.com` API link and
+                        this only decides which failure it is.
                     */
-                    if (pathParts[0] === 'api') {
+                    if (
+                        url.hostname.replace(/^www\./, '') === 'factorioprints.xyz' &&
+                        pathParts[0] === 'api'
+                    ) {
                         return fetchData(url.href).then(r => r.text())
                     }
 

--- a/packages/worker/src/proxyTarget.ts
+++ b/packages/worker/src/proxyTarget.ts
@@ -37,6 +37,7 @@ export const ALLOWED_HOSTS: ReadonlySet<string> = new Set([
     'www.factorio.school',
     'factorio.school',
     'factorioprints.xyz',
+    'www.factorioprints.xyz',
     'factoriobin.com',
     'docs.google.com',
 ])

--- a/tests/blueprint-sources.spec.ts
+++ b/tests/blueprint-sources.spec.ts
@@ -135,6 +135,46 @@ test('a factorioprints API url is passed through unchanged and read as text', as
     expect(r.entities).toBe(2)
 })
 
+/*
+    The other half of that fork, and the reason it checks the hostname. The arm
+    is reached by first label alone, so `factorioprints.com` lands here too - but
+    it is the site rather than the API, and answers its own index.html at 200 for
+    an /api/ path. Pinned because the passthrough looks host-agnostic at a glance
+    and nothing else would notice a URL that starts fetching HTML.
+*/
+test('a factorioprints.com API url still takes the firebase rewrite', async ({ page }) => {
+    const r = await fetchThrough(
+        page,
+        'https://factorioprints.com/api/blueprintData/xyz321/position/1.0',
+        printsBody
+    )
+    expect(r.target).toBe('https://facorio-blueprints.firebaseio.com/blueprints/blueprintData.json')
+    expect(r.entities).toBe(2)
+})
+
+/*
+    The path half of that condition, which nothing else holds up: with the host
+    check in place, `.com` is excluded on its own, so a `/view/` URL on the API
+    host is what fails if `pathParts[0] === 'api'` is ever dropped.
+*/
+test('a factorioprints.xyz /view/ url still reads the firebase record', async ({ page }) => {
+    const r = await fetchThrough(page, 'https://factorioprints.xyz/view/abc987', printsBody)
+    expect(r.target).toBe('https://facorio-blueprints.firebaseio.com/blueprints/abc987.json')
+    expect(r.entities).toBe(2)
+})
+
+/*
+    And the `www.` strip, which the allowlist entry alone does not exercise -
+    `www.factorioprints.xyz` serves the same API, and without the strip a link to
+    it would take the firebase rewrite.
+*/
+test('a www.factorioprints.xyz API url is passed through unchanged', async ({ page }) => {
+    const source = 'https://www.factorioprints.xyz/api/blueprintData/xyz321/position/1.0'
+    const r = await fetchThrough(page, source, BP)
+    expect(r.target).toBe(source)
+    expect(r.entities).toBe(2)
+})
+
 test('factorio.school reads the doubly nested blueprintString', async ({ page }) => {
     const r = await fetchThrough(page, 'https://www.factorio.school/view/xyz321', schoolBody)
     expect(r.target).toBe('https://www.factorio.school/api/blueprint/xyz321')

--- a/tests/corsproxy.test.ts
+++ b/tests/corsproxy.test.ts
@@ -71,7 +71,12 @@ describe('checkProxyTarget - the editor’s own sources', () => {
         catch-all would go unnoticed.
     */
     it('allowlists the hosts the pass-through arms fetch', () => {
-        const passThrough = ['factorio.school', 'www.factorio.school', 'factorioprints.xyz']
+        const passThrough = [
+            'factorio.school',
+            'www.factorio.school',
+            'factorioprints.xyz',
+            'www.factorioprints.xyz',
+        ]
 
         for (const host of passThrough) {
             expect(ALLOWED_HOSTS.has(host), `${host} is passed through but not allowlisted`).toBe(


### PR DESCRIPTION
Follow-up to #276, addressing the review it got there.

**What this actually buys.** Not a link that starts working — a `factorioprints.com/api/...` link fails either way, and the honest framing is that this decides *which* failure. Passed through, it fetches the site's own index.html and dies in pako as `incorrect header check`. Sent down the firebase rewrite, it fetches `blueprints/blueprintData.json`, which answers 200 with a body of `null`, and `data.blueprintString` throws. What the change buys is that `.com` keeps the behaviour it had before #276 rather than quietly acquiring a new one, and that the passthrough says out loud which host it is for.

**The finding.** The `factorioprints` arm is reached by first hostname label alone, so the `/api/` passthrough #276 added fires for `factorioprints.com` as well as `factorioprints.xyz`. Only `.xyz` is the API; `factorioprints.com` is the site, and answers its own `index.html` at status 200 for an `/api/` path. Against the deployed editor:

```
?source=https://factorioprints.xyz/api/blueprintData/9030bab…/position/1.0   197 entities, the nested leaf
?source=https://factorioprints.com/api/blueprintData/9030bab…/position/1.0   Error: incorrect header check
```

**The nit.** `www.factorioprints.xyz` joins the allowlist, and the host check strips a leading `www.` so both spellings pass through. Not hypothetical — that host serves the same API:

```
$ curl -s https://www.factorioprints.xyz/api/blueprintDetails/-Kn2afLokZdBO-uHcIAF | head -c 60
{"key":"-Kn2afLokZdBO-uHcIAF","version":{"number":59,…
```

## Tests

Four cases now cover the arm, one per clause of the condition:

| case | dies if you drop |
| --- | --- |
| `factorioprints.com/view/<key>` → firebase *(pre-existing)* | the whole arm |
| `factorioprints.com/api/...` → firebase | the host check |
| `factorioprints.xyz/view/<key>` → firebase | `pathParts[0] === 'api'` |
| `www.factorioprints.xyz/api/...` → passthrough | `.replace(/^www\./, '')` |

Each of the two new ones was checked red against the mutation it is there for. `tests/corsproxy.test.ts` also gains `www.factorioprints.xyz` in the pass-through host list.

`vp check`, `vp test` and the full `blueprint-sources` spec pass locally.
