### PR TITLE
Re-collect the tests #268 orphaned, and correct what it made stale

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -114,7 +114,7 @@
     // exceptions below, including GitHub Action digest re-pins.
     //
     // What CI actually covers: `vp check` (oxfmt + oxlint + tsc), `vp test`
-    // (vitest units + the type-check gate), the Playwright suite in the `e2e` job
+    // (vitest units), the Playwright suite in the `e2e` job
     // sharded across four runners, and a compile of packages/exporter on ubuntu
     // and Windows. That is real coverage, and it is MORE than this paragraph
     // claimed until 2026-09-01 - see the corrections below.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -90,25 +90,28 @@ carried 15 unchecked type errors (issue #78).
 Measured 2026-09-02 over 11 successful runs: median 37s, range 31s to 42s. An
 earlier comment in `ci.yml` said 46s, which is above every sample in that set.
 
-### The type-check gate, and the strict-ratchet recipe
+### The strict-ratchet recipe (the type-check gate is gone)
 
-The gate sits alongside `vp check` rather than inside it. The two answer
+A `Type-check gate` step used to run alongside `vp check`. The two answered
 different questions. `vp check` asks whether the code type-checks under the flags
-that are currently on. The gate asks whether the error count has gone above a
-committed baseline. With `strict: true` landed (issue #77) the baseline is 0
-again, so the gate is redundant until the next flag flip.
+that are currently on. The gate asked whether the error count had risen above a
+committed baseline. Once `strict: true` landed (issue #77) the baseline was back
+to 0, which left the gate redundant until the next flag flip, and #268 removed
+the step, the script, its test and the baseline.
 
-**Keep this recipe. It is the part that is expensive to rediscover.** To turn on
-a new strict flag without a red build on every commit in between:
+**Keep this recipe. It is the part that is expensive to rediscover.** It does not
+depend on the gate still existing - it describes how to stand a counting job back
+up for one flag flip and retire it again. To turn on a new strict flag without a
+red build on every commit in between:
 
 1. Turn the flag on in a **second** TypeScript project that nothing compiles
-   with and only the gate reads.
+   with and only the counting job reads.
 2. Start the baseline at whatever the current error count is.
-3. Ratchet it down, keeping this job green the whole way.
+3. Ratchet it down, keeping that job green the whole way.
 
 Turning the flag on in the root config instead fails the `vp check` step on the
 first commit and every one after, whatever the baseline says, because `vp check`
-runs before the gate and tolerates nothing.
+runs first and tolerates nothing.
 
 Issue #77 ran it from 24 to 0 this way.
 

--- a/tools/oracle/factorio-probe.test.mjs
+++ b/tools/oracle/factorio-probe.test.mjs
@@ -1,29 +1,54 @@
+import { test } from 'vite-plus/test'
 import assert from 'node:assert/strict'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { prepareProbe, runProbe } from './factorio-probe.mjs'
 
-const probe = prepareProbe({
-    name: 'runner_test',
-    title: 'Runner test',
-    factorio_version: '2.1',
-    dependencies: ['base'],
-})
-const expected = { ok: true }
-const { text } = runProbe({
-    ...probe,
-    bin: 'factorio',
-    dump: 'result.json',
-    spawn: (_bin, _args, options) => {
-        assert.equal(options.encoding, 'utf8')
-        const output = join(probe.writeData, 'script-output')
-        mkdirSync(output, { recursive: true })
-        writeFileSync(join(probe.work, 'spawned'), '')
-        writeFileSync(join(output, 'result.json'), JSON.stringify(expected))
-        return { stdout: '', stderr: '' }
-    },
+/**
+ * Runs the shared probe runner against a fake spawn, so the whole path is
+ * exercised without a Factorio installation. Returns everything the assertions
+ * below need to look at.
+ *
+ * The real runner treats the dump file, not Factorio's exit code, as the
+ * verdict - a probe signals success with a deliberate `error("DUMPED-OK")` - so
+ * the fake writes a dump and returns cleanly.
+ */
+function runAgainstFakeFactorio() {
+    const probe = prepareProbe({
+        name: 'runner_test',
+        title: 'Runner test',
+        factorio_version: '2.1',
+        dependencies: ['base'],
+    })
+    const expected = { ok: true }
+    const { text } = runProbe({
+        ...probe,
+        bin: 'factorio',
+        dump: 'result.json',
+        spawn: (_bin, _args, options) => {
+            assert.equal(options.encoding, 'utf8')
+            const output = join(probe.writeData, 'script-output')
+            mkdirSync(output, { recursive: true })
+            writeFileSync(join(probe.work, 'spawned'), '')
+            writeFileSync(join(output, 'result.json'), JSON.stringify(expected))
+            return { stdout: '', stderr: '' }
+        },
+    })
+    return { probe, expected, text }
+}
+
+test('runProbe returns the dump the probe wrote', () => {
+    const { expected, text } = runAgainstFakeFactorio()
+    assert.deepEqual(JSON.parse(text), expected)
 })
 
-assert.deepEqual(JSON.parse(text), expected)
-assert.equal(existsSync(join(probe.work, 'spawned')), true)
-assert.equal(JSON.parse(readFileSync(join(probe.modPath, 'info.json'))).author, 'oracle')
+test('runProbe actually spawns Factorio', () => {
+    const { probe } = runAgainstFakeFactorio()
+    assert.equal(existsSync(join(probe.work, 'spawned')), true)
+})
+
+test('prepareProbe writes an isolated mod owned by the oracle', () => {
+    const { probe } = runAgainstFakeFactorio()
+    const info = JSON.parse(readFileSync(join(probe.modPath, 'info.json')))
+    assert.equal(info.author, 'oracle')
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -241,15 +241,29 @@ export default defineConfig({
                     a file off disk therefore has to sit under a directory the
                     root config owns, whatever package it is testing.
 
-                    Only *.test.ts is collected. The 40 specs next door are
-                    Playwright's and would fail immediately under vitest, having
-                    no browser fixtures; playwright.config.ts pins the mirror
-                    image of this so neither runner collects the other's files.
+                    Under tests/ only *.test.ts is collected. The 40 specs
+                    next door are Playwright's and would fail immediately under
+                    vitest, having no browser fixtures; playwright.config.ts pins
+                    the mirror image of this so neither runner collects the
+                    other's files.
+
+                    The scripts/ and tools/ globs are narrow on purpose. They
+                    replace the `gate` project that #268 deleted, which was the
+                    only thing collecting the .test.mjs files under scripts/ -
+                    dropping it silently stopped running
+                    scripts/localpreview.test.mjs, and nothing failed to say so.
+                    Keep them limited to .test.mjs files: a wider glob picks up
+                    plain scripts and vitest fails them with "No test suite
+                    found in file".
+
+                    Do not write a star-slash glob in this comment. That
+                    sequence closes the block comment and the config stops
+                    parsing.
                 */
                 test: {
                     name: 'unit',
                     environment: 'node',
-                    include: ['tests/**/*.test.ts'],
+                    include: ['tests/**/*.test.ts', 'scripts/**/*.test.mjs', 'tools/**/*.test.mjs'],
                 },
             },
         ],


### PR DESCRIPTION
Follow-up to #268, covering the two test-collection defects raised in its review and the two documentation claims it made stale.

## The orphaned tests

#268 deleted the type-check gate, and with it the `gate` vitest project. That project was the only thing whose `include` matched the `.test.mjs` files under `scripts/`, so `scripts/localpreview.test.mjs` stopped being collected. Nothing failed - vitest does not report a file it was never asked to look at.

Measured on `f70ec6cb`, the merge commit itself:

| | Test files | Tests |
|---|---|---|
| Before | 16 | **203** |
| After | 18 | **212** |

The 6 recovered tests cover `parseArgs` and `isPortFree` in the localpreview launcher, including the IPv6-only-listener guard. The other 3 are new, below.

## The probe test that was never a test

`tools/oracle/factorio-probe.test.mjs`, added by #268, was collected by nothing and declared nothing - a flat run of top-level `assert` calls. Even a glob that reached it would have registered zero tests, and vitest would have failed the file with "No test suite found in file".

It now uses `test` from `vite-plus/test`, matching `scripts/localpreview.test.mjs`, and splits into three cases: the runner returns the dump, it actually spawns Factorio, and `prepareProbe` writes an isolated mod owned by the oracle. The fake-spawn setup is shared through a helper rather than run once at module scope.

This matters more than three tests suggests: #268 migrated 17 probes onto that shared runner, so it had no automated coverage at all.

The include globs stay narrow - `scripts/` and `tools/` rather than the whole tree - because a wider one collects plain scripts and fails them.

## Documentation the gate's removal made false

- **`.github/workflows/README.md`** described the type-check gate as a live job. The section now reads as history and says #268 removed it. **The strict-ratchet recipe is kept intact and unhedged**, because it never depended on the gate existing - it describes how to stand a counting job back up for one flag flip and retire it again. That is the part the doc itself calls expensive to rediscover.
- **`.github/renovate.json5`** claimed `vp test` covers "vitest units + the type-check gate". It covers the units.

## One guard worth its line

A `*` followed by `/` inside the block comment in `vite.config.ts` closes the comment. Writing the glob literally in that prose broke the config parse, and the error points at the comment text rather than at anything resembling code, so the comment now says not to.

## Verification

Run locally on this branch:

- `vp test` - 212 passed in 18 files, with `scripts/localpreview.test.mjs` (6) and `tools/oracle/factorio-probe.test.mjs` (3) both listed as collected.
- `vp check .` - no warnings, lint errors or type errors across 190 files.

## Still open, deliberately not in this PR

Roughly 12 references to the type-check gate survive in two historical design records under `docs/superpowers/specs/`. Those are records of what was decided at the time, so a header note is probably better than editing the prose. Worth its own pass.
