### PR TITLE
Note in two design records that the type-check gate is gone

### DIFF
--- a/docs/superpowers/specs/2026-06-27-batch-2a-sprite-shape-narrowing-design.md
+++ b/docs/superpowers/specs/2026-06-27-batch-2a-sprite-shape-narrowing-design.md
@@ -7,7 +7,7 @@ Branch base: `wormeyman-space-age-support`
 > **Historical note, added 2026-09-02.** The type-check gate described below no
 > longer exists. #268 removed `scripts/type-check-gate.mjs`, its baseline and the
 > CI step, after `strict: true` landed under #77 and brought the baseline back to
-> 0. Everything below records the state at the time of writing and is left as
+> zero. Everything below records the state at the time of writing and is left as
 > written. The strict-ratchet technique itself is kept, in
 > `.github/workflows/README.md`.
 

--- a/docs/superpowers/specs/2026-06-27-batch-2a-sprite-shape-narrowing-design.md
+++ b/docs/superpowers/specs/2026-06-27-batch-2a-sprite-shape-narrowing-design.md
@@ -4,6 +4,13 @@ Date: 2026-06-27
 Status: Approved (design)
 Branch base: `wormeyman-space-age-support`
 
+> **Historical note, added 2026-09-02.** The type-check gate described below no
+> longer exists. #268 removed `scripts/type-check-gate.mjs`, its baseline and the
+> CI step, after `strict: true` landed under #77 and brought the baseline back to
+> 0. Everything below records the state at the time of writing and is left as
+> written. The strict-ratchet technique itself is kept, in
+> `.github/workflows/README.md`.
+
 ## Context
 
 The editor enforces a TypeScript error budget via a CI gate

--- a/docs/superpowers/specs/2026-06-29-vite-plus-migration-design.md
+++ b/docs/superpowers/specs/2026-06-29-vite-plus-migration-design.md
@@ -7,7 +7,7 @@
 > **Historical note, added 2026-09-02.** The type-check gate described below no
 > longer exists. #268 removed `scripts/type-check-gate.mjs`, its baseline and the
 > CI step, after `strict: true` landed under #77 and brought the baseline back to
-> 0. Everything below records the state at the time of writing and is left as
+> zero. Everything below records the state at the time of writing and is left as
 > written. The strict-ratchet technique itself is kept, in
 > `.github/workflows/README.md`.
 

--- a/docs/superpowers/specs/2026-06-29-vite-plus-migration-design.md
+++ b/docs/superpowers/specs/2026-06-29-vite-plus-migration-design.md
@@ -4,6 +4,13 @@
 - Branch: `explore/vite-plus`
 - Status: Approved (design); revised after subagent review; pending implementation plan
 
+> **Historical note, added 2026-09-02.** The type-check gate described below no
+> longer exists. #268 removed `scripts/type-check-gate.mjs`, its baseline and the
+> CI step, after `strict: true` landed under #77 and brought the baseline back to
+> 0. Everything below records the state at the time of writing and is left as
+> written. The strict-ratchet technique itself is kept, in
+> `.github/workflows/README.md`.
+
 ## Goal & scope
 
 Adopt the full Vite+ toolchain for the factorio-blueprint-editor monorepo:


### PR DESCRIPTION
The last of the stale references left by #268's removal of the type-check gate.

Two design records under `docs/superpowers/specs/` describe the gate as a live part of CI:

- `2026-06-27-batch-2a-sprite-shape-narrowing-design.md`
- `2026-06-29-vite-plus-migration-design.md`

Between them they name `scripts/type-check-gate.mjs`, `scripts/type-check-baseline.json` or `npm run type-check:gate` about 12 times, and roughly 34 lines read as though the job still runs. A reader arriving at either one now gets a confident description of something that does not exist.

## Why a note rather than an edit

These are dated records of what was decided at the time. Rewriting past reasoning into the past tense makes them less useful as history, not more, and it edits a decision record after the fact. The note says what changed, points at where the surviving technique lives, and leaves the body untouched.

The note is placed after each document's metadata block and before its first section, so it is unmissable without displacing the title.

Docs only. No code, config or workflow changes, so nothing here can affect the build or the site.

This completes the cleanup after #268. The live files were handled in #319; these two are the historical remainder.
