### PR TITLE
Cut CI cost on dependency PRs, and correct the Playwright claim

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -113,22 +113,31 @@
     // prerequisites for ever carving an exception are specific to this repo. No
     // exceptions below, including GitHub Action digest re-pins.
     //
-    // The local reason is specific and stronger than the usual one: CI runs
-    // `vp check` (oxfmt + oxlint + tsc), `vp test` (vitest units + the type-check
-    // gate), and compiles packages/exporter on ubuntu and Windows. It does NOT run
-    // Playwright - and tests/ is where essentially all of this project's
-    // behavioural coverage lives, 25-odd specs covering placement, paste, sprites
-    // and the blueprint round trip. So a green check here proves the repo is
-    // CONSISTENT under lint and types and that the Rust side still builds; it says
-    // nothing about whether a bump is CORRECT.
+    // What CI actually covers: `vp check` (oxfmt + oxlint + tsc), `vp test`
+    // (vitest units + the type-check gate), the Playwright suite in the `e2e` job
+    // sharded across four runners, and a compile of packages/exporter on ubuntu
+    // and Windows. That is real coverage, and it is MORE than this paragraph
+    // claimed until 2026-09-01 - see the corrections below.
     //
-    // This paragraph used to end "it also never compiles packages/exporter", which
-    // the `Rust exporter` and `Rust exporter (Windows)` jobs at ci.yml:89 and :163
-    // contradict - and which the cargo rule below already contradicted in the same
-    // file, noting that an earlier draft said the opposite and was corrected. The
-    // conclusion is unchanged either way: the exporter is COMPILED and never RUN,
-    // which is the boundary the cargo note draws, and the Playwright gap carries
-    // this argument on its own.
+    // What a green check still does not prove is that a bump is CORRECT. The
+    // exporter is COMPILED and never RUN, so a crate that changes runtime
+    // behaviour without breaking the build passes. And a suite can be green while
+    // an invariant it never asserts has moved - the sibling repo has that
+    // counterexample on record, just below.
+    //
+    // TWO CORRECTIONS LIVE HERE, both of claims this file stated as measured fact
+    // and got wrong. First: it used to end "it also never compiles
+    // packages/exporter", which the `Rust exporter` and `Rust exporter (Windows)`
+    // jobs contradict. Second, found 2026-09-01: it said in three places that CI
+    // does NOT run Playwright, and that was the load-bearing half of this
+    // argument. The `e2e` job runs 229 `test(` calls across 52 spec files under
+    // tests/, counted with `grep -c -E "^\s*test\(" tests/*.spec.ts`, and
+    // `deploy` is gated on it. Read ci.yml before repeating anything here.
+    //
+    // The conclusion is unchanged, because it never rested on the Playwright gap
+    // alone. It rests on the two prerequisites below, and this repo still meets
+    // neither - re-measured 2026-09-01: `allow_auto_merge` is false, and the only
+    // ruleset is "No ForcePush" with enforcement `disabled`.
     //
     // The sibling repo has the counterexample on record: pako 3.0.0 flipped a hash
     // default that passes a green suite while silently breaking a byte-exactness
