### PR TITLE
Make the factorioprints comment agree with itself, and strip www. once

### DIFF
--- a/packages/editor/src/core/bpString.ts
+++ b/packages/editor/src/core/bpString.ts
@@ -265,6 +265,10 @@ function getBlueprintOrBookFromSource(source: string): Promise<Blueprint | Book>
         }).then((url: URL) => {
             console.log(`Loading data from: ${url}`)
             const pathParts = url.pathname.slice(1).split('/')
+            // One strip, read by both the switch discriminant and the
+            // factorioprints host check below - the two have to agree on what
+            // "the host" is, and a second copy is a bound written down twice.
+            const host = url.hostname.replace(/^www\./, '')
 
             const fetchData = (url: string): Promise<Response> =>
                 fetch(`/corsproxy?url=${encodeURIComponent(url)}`).then(response => {
@@ -284,7 +288,7 @@ function getBlueprintOrBookFromSource(source: string): Promise<Blueprint | Book>
                 blueprint string. That second one is a property of fetchData rather
                 than of Dropbox, and so applies to every source below.
             */
-            switch (url.hostname.replace(/^www\./, '').split('.')[0]) {
+            switch (host.split('.')[0]) {
                 case 'pastebin':
                     return fetchData(`https://pastebin.com/raw/${pathParts[0]}`).then(r => r.text())
                 case 'hastebin':
@@ -303,26 +307,26 @@ function getBlueprintOrBookFromSource(source: string): Promise<Blueprint | Book>
                         narrower one: that arm keys on the path alone, this arm
                         has to check the host as well. `factorioprints.xyz` is
                         the API, and a link to one blueprint *inside a book* is
-                        an `/api/blueprintData/<sha>/position/<i>` URL. The
-                        firebase record below holds the whole book and nothing
-                        else, so rewriting to it would drop the position and open
-                        the book instead of the blueprint that was linked.
+                        an `/api/blueprintData/<sha>/position/<i>` URL, which the
+                        pass-through hands to the proxy untouched. The firebase
+                        rewrite below cannot serve that link: `pathParts[1]` of
+                        an API path is the literal string `blueprintData`, not a
+                        blueprint key, so the rewrite fetches
+                        `blueprints/blueprintData.json`, which answers 200 with a
+                        body of `null`, and `data.blueprintString` throws.
 
                         The host check is what keeps `factorioprints.com` out.
                         This arm is reached by first label alone, so
                         `factorioprints` under *any* TLD lands here, and `.com`
                         is the site rather than the API: `factorioprints.com/api/
                         ...` answers the SPA's index.html at status 200, which
-                        would reach `decode` as a page of HTML. Sending it down
-                        the firebase rewrite instead is not a fix - that request
-                        200s with a body of `null` and `data.blueprintString`
-                        throws - so both routes fail for a `.com` API link and
-                        this only decides which failure it is.
+                        would reach `decode` as a page of HTML. Routing it to the
+                        firebase rewrite instead is not a fix - it hits the same
+                        missing-record throw as above - so both routes fail for a
+                        `.com` API link, and the host check only decides which
+                        failure it is.
                     */
-                    if (
-                        url.hostname.replace(/^www\./, '') === 'factorioprints.xyz' &&
-                        pathParts[0] === 'api'
-                    ) {
+                    if (host === 'factorioprints.xyz' && pathParts[0] === 'api') {
                         return fetchData(url.href).then(r => r.text())
                     }
 
@@ -332,6 +336,16 @@ function getBlueprintOrBookFromSource(source: string): Promise<Blueprint | Book>
                         .then(r => r.json())
                         .then(data => data.blueprintString)
                 case 'factorio': // factorio.school
+                    /*
+                        Keyed on the path alone, unlike the factorioprints arm
+                        above - not because that is safer, but because no other
+                        `factorio.<tld>` is known to reach this case. Any
+                        `factorio.<tld>` lands here, an `/api/` path is passed
+                        through and every other path is rewritten to
+                        `www.factorio.school/api/blueprint/<pathParts[1]>`. If a
+                        second `factorio.<tld>` ever serves blueprints, this arm
+                        needs the same host check #291 added above.
+                    */
                     if (pathParts[0] === 'api') {
                         return fetchData(url.href).then(r => r.text())
                     }


### PR DESCRIPTION
Closes #293.

## The contradiction

The `factorioprints` arm's comment in `bpString.ts` had two paragraphs that disagreed:

- Paragraph one: rewriting an `/api/blueprintData/<sha>/position/<i>` link to firebase "would drop the position and open the book instead of the blueprint that was linked."
- Paragraph two: the same rewrite "200s with a body of `null` and `data.blueprintString` throws."

The second is right. The rewrite uses `pathParts[1]`, which for an API path is the literal string `blueprintData`, not a blueprint key, so it fetches `blueprints/blueprintData.json` — a record that does not exist — and throws on the parse. It never reaches the book.

The pre-#291 comment had the accurate `pathParts[1]` explanation; #291's review asked for a wrong trailing clause to be fixed, and the rewrite dropped the accurate half with it. This restores it and drops the book consequence, so paragraph one now describes the same failure as paragraph two (same shape as #284).

## While in there: strip `www.` once

`bpString.ts` stripped a leading `www.` twice — once to pick the switch label, once to compare the host in the factorioprints arm — with nothing keeping the two copies in agreement (per #293, they were held up by different spec mutations). Hoisted into one `const host` above the switch, read in both places. Pure refactor, no behaviour change.

## Note added, not a task

Added a sentence on `case 'factorio'` explaining it keys on the path alone because no other `factorio.<tld>` is known to reach it — not because that is inherently safe. #291's comment contrasted the two arms without saying why the school arm is fine without a host check.

## Verification

Comment change plus a hoist of an identical expression into a `const`. The Vite+ toolchain isn't installed in my environment so I couldn't run `vp check` / the Playwright `blueprint-sources.spec.ts` locally; CI covers both. The two `www.`-strip mutations from #293 (`a www.factorioprints.xyz API url is passed through unchanged` and `factorio.school reads the doubly nested blueprintString`) both now exercise the single `host` binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)