### PR TITLE
Log every Worker invocation now that there are far fewer of them

### DIFF
--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -38,20 +38,25 @@
         new Workers, and this config never declared it, so deploys turned it
         off. The cost of that was measured rather than assumed: a query for
         this Worker's logs returned 0 events over 7 days while GraphQL
-        analytics reported 330,522 requests in one day. Zero logs against real
-        traffic is indistinguishable from zero traffic, which is exactly the
-        wrong thing to discover during a spike.
+        analytics reported 330,522 requests on 2026-09-01. Zero logs against
+        real traffic is indistinguishable from zero traffic, which is exactly
+        the wrong thing to discover during a spike.
 
-        Sampled at 10% deliberately. Log events bill at $0.60 per million past
-        20 million included per month, so an unsampled Worker is one traffic
-        spike away from a log bill larger than its compute bill. 10% of the
-        post-scoping invocation count is still thousands of samples a day,
-        which is plenty for the error rate and the path mix. Raise it once the
-        steady-state volume is known.
+        Unsampled, because at this Worker's invocation rate the quota is not
+        the binding constraint. Scoping `run_worker_first` above took
+        invocations from 93.8/min to 9.9/min, measured per minute across the
+        deploy on 2026-09-02: 199 in the minute before it landed, 21 in the
+        minute after. That is roughly 14,000 log events a day, or 430,000 a
+        month against 20 million included.
+
+        The number to watch is invocations, not this rate. Log events bill at
+        $0.60 per million past the included 20 million, so this stays free
+        while invocations track the page-view count. If they climb back toward
+        the pre-scoping figure, drop this to 0.1 rather than pay for volume.
     */
     "observability": {
         "enabled": true,
-        "head_sampling_rate": 0.1,
+        "head_sampling_rate": 1,
     },
     /*
         A guard against a runaway loop, not a cost control - worth saying


### PR DESCRIPTION
Follow-up to #303.

Scoping `run_worker_first` took invocations from **93.8/min to 9.9/min**, measured per minute across the deploy on 2026-09-02:

| window | invocations/min |
| --- | --- |
| 03:00-03:45 (pre-deploy, 46 min) | 93.8 |
| 03:40-03:45 (last 6 min before) | 160.0 |
| 03:46-03:58 (post-deploy, 13 min) | 9.9 |

199 requests in the minute the deploy landed, 21 in the next. Overnight traffic does not fall 89% in sixty seconds, so that step is the change taking effect rather than the nightly decline.

## Why raise sampling

10% was sized against 330,522 requests/day, when a further spike was plausible and an unsampled Worker could have run up a log bill larger than its compute bill. At 9.9 invocations/min the Worker writes roughly **14,000 log events/day, or 430,000/month against 20 million included**, so full sampling is free.

It is also a better signal than it was. The asset noise is gone, so what remains is page views and `/corsproxy` - the invocations actually worth reading. At 10% that was about 1,400 samples/day.

The comment now points at the thing that actually governs cost: watch invocations, not the sampling rate, and drop back to 0.1 if they climb toward the pre-scoping figure.

## Verification

`vp check` passes (244 files formatted, 193 clean). `wrangler deploy --dry-run` parses the config. The deployed setting will be confirmed against the API after merge, the same way #303 was.

Scheduled a check for 2026-09-07 in #312, since the argument here rests on invocations staying near the page-view count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iKcwmj7ZZ1sZJyDtb7VK8