@@ -273,7 +282,7 @@
             prBodyNotes: [
                 'This is the ENTIRE toolchain (Vite, Rolldown, oxlint, oxfmt, Vitest). Nothing under it is independently upgradable.',
                 'Check `.github/actions/setup-vp/action.yml` moved too - `VP_VERSION` and the cache key are updated by a customManager, but **the installer sha256 is not**. Re-fetch https://vite.plus and re-hash if that script changed; a mismatch fails CI rather than passing silently.',
-                'CI does not run Playwright. Run `npm run localpreview` then `npx playwright test` locally before merging.',
+                'CI runs the Playwright suite in the `e2e` job, so this bump is gated on it - this note said the opposite until 2026-09-01 and was wrong. What CI still cannot see is a mismatch between the `vp` CLI and the local vite-plus, so read the diff and confirm every pin site moved together.',
             ],
         },
         {
@@ -283,8 +292,8 @@
             // suite-wide regression rather than a missing download.
             matchPackageNames: ['@playwright/test'],
             prBodyNotes: [
-                '**Run `npx playwright install` in this same PR before merging**, or every spec fails on a missing `chrome-headless-shell` and reads as a suite-wide regression rather than a missing download.',
-                'CI does not run Playwright, so this bump gets **no** automated verification. Bring both dev servers up with `npm run localpreview` and run `npx playwright test` locally.',
+                'Run `npx playwright install` in your own working tree after taking this, or every local spec fails on a missing `chrome-headless-shell` and reads as a suite-wide regression rather than a missing download. CI does not need the same step: the `e2e` job keys its browser cache on the resolved @playwright/test version, so a bump misses the cache and reinstalls by itself.',
+                'CI does run the suite (the `e2e` job, four shards), so a browser-revision problem surfaces there rather than only on your machine. This note claimed the bump got **no** automated verification at all; that was wrong.',
             ],
         },
         {
@@ -331,6 +340,23 @@
             // ungated. Same correction as CLAUDE.md's "Known and unfixed" entry, which
             // was fixed first; keep the two in step.
             matchManagers: ['cargo'],
+            // Grouped into ONE PR. 14 of the 20 Renovate PRs before 2026-09-01 were
+            // single Rust crate bumps, and each one used to trigger all seven CI
+            // jobs - about 23 minutes of runner time, 17 of it Playwright shards
+            // that cannot observe a Rust change. The `changes` job added to ci.yml
+            // on the same day stops the wasted jobs; this stops the wasted PRs.
+            //
+            // Safe to group here in a way it would not be for the npm side: these
+            // bumps share one gate, `cargo check --locked` on ubuntu and Windows,
+            // so either the batch compiles or it does not. And backing one out is a
+            // `git revert` of a single commit rather than a hunt across five PRs.
+            //
+            // The cost is real and worth naming: a lockfile-only group PR has no
+            // Cargo.toml diff to read, so the per-crate judgement below applies to
+            // the whole batch at once. If a batch ever mixes a routine bump with an
+            // image, zip, tar or compression crate, split it rather than waving the
+            // note through.
+            groupName: 'rust crates',
             prBodyNotes: [
                 'CI compiles this crate (the `Rust exporter` job) but **cannot run it** - the exporter needs a Factorio install to extract from, and sprite encoding shells out to `./basisu`, for which only a macOS ARM64 binary is tracked. So a green check means it still builds and the lockfile is coherent; a crate that changes runtime behaviour without breaking the build will pass. For anything touching **image** handling, run the exporter locally on macOS before merging. For **zip, tar or compression**, a macOS run is not an option and should not be attempted: `download()` panics on macOS (`src/setup.rs:568`), and both extraction branches sit below that panic - `zip` under `cfg(target_os = "windows")` and `tokio-tar` over an `async-compression` `LzmaDecoder` under `cfg(target_os = "linux")`. The ubuntu and Windows compiles are the only evidence available short of running the exporter on one of those platforms.',
             ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,95 @@ permissions:
   contents: read
 
 jobs:
+  # Which jobs a run actually needs, worked out once and reused. Before this,
+  # every pull request ran all seven jobs: a Cargo.lock-only crate bump spent
+  # about 23 minutes of runner time, 17 of it on four Playwright shards that
+  # cannot observe a Rust change. Renovate makes that the common case rather
+  # than a corner case - 14 of the 20 bot PRs before 2026-09-01 were single
+  # Rust crate bumps.
+  #
+  # A job with `if:` rather than `on.pull_request.paths`, and the difference is
+  # the point. A workflow-level path filter skips the whole run, so the PR shows
+  # no CI at all - indistinguishable from CI being broken, and it would block
+  # any check that is ever marked required, because a skipped WORKFLOW never
+  # reports while a skipped JOB does.
+  #
+  # It fails open on purpose. Any error listing the files leaves both outputs
+  # true and the run does everything. A wasted run costs minutes; a gate that
+  # skips itself quietly costs a bad merge.
+  #
+  # Cost: `checks` and `e2e` now wait on this, so the deploy critical path the
+  # `deploy` job discusses grows by however long this takes - about 5 seconds,
+  # since it checks nothing out and makes one API call.
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      web: ${{ steps.detect.outputs.web }}
+      rust: ${{ steps.detect.outputs.rust }}
+    steps:
+      - name: List changed files and classify them
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.number }}
+        # No `set -e`: every failure path below is meant to fall through to
+        # "run everything" rather than abort the job.
+        run: |
+          set -uo pipefail
+
+          # Anything that is not a pull request - a push to the deploy branch, a
+          # manual dispatch - runs the lot. `deploy` is gated on `checks` and
+          # `e2e`, so narrowing either one here would change when the site ships.
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "Not a pull request. Running every job."
+            echo "web=true"  >> "$GITHUB_OUTPUT"
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          files=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+          if [ -z "$files" ]; then
+            echo "Could not list the changed files. Running every job."
+            echo "web=true"  >> "$GITHUB_OUTPUT"
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Changed files:"
+          echo "$files"
+
+          # `rust` covers the exporter crate, plus this workflow itself, so a
+          # change to these rules is always tested against both sides.
+          if echo "$files" | grep --quiet --extended-regexp '^packages/exporter/|^\.github/workflows/ci\.yml$'; then
+            rust=true
+          else
+            rust=false
+          fi
+
+          # `web` is deliberately the loose one: anything at all outside the
+          # exporter turns it on. That runs `checks` and Playwright for a
+          # README-only change, which wastes a few minutes and cannot miss a
+          # real one.
+          if echo "$files" | grep --quiet --invert-match '^packages/exporter/'; then
+            web=true
+          else
+            web=false
+          fi
+
+          echo "web=$web"   >> "$GITHUB_OUTPUT"
+          echo "rust=$rust" >> "$GITHUB_OUTPUT"
+          echo "Decided: web=$web rust=$rust"
+
   checks:
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -87,6 +175,8 @@ jobs:
   # from the exporter.
   rust:
     name: Rust exporter
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -161,6 +251,8 @@ jobs:
   # the 2x Windows billing multiplier costs nothing here.
   rust-windows:
     name: Rust exporter (Windows)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
