### PR TITLE
Keep the Playwright test API out of the production bundle

### DIFF
--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -452,8 +452,13 @@ const testApi = {
      * whatever they returned, which mirrors the guard only for an *empty*
      * blueprint; for a loaded one it silently performs the real action -
      * an actual clipboard write and an actual PNG download - every time it
-     * is called. Harmless now that the API is dev-only (issue #292), but a
-     * guard predicate should still read state rather than change it. See
+     * is called. The gate below removes one half of that reach: this no
+     * longer sits on `window` at fbe.factorygamefan.com for any script on the
+     * page to call (issue #292). It does not remove the other half. The specs
+     * run against `vp dev`, where the hook is present, so a mutating predicate
+     * would still do a real clipboard write and a real PNG download on every
+     * call inside a Playwright run. What makes this safe is that it reads
+     * state instead of changing it, not the gate. See
      * tests/quick-actions.spec.ts.
      */
     exportGuardResult: () => ({ exportString: !bp.isEmpty(), exportImage: !bp.isEmpty() }),

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -70,9 +70,18 @@ let book: Book | undefined
 
 /*
     Whether startup has run to the point where `bp` and the editor's `G.UI`
-    both exist - set at exactly the moment `__fbe_test` goes on `window`, and
-    for the same reason its own comment gives. Read by the clipboard listeners
-    below; see clipboardShortcutsBelongToCanvas for why they need it.
+    both exist - set in the same `.then` that would put `__fbe_test` on
+    `window`, and for the same reason its own comment gives. Read by the
+    clipboard listeners below; see clipboardShortcutsBelongToCanvas for why
+    they need it.
+
+    The two used to be one statement. Since #292 the hook is behind
+    `import.meta.env.DEV` and this flag is not, so in a production build this
+    is set and `__fbe_test` is absent. **Do not collapse them back.** Reading
+    `window.__fbe_test !== undefined` instead of this flag would leave the
+    clipboard listeners permanently disabled in production and nowhere else,
+    which is the #109 Ctrl+C crash again in the one environment no spec
+    covers - the whole suite runs against `vp dev`, where the hook is there.
 
     Measured before it existed: with the canvas focused during a cold data.json
     load, Ctrl+C threw an uncaught "Cannot read properties of undefined

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -282,10 +282,21 @@ editor
                 initial blueprint is on screen, not merely that this module has
                 run (issue #109). It comes after the catch on purpose: a source
                 that fails to import is a state specs still need to drive.
+
+                `import.meta.env.DEV` gates the assignment so the test API never
+                reaches the production bundle at fbe.factorygamefan.com (issue
+                #292). Vite replaces it with `false` in a `vp build`, which drops
+                this branch and lets Rolldown tree-shake `testApi` and everything
+                only it references. The e2e job serves the app with `vp dev`
+                (via `npm run localpreview`), where it is `true`, so every spec
+                still gets its hook. `startupFinished` stays outside the guard -
+                the clipboard listeners below read it in production too.
             */
             .then(() => {
                 startupFinished = true
-                ;(window as any).__fbe_test = testApi
+                if (import.meta.env.DEV) {
+                    ;(window as any).__fbe_test = testApi
+                }
             })
             .catch(error => createErrorMessage('Could not finish starting up.', error))
     })
@@ -384,7 +395,9 @@ document.addEventListener('paste', (e: ClipboardEvent) => {
 
 /*
     The Playwright test API. Built here, but not put on `window` until startup
-    has finished - see the `.then` above that assigns it, and issue #109.
+    has finished - see the `.then` above that assigns it, and issue #109 - and
+    then only under `import.meta.env.DEV`, so a production build strips the whole
+    thing (issue #292).
 
     Every spec waits for `window.__fbe_test` and treats its arrival as "the
     editor is ready". That was only true by luck: this used to be assigned
@@ -439,10 +452,9 @@ const testApi = {
      * whatever they returned, which mirrors the guard only for an *empty*
      * blueprint; for a loaded one it silently performs the real action -
      * an actual clipboard write and an actual PNG download - every time it
-     * is called. That is reachable from more than a future spec that loads
-     * a blueprint first: `__fbe_test` is assigned unconditionally above, so
-     * this sits on `window` at fbe.factorygamefan.com for any script on the
-     * page to call. See tests/quick-actions.spec.ts.
+     * is called. Harmless now that the API is dev-only (issue #292), but a
+     * guard predicate should still read state rather than change it. See
+     * tests/quick-actions.spec.ts.
      */
     exportGuardResult: () => ({ exportString: !bp.isEmpty(), exportImage: !bp.isEmpty() }),
     /**

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -1,7 +1,13 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "lib": ["ESNext", "DOM"]
+        "lib": ["ESNext", "DOM"],
+        // Vite serves and bundles this package as ESM, and `src/index.ts` reads
+        // `import.meta.env.DEV` to keep the Playwright test API out of the
+        // production build (issue #292). `import.meta` needs `module` at
+        // es2020+; the root config is on `ES6`. Same override the worker
+        // tsconfig already carries.
+        "module": "ESNext"
     },
     "include": ["src", "../editor/src/global.d.ts"]
 }

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -5,8 +5,15 @@
         // Vite serves and bundles this package as ESM, and `src/index.ts` reads
         // `import.meta.env.DEV` to keep the Playwright test API out of the
         // production build (issue #292). `import.meta` needs `module` at
-        // es2020+; the root config is on `ES6`. Same override the worker
-        // tsconfig already carries.
+        // es2020+; the root config is on `ES6`, so without this the build is
+        // fine but `vp check` fails the file with TS1343.
+        //
+        // Safe because the root sets `moduleResolution: bundler` explicitly.
+        // Raising `module` alone would otherwise fall back to `Classic`
+        // resolution and break every import in the package. Measured: the
+        // resolved config differs from the base by this one line and nothing
+        // else. `packages/worker/tsconfig.json` pairs the same two settings,
+        // though it spells both out because it does not extend the root.
         "module": "ESNext"
     },
     "include": ["src", "../editor/src/global.d.ts"]

--- a/tests/quick-actions.spec.ts
+++ b/tests/quick-actions.spec.ts
@@ -512,9 +512,12 @@ test('exportGuardResult reports the guard without writing to the clipboard or st
         whatever they returned - which mirrors the guard only for an empty
         blueprint; for a loaded one it silently performed the real action,
         a real clipboard write and a real PNG download, every time it was
-        called (#242 review, the other blocking issue). Reachable from more
-        than a spec: `__fbe_test` is assigned unconditionally, so this sits
-        on `window` in production for any script on the page to call.
+        called (#242 review, the other blocking issue). `__fbe_test` is
+        dev-only since #292, so that no longer sits on `window` at
+        fbe.factorygamefan.com for any script on the page to call - but it
+        would still reach every spec here, because this suite runs against
+        `vp dev`, where the hook exists. The gate is not what makes this
+        safe; reading state instead of changing it is.
 
         The clipboard write is caught by wrapping `navigator.clipboard.
         writeText` before the app's own scripts run - has to happen before


### PR DESCRIPTION
## What

`window.__fbe_test` - and the ~360-line test API object behind it - was assigned unconditionally at the end of startup in `packages/website/src/index.ts`. Every `vp build` shipped the whole thing to fbe.factorygamefan.com: the mutators (`loadBp`, `setEntityFilters`, `setWagonInventory`, `selectBookIndex`), the four fixture tally functions, `ThrowingDialog`, and the digest helpers.

## Fix

Gate the assignment on `import.meta.env.DEV`:

```ts
.then(() => {
    startupFinished = true
    if (import.meta.env.DEV) {
        ;(window as any).__fbe_test = testApi
    }
})
```

- **Production**: Vite statically replaces `import.meta.env.DEV` with `false`, the branch is dropped as dead code, and Rolldown then tree-shakes `testApi` and everything only it references (`ThrowingDialog`, `spriteDataDigest`, `DIGESTED_FIELDS`, `entityOf`).
- **e2e**: the `e2e` CI job serves the app with `vp dev` (via `npm run localpreview`), where `import.meta.env.DEV` is `true`, so `window.__fbe_test` still appears and still means "the editor is ready" - the invariant `tests/test-hook-readiness.spec.ts` guards (issue #109).
- `startupFinished` stays **outside** the guard - the `copy`/`paste` clipboard listeners read it in production too. Inside, a production build would pin it `false`, and Ctrl+C/Ctrl+V on the canvas would silently stop working with no spec able to catch it.

`import.meta` requires `module` at es2020+, and the root tsconfig is on `ES6`, so `packages/website/tsconfig.json` gets `"module": "ESNext"`. That is safe because the root sets `moduleResolution: bundler` explicitly - raising `module` alone would otherwise fall back to `Classic` resolution and break every import in the package. Measured with `tsc --showConfig`: the resolved config differs from the base by that one line and nothing else.

## What only tree-shakes locally

Only the bindings declared inside `index.ts` disappear - `testApi`, `entityOf`, `ThrowingDialog`, `spriteDataDigest`, `DIGESTED_FIELDS`. The eight imports from `@fbe/editor` (`OverlayContainer`, `EntityContainer`, `EntitySprite`, `EntityInfoPanel`, `getSpriteData`, `SPRITE_GENERATION_FAILED`, `Dialog`, `FD`) stay in the bundle, because the editor's own production code still references those modules. Nothing gets smaller for them.

## On the tally members

The issue asks whether removing the four tally functions saves bundle size or is just cleanliness. It's moot: the guard already strips them along with the rest of `testApi`. No separate removal needed.

## Verification

Re-measured on the current base (the first numbers here predated #268, which moved the baseline):

- `vp check .` - clean
- `vp test` - 212 passed in 18 files. This PR adds and removes no tests; the earlier "225" was from before #268/#319 reshuffled test collection.
- `npx playwright test --list` - 243 tests in 52 files
- Production build, A/B on the same base: main chunk **842.48 kB -> 838.81 kB**, a **-3,670 byte** delta (gzip **235.32 -> 233.91 kB**, -1.41 kB). Every other emitted chunk is byte-identical except the two that embed the main chunk's content hash.

### Bundle greps

`__fbe_test`, `spriteDataTally`, `recipeShapeTally`, `overlayInfoTally`, `paintPreviewTally`, `throwingDialogAttempt`, `setWagonInventory`, `exportGuardResult`, `selectBookIndex`, `setEntityFilters` all go **1 hit -> 0** across `dist/assets/*.js`.

`DIGESTED_FIELDS`, `spriteDataDigest` and `ThrowingDialog` are **not** usable as evidence and an earlier version of this body cited them in error. They are module-local bindings, so oxc renames them in every production build - they are 0 in the baseline too, which is the minifier rather than tree-shaking. String literals discriminate instead, since no minifier renames them:

| probe | this PR | baseline |
| --- | --- | --- |
| `deliberate: a dialog constructor that throws after super()` | 0 | 1 |
| `never shown` (a `DIGESTED_FIELDS` entry) | 0 | 1 |

Confirmed the same way against `--minify false` builds of both sides, where the identifiers survive: the dropped code is present in the baseline and absent here.

Closes #292
