### PR TITLE
Read the changed-file list with a here-string, not a pipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,12 @@ jobs:
 
           # `rust` covers the exporter crate, plus this workflow itself, so a
           # change to these rules is always tested against both sides.
-          if echo "$files" | grep --quiet --extended-regexp '^packages/exporter/|^\.github/workflows/ci\.yml$'; then
+          # Read the list with a here-string, not `echo ... | grep`. `grep --quiet`
+          # exits on its first match and closes the pipe, so on a large PR the
+          # `echo` dies of SIGPIPE, `pipefail` turns that into a non-zero
+          # pipeline, and a MATCH is read as NO MATCH. PR #268 (5,767 files)
+          # skipped the whole gate that way and still reported mergeable.
+          if grep --quiet --extended-regexp '^packages/exporter/|^\.github/workflows/ci\.yml$' <<< "$files"; then
             rust=true
           else
             rust=false
@@ -86,7 +91,7 @@ jobs:
           # exporter turns it on. That runs `checks` and Playwright for a
           # README-only change, which wastes a few minutes and cannot miss a
           # real one.
-          if echo "$files" | grep --quiet --invert-match '^packages/exporter/'; then
+          if grep --quiet --invert-match '^packages/exporter/' <<< "$files"; then
             web=true
           else
             web=false


### PR DESCRIPTION
The `changes` job silently skips the entire gate on a large pull request, while the pull request still reports as passing and mergeable.

## The mechanism

`grep --quiet` exits the moment it finds a match and closes the pipe. When the changed-file list is bigger than the pipe buffer, the `echo` feeding it is still writing, so it dies of SIGPIPE with status 141. `pipefail` is on, so the pipeline returns 141, the `if` takes the else branch, and **a successful match is read as no match**. Both `web` and `rust` come out false, and every job gated on them skips.

## Measured in CI

PR #268 changes 5,767 files. Its `Detect changed areas` job logged:

```
line 26: echo: write error: Broken pipe
line 36: echo: write error: Broken pipe
Decided: web=false rust=false
```

`checks`, both Rust jobs and all four Playwright shards skipped. The pull request then reported `MERGEABLE` / `CLEAN` with nothing having been tested. That is the failure that matters: not a red build, a green one that did nothing.

## Reproduced locally

6,001 filenames, 430,917 bytes against a 65,536 byte pipe buffer:

```
OLD FORM (echo | grep): rust=false   <-- the bug
NEW FORM (here-string):  rust=true    <-- fixed
OLD FORM on a 2-line list: rust=true  (control, expected true)
```

The control is the reason this was never seen. Any list that fits in the pipe buffer lets `echo` finish before `grep` exits, so there is no SIGPIPE. The threshold is roughly 700 to 1,100 changed files at this repository's average path length, and every pull request merged since the `changes` job landed in #305 was far below it.

## The fix

A here-string, so `echo` is no longer in the pipeline and there is nothing to receive SIGPIPE. The comparison logic is untouched and `pipefail` is left alone.

A guard comment is sited at the first of the two, because replacing a here-string with the more familiar `echo ... | grep` is exactly the edit that reintroduces this.

## Note on this pull request's own gate

This change is small, so it classifies correctly and gets a real run. That is worth stating, since the bug being fixed is one where a green tick means nothing: check that `Detect changed areas` reports `Decided: web=true rust=true` and that `checks` and the Playwright shards actually ran rather than skipped.