@@ -201,6 +293,8 @@ jobs:
   # `deploy` waits on this as well as on `checks` - see the note there.
   e2e:
     name: Playwright ${{ matrix.shard }}/${{ strategy.job-total }}
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     # Sharded across runners rather than run in one job, and the per-step
     # timings are why that is the lever worth pulling. The first push run spent


### PR DESCRIPTION
Three changes. The first two cut wasted CI. The third fixes a wrong claim I found while doing it.

## 1. Skip jobs that cannot see the change (ci.yml)

Every PR ran all seven jobs. A Cargo.lock-only crate bump spent about 23 minutes of runner time, 17 of it on four Playwright shards that cannot observe a Rust change. 14 of the 20 Renovate PRs before 2026-09-01 were single Rust crate bumps, so this was the common case rather than a corner case.

A new `changes` job lists the files a PR touches and sets two outputs. `checks` and `e2e` wait on `web`. `rust` and `rust-windows` wait on `rust`.

Job-level `if:` rather than workflow-level `on.pull_request.paths`, because a path filter skips the whole run and the PR then shows no CI at all. A skipped workflow never reports. A skipped job does.

It fails open: any error listing the files leaves both outputs true and the run does everything. Anything that is not a pull request runs every job, so deploy behaviour is untouched.

Checked with actionlint 1.7.7, which also runs shellcheck over the embedded script.

## 2. Group Rust crate bumps (renovate.json5)

Cargo updates now arrive as one PR. Grouping is safe here in a way it would not be for the npm side, because these bumps share one gate: `cargo check --locked` on ubuntu and Windows. Either the batch compiles or it does not, and backing one out is a revert of a single commit.

## 3. Correct the Playwright claim (renovate.json5)

This file said in three places that CI does not run Playwright, and used that as the load-bearing half of its argument for `automerge: false`. The `e2e` job runs 229 `test(` calls across 52 spec files under tests/, counted with `grep -c -E "^\s*test\(" tests/*.spec.ts`, and `deploy` is gated on it.

Two prBodyNotes built on the wrong claim are rewritten. One of them told a reviewer to run `npx playwright install` in the PR; CI keys its browser cache on the resolved `@playwright/test` version, so a bump reinstalls by itself.

The `automerge: false` conclusion is unchanged. It never rested on the Playwright gap alone, and the prerequisites it does rest on are still unmet. Re-measured 2026-09-01: `allow_auto_merge` is false, and the only ruleset is "No ForcePush" with enforcement `disabled`.

This is the second claim in that paragraph to be stated as measured fact and turn out wrong, so the correction is written into the file rather than quietly applied.

## Note

This does not fix Renovate being stuck. That is the schedule, fixed separately in FactoryGameFan/.github#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
