### PR TITLE
Correct stale sprite claims and restore the reasoning #277 thinned

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ closing references such as `Closes #123` in the pull request body.
 - `tests` — Playwright browser and blueprint-corpus tests
 - `test-blueprints` — committed real-world blueprint corpus
 - `tools/oracle` — probes that ask a local Factorio installation what it does
-- `docs/superpowers/specs` — design documents for larger past changes
+- `docs/superpowers` — `plans` (9) and `specs` (6) for larger past changes
 
 ## Setup and commands
 
@@ -50,8 +50,13 @@ cargo check --manifest-path packages/exporter/Cargo.toml
 tailed log still shows a failure — missing `vp lint`'s single error line has
 already reached CI here.
 
-There is no root `tsc` command because the root tsconfig is only a base. To
-check one package, use its own project, for example:
+There is deliberately no root `tsc` command. The root tsconfig is a base to
+extend — no `include`, no `lib`, and `node` in `types` for the Playwright specs
+— so a bare `tsc` against it compiles the whole tree under settings no package
+builds with. Measured, that reports 5 errors that neither a build nor `vp check`
+sees: four in editor code checked against node's fetch types (`r.json()` gives
+`unknown`), one in website code checked against node globals. Every package is
+at 0 under its own project. To check one, name it, for example:
 
 ```sh
 npx tsc --noEmit -p packages/editor/tsconfig.json
@@ -228,9 +233,12 @@ tests pass. Required secrets are `CLOUDFLARE_API_TOKEN` and
   with none it loses the whole blueprint. Serialization keeps the icon's signal
   (issue #264); drawing it is still open (issue #231).
 - `getDirName` throws on diagonal directions, so any `draw_*` that calls it
-  renders a placeholder for a diagonally-placed entity. This is live, not
-  hypothetical: `railgun-turret` calls it and the corpus places it at directions
-  2 and 14, so it is pinned failing in `tests/__fixtures__/sprite-data.json`.
+  renders a placeholder for a diagonally-placed entity. `railgun-turret` calls
+  it. The hazard is latent, not pinned: no committed test reaches it. The public
+  corpus (#191) places the turret at direction 8 only, and the synthetic halves
+  of `sprite-data.spec.ts` sweep cardinals alone, so
+  `tests/__fixtures__/sprite-data.json` records it succeeding with 8 layers. It
+  was pinned failing against the private corpus this one replaced.
 - Rail placement models rails as integer tile rectangles where Factorio uses
   continuous collision geometry, so it is wrong in both directions — it accepts
   some arrangements the game refuses and refuses 24 measured cases the game

--- a/packages/editor/src/containers/EntitySprite.ts
+++ b/packages/editor/src/containers/EntitySprite.ts
@@ -297,8 +297,12 @@ export class EntitySprite extends Sprite {
                 sprite.__zIndex = LAYER.ENTITY_BASE
             }
             // `i` is the pre-skip index into spriteData: the loop `continue`s
-            // past shadow and filename-less entries above, so zOrder values can
-            // have gaps. Harmless - `compareFn` only compares them relatively.
+            // past falsy, shadow and filename-less entries above, so zOrder
+            // values can have gaps. Harmless in itself - `compareFn` only
+            // compares them relatively - but it means the numbering is not
+            // stable across edits to the generators: a draw_* that stops
+            // emitting an `undefined` placeholder shifts every later zOrder
+            // down by one. draw_reactor has already been changed that way.
             sprite.zOrder = i
 
             // Only tint the colorable mask layers (those flagged apply_runtime_tint),

--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -2,9 +2,16 @@
     Entity rendering. `generateGraphics` dispatches on prototype `type` to a
     `draw_*` function that returns `(data) => SpriteData[]` - the sprite layers
     for one facing. `getSpriteData` caches the returned closure per entity name
-    and wraps it in a try/catch, so a throw here degrades to a placeholder box
-    rather than losing the blueprint - `EntitySprite`/`OverlayContainer` are the
-    boundaries `need()` relies on.
+    and wraps *the closure* in a try/catch, so a throw at draw time degrades to a
+    placeholder box.
+
+    That try does not cover the factory. `generateGraphics(entity)` is called one
+    line above it, so anything a `draw_*` throws before it returns its closure
+    propagates out of `getSpriteData` uncaught - and neither `EntitySprite` nor
+    `EntityContainer` has a try above that, so it loses the blueprint. Two do it
+    today: `draw_mining_drill`, whose `switch (e.name)` is in the factory body,
+    and `draw_furnace`, whose `need(e, 'graphics_set')` runs there. Keep new work
+    that can throw - `need()` especially - inside the returned closure.
 
     Common `draw_*` patterns:
 
@@ -29,7 +36,11 @@
     - Which layer keys a prototype carries is per entity, not per type - ground
       rails have all five picture layers, elevated rails have no `ties`,
       `heating-tower` is a reactor with no `lower_layer_picture`. Probe
-      `data.json` per entity rather than assuming a whole `type` matches.
+      `data.json` per entity rather than assuming a whole `type` matches. That
+      decides the tool: `draw_rail` can read its keys through `need()` because
+      every ground rail has all of them, while `draw_elevated_rail` has to
+      `.filter(p => p !== undefined)` because they are not all there. Reaching
+      for `need()` on a key this particular entity lacks is the way this bites.
 */
 import util from '../common/util'
 import {
@@ -2127,11 +2138,16 @@ function draw_mining_drill(e: MiningDrillPrototype): (data: IDrawData) => readon
 
         default:
             /*
-                getSpriteData catches this and logs it, so an unhandled drill degrades
-                to a placeholder box rather than taking the editor down. Falling off
-                the end of the switch instead used to return undefined, which surfaced
-                as "graphicsFn is not a function" and named neither the entity nor the
-                real problem. See issue #29.
+                Throwing here still beats falling off the end of the switch, which
+                returned undefined and surfaced as "graphicsFn is not a function",
+                naming neither the entity nor the real problem. See issue #29.
+
+                But note where this runs: the switch is in the factory body, so this
+                throw happens inside generateGraphics, which getSpriteData calls
+                OUTSIDE its try. It is not caught and does not degrade to a
+                placeholder - it loses the blueprint. Unreachable today, since every
+                mining-drill prototype in data.json has a case above; a Space Age
+                addition would reach it. See the file header.
             */
             throw new Error(`no draw case for mining drill '${e.name}'`)
     }

--- a/tests/sprite-data.spec.ts
+++ b/tests/sprite-data.spec.ts
@@ -45,9 +45,22 @@ const DIRECTIONS = [0, 4, 8, 12]
 
     Some entries record known-wrong behaviour rather than correct behaviour, so
     do not "fix" them by editing the file: dummy-rail-ramp and dummy-rail-support
-    generate no layers at all ("0:..."), and railgun-turret is "FAILED" in both
-    real halves because util.getDirName throws for the diagonal facings (2 and
-    14) the corpus places it at.
+    generate no layers at all ("0:...").
+
+    railgun-turret used to belong on that list, and no longer does. It calls
+    util.getDirName, which throws for diagonal facings, and against the private
+    corpus that placed it at directions 2 and 14 both real halves read "FAILED".
+    The public corpus committed in #191 places it at direction 8 only, so the
+    entry is now four ordinary 8-layer digests. Nothing about getDirName changed
+    - DIRECTIONS above is cardinals only, so the synthetic halves could never
+    have shown it either. The hazard is simply no longer covered here.
+
+    More generally: the real halves carry no FAILED entry at all. All 5 failing
+    prototypes (the three factorio-logo sizes, fulgoran-ruin-attractor,
+    hidden-electric-energy-interface) appear only under synthetic, noGrid and
+    paintPreview, which come from the all-entities blueprint. So no committed
+    corpus entity is pinned failing, and a corpus figure quoted in prose is a
+    measurement with a date on it - say which corpus it was taken against.
 */
 const EXPECTED: {
     synthetic: Record<string, string[]>


### PR DESCRIPTION
Closes #278.

#278 audited PR #277's `CLAUDE.md` rewrite: 7 statements it called wrong, 14 findings that had no home outside the old 997-line file, and 3 "also worth fixing" items. #277 merged as `1f771b87` after Alex addressed the review in `0f793e36`, so the audit is now against the merged branch.

I re-checked all of it, not by grepping for keywords but by pulling the old text for each row and reading what now stands beside the code. **All but one landed.** This PR fixes the one that did not, plus a defect the fix itself introduced and two clauses that were thinned on the way to the code site.

## The one that did not land

`CLAUDE.md` and `tests/sprite-data.spec.ts` both said `getDirName`'s diagonal throw is "live, not hypothetical" because the corpus places `railgun-turret` at directions 2 and 14, pinning it `FAILED` in the sprite-data fixture. Measured, neither half holds:

- **Fixture:** `railgun-turret` succeeds everywhere. `real` and `noGridReal` are `['8:6394f41e']`; `synthetic` and `noGrid` carry four 8-layer digests. The only `FAILED` entries in the file are `factorio-logo-11tiles`, `factorio-logo-16tiles`, `factorio-logo-22tiles`, `fulgoran-ruin-attractor` and `hidden-electric-energy-interface`.
- **Corpus:** decoding all 12 files (367 blueprints) puts the turret at **direction 8 only, 4 times**. The diagonal placements belong to rails and signals, which call `getDirName8Way`.

It was true until `5f0b1390` (#191) replaced the private corpus with the public one - the fixture went from `['8:6394f41e', '8:afa96fcc', 'FAILED']` to `['8:6394f41e']` and the prose was never updated. #277 carried the claim forward from the spec comment rather than inventing it.

The mechanism is real and stays documented, demoted to latent. Worth saying plainly: `DIRECTIONS` in that spec is cardinals only, so the synthetic halves could never have covered it either.

## A defect the fix introduced

The new `spriteDataBuilder.ts` header says `getSpriteData` "wraps it in a try/catch, so a throw here degrades to a placeholder box rather than losing the blueprint". That is false for the exact pattern its own next paragraph prescribes:

```ts
const graphicsFn = generateGraphics(entity)   // outside the try
const generator = (data: IDrawData) => {
    try { return [...graphicsFn(data), ...] }
    catch (err) { ...; return SPRITE_GENERATION_FAILED }
}
```

A `draw_*` that throws **before returning its closure** propagates out of `getSpriteData` uncaught, and neither `EntitySprite.ts` nor `EntityContainer.ts` has a `try` above it. Two do that today: `draw_mining_drill`, whose `switch (e.name)` sits in the factory body, and `draw_furnace`, whose `need(e, 'graphics_set')` runs there. `draw_mining_drill`'s own `default:` comment repeated the claim, so both are corrected.

That `default:` is unreachable at present - all four `mining-drill` prototypes in `data.json` have a case - so this is a documentation fix, not a bug fix. I have deliberately **not** moved `generateGraphics` inside the try: that is a behaviour change that wants its own test and review.

## Two clauses restored

Both relocations kept the observation and dropped the actionable half:

- **`EntitySprite.getParts`** lost "a generator that stops emitting an `undefined` placeholder shifts every later `zOrder` down by one". That is the forward-looking point - the numbering is unstable across generator edits - and `draw_reactor` has already been changed exactly that way. The comment also listed only two of the loop's three skip conditions, omitting the falsy `!data` skip that the dropped clause was about.
- **Layer keys are per entity** lost "so `draw_rail` can use `need()` and `draw_elevated_rail` has to filter", which is the only clause saying what to do about the hazard. Verified: `draw_rail` is `RAIL_LAYER_KEYS.map(k => sheetOf(need(ps, k)))`, `draw_elevated_rail` is `.filter(p => p !== undefined)`.

## Also

- **No root `tsc`** kept the fact and lost the warning. Restored, and re-measured here rather than copied from the old file: still exactly **5 errors** - four in editor code checked against node's fetch types (`r.json()` gives `unknown`), one in website code checked against node globals.
- **Repository layout** named only `docs/superpowers/specs`. `plans` holds 9 of the 15 files, so the entry now covers both.

## What I checked and did not change

The other 20 items are addressed, several better than #278 asked for. Spot figures I re-derived rather than trusted: the 24 rail refusals are exactly 24 rows in `rail-on-rail.json`, all identical-name identical-direction curved rails; the sprite prefixes are exactly the five exporter output directories; `tile_width`/`tile_height` is 7 of 155 entities, matching #278's list. Two notes on the issue's own accuracy: the pattern table has **9** rows, not 10, in both the old file and the new header; and the merged file is 241 lines, not 197, because `0f793e36` grew it during review.

The `draw_burner_mining_drill` -> `draw_asteroid_collector` swap in the pattern table is an improvement and stays: `draw_burner_mining_drill` never existed, and the `burner-mining-drill` case actually implements the *Direction-indexed* pattern, not the 4-way animation one it was illustrating.

Left for a follow-up rather than widened into this PR:

- Five other sites repeat the "getSpriteData wraps every generator in a try/catch" belief: `need.ts:8`, `spriteShape.ts:20`, `TileContainer.ts:26`, and the headers of `sprite-data.spec.ts` and `sprite-generation.spec.ts`. Each is true in its own local context (those throws are draw-time), but the wording invites the general reading.
- `tests/blueprint-grid-position.spec.ts` does not exist on this branch, yet `tests/tools-panel.spec.ts:88` cites it as covering commit timing and `tools/oracle/probe-blueprint-grid-position.mjs:9` cites it as where a premise is written. It lives only on the unmerged `pr/243` branches.
- `CLAUDE.md` carries 26 em dashes; the old 997-line file had none.

## Verification

`vp check .` - 244 files formatted, 0 warnings, lint errors or type errors.
`vp test` - 225/225.
Playwright not run: every change here is a comment or Markdown, with no behaviour to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174Hm717NoyhFXMXcZipob5