### PR TITLE
Correct two blueprint-sources comments that #294 left behind

### DIFF
--- a/tests/blueprint-sources.spec.ts
+++ b/tests/blueprint-sources.spec.ts
@@ -124,9 +124,13 @@ test('factorioprints reads blueprintString off the firebase record', async ({ pa
 
 /*
     The same fork inside the factorioprints arm. factorioprints links a blueprint
-    inside a book by its position in the API URL, and the firebase record the
-    /view/ shape rewrites to holds only the whole book - so a rewrite here would
-    load the book and lose the position, with the request still looking right.
+    inside a book by its position in the API URL, and the firebase rewrite cannot
+    serve that link: `pathParts[1]` of an API path is the literal string
+    `blueprintData`, not a blueprint key, so the rewrite fetches
+    `blueprints/blueprintData.json`, which answers 200 with a body of `null`, and
+    `data.blueprintString` throws (issue #293). The next test pins that exact
+    target. So a rewrite here never reaches the book at all, though one that did
+    read the right key would still lose the position.
 */
 test('a factorioprints API url is passed through unchanged and read as text', async ({ page }) => {
     const source = 'https://factorioprints.xyz/api/blueprintData/xyz321/position/1.0'
@@ -164,9 +168,18 @@ test('a factorioprints.xyz /view/ url still reads the firebase record', async ({
 })
 
 /*
-    And the `www.` strip, which the allowlist entry alone does not exercise -
-    `www.factorioprints.xyz` serves the same API, and without the strip a link to
-    it would take the firebase rewrite.
+    And the `www.` host, which the allowlist entry alone does not exercise:
+    `www.factorioprints.xyz` serves the same API, so the pass-through has to
+    survive the prefix.
+
+    What this test does not hold up is the `www.` strip itself, and it did until
+    #294 gave the switch and the host check one shared `const host`. With a single
+    strip, deleting it keys the switch on `www`, which falls to `default` - and
+    `default` is the same `fetchData(url.href).then(r => r.text())` as this
+    pass-through, so the target is identical and this test stays green. Measured:
+    the one test that goes red on that mutation is `factorio.school reads the
+    doubly nested blueprintString`, where `www.factorio.school/view/...` would
+    fall to `default` instead of being rewritten to `/api/blueprint/<id>`.
 */
 test('a www.factorioprints.xyz API url is passed through unchanged', async ({ page }) => {
     const source = 'https://www.factorioprints.xyz/api/blueprintData/xyz321/position/1.0'


### PR DESCRIPTION
Comments only, in `tests/blueprint-sources.spec.ts`. No code change, no test change. Follow-up to #294, which fixed the same class of thing in `packages/editor/src/core/bpString.ts` and left these two behind.

## 1. The factorioprints API pass-through comment repeated the claim #293 refuted

It said the firebase record a `/view/` link rewrites to "holds only the whole book - so a rewrite here would load the book and lose the position".

The rewrite never gets that far. `pathParts[1]` of an API path is the literal string `blueprintData`, not a blueprint key:

```
pathParts: ["api","blueprintData","9030bab","position","1.0"]
rewrite:   https://facorio-blueprints.firebaseio.com/blueprints/blueprintData.json
```

That answers 200 with a body of `null`, so `fetchData`'s `ok` check passes and `data.blueprintString` throws. #293 measured it with `curl`, and the very next test in the file - `a factorioprints.com API url still takes the firebase rewrite` - already asserts that exact target. The comment now says the same thing `bpString.ts` says, and points at that test.

One clause of the old comment survives, because it is still true and still worth knowing: a rewrite that did read the right key would lose the position.

## 2. The `www.` comment described the code as it was before #294

It said "without the strip a link to it would take the firebase rewrite". That was true while the host check had its own second copy of the strip. #294 hoisted both copies into one `const host` above the switch, which changed what deleting the strip does.

Measured on the merged head (`65eec0b1`), by deleting the `.replace(/^www\./, '')` and running the spec:

| | result |
| --- | --- |
| `a www.factorioprints.xyz API url is passed through unchanged` | passes |
| `factorio.school reads the doubly nested blueprintString` | **fails** |
| the other 13 | pass |

With one strip, deleting it keys the switch on `www`, which falls to `default` - and `default` is the same `fetchData(url.href).then(r => r.text())` as the pass-through, so the target is byte-identical and this test cannot see it. What goes red is factorio.school, where `www.factorio.school/view/...` falls to `default` instead of being rewritten to `/api/blueprint/<id>`.

So the comment now says two things: this test pins the pass-through for the `www.` host, and the factorio.school test is what holds the strip itself up. The line was restored after the mutation; `packages/` is untouched by this PR.

## Verification

- `vp check` - 242 files formatted, no warnings, lint errors or type errors in 191 files.
- `npx playwright test tests/blueprint-sources.spec.ts` - 15 passed, before and after the edit.
- The mutation run above, which is the evidence for the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hQpEsZojx1pWE9kHn75MH