### PR TITLE
DO NOT MERGE: verify the changes job skips web jobs

### DIFF
--- a/packages/exporter/Cargo.toml
+++ b/packages/exporter/Cargo.toml
@@ -23,3 +23,5 @@ hyper = { version = "1.5.1", features = ["http1", "server"] }
 hyper-util = { version = "0.1.10", features = ["tokio"] }
 zip = "8.0.0"
 dotenvy = "0.15.7"
+# Scratch branch: verifies the ci.yml `changes` job skips the web jobs
+# for an exporter-only diff. Delete this branch after reading the checks.


### PR DESCRIPTION
Throwaway, to be closed without merging.

#305 added a `changes` job that gates `checks` and the four Playwright shards on whether a PR touches anything outside `packages/exporter`. I verified the classifier logic locally against 8 file lists, but no run has yet produced `web=false`, so the GitHub half is untested: whether `if: needs.changes.outputs.web == 'true'` actually skips when the output string is `"false"`.

This PR changes one comment in `packages/exporter/Cargo.toml` and nothing else.

Expected:

- `Detect changed areas` passes and logs `Decided: web=false rust=true`
- `Rust exporter` and `Rust exporter (Windows)` run
- `checks` and `Playwright 1/4` through `4/4` report as **skipped**, not missing

If the Playwright shards run anyway, the gate does not work and #305 saves nothing. If they report as missing rather than skipped, the gate works but would block a required check, which is the failure #305's comments say the job-level `if:` was chosen to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
