### PR TITLE
Move vp preview off the port the specs default to, and document why

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,13 @@ browser UI. The committed corpus is useful for modern blueprints but does not
 cover pre-2.0 migrations; create a synthetic blueprint at the required version
 with `tests/helpers/encode-blueprint.ts` for those branches.
 
-Browser tests use `window.__fbe_test` to load sources without URL-length limits.
+Browser tests use `window.__fbe_test` to load sources without URL-length
+limits. That hook is assigned only under `import.meta.env.DEV` (#292), so the
+specs need the dev server `npm run localpreview` starts. Run against
+`vp preview` / `preview:website` - a production bundle, no hook - every spec
+instead burns its 60s wait on a function that never appears, and the only
+symptom is a timeout that names nothing (#321). `vp preview` binds 4173, not
+8080, so that mistake surfaces as a connection refused rather than a hang.
 Tests that dispatch pointer input should call `suppressOverlays(page)` before
 navigation so toasts and the settings panel cannot intercept events. Do not
 edit files while a Playwright run is active: Vite reloads the page and destroys

--- a/packages/website/vite.config.js
+++ b/packages/website/vite.config.js
@@ -45,7 +45,14 @@ export default defineConfig(async ({ command, mode }) => {
                 'pixi.js/basis',
             ],
         },
-        preview: { port: 8080 },
+        // Deliberately not 8080. playwright.config.ts defaults baseURL to 8080
+        // and every spec waits on window.__fbe_test, which since #292 is
+        // assigned only under `vp dev`. A suite pointed at `vp preview` - a
+        // production bundle with no hook - would otherwise hang 60s per spec on
+        // a function that never appears, with nothing naming the cause (#321).
+        // On a different port the same mistake is a connection refused instead.
+        // The specs need `npm run localpreview`; see CLAUDE.md.
+        preview: { port: 4173 },
         server: {
             port: 8080,
             proxy,

--- a/tests/helpers/fbe-test-api.ts
+++ b/tests/helpers/fbe-test-api.ts
@@ -4,7 +4,11 @@
     `declare global` blocks that give the same property different types, so any
     spec needing a new hook has to add it here.
 
-    The implementation lives in packages/website/src/index.ts.
+    The implementation lives in packages/website/src/index.ts, and since #292 it
+    is assigned only under `import.meta.env.DEV`. So the specs run against the
+    dev server `npm run localpreview` starts, never `vp preview` /
+    `preview:website`: a production bundle has no hook, and `waitForEditor` below
+    would then wait out its full 60s on every spec (#321).
 */
 
 /** Entity name -> info overlay child count per placement, -1 for no overlay. */
@@ -263,7 +267,12 @@ declare global {
 
 type Page = import('@playwright/test').Page
 
-/** Load the editor and wait for the test hooks to be attached. */
+/**
+ * Load the editor and wait for the test hooks to be attached. A full 60s wait
+ * here almost always means the target has no hook to attach - a production
+ * bundle rather than the `npm run localpreview` dev server (see the file header
+ * and #321) - not a slow machine.
+ */
 export async function waitForEditor(page: Page): Promise<void> {
     await page.goto('/')
     await page.waitForFunction(() => window.__fbe_test !== undefined, { timeout: 60_000 })


### PR DESCRIPTION
Closes #321.

## Problem

`playwright.config.ts` defaults `baseURL` to `http://localhost:8080`;
`packages/website/vite.config.js` bound `vp preview` to the same port. Nothing
connected the two, and before #292 the overlap was harmless - a preview server
serves a self-sufficient bundle, so `npx playwright test` against it worked.

Since #292 the test API is dev-only, so it does not exist on a preview server.
Every spec waits on `window.__fbe_test`, so a suite pointed at `vp preview`
fails with each spec burning its full 60s `waitForFunction` timeout, and the
only symptom is "timeout waiting for `window.__fbe_test`" - nothing points at
the cause.

CI never hits this (`npm run localpreview` runs `vp dev` and refuses to start
when 8080 is held), but `preview:website` is a real root script someone
debugging a build would reach for.

## Change

- **`vite.config.js`**: `preview` binds **4173** (Vite's default) instead of
  8080, with a comment explaining why not to move it back. The same mistake is
  now a connection refused on 8080 rather than a silent per-spec hang. Nothing
  documented or automated depended on preview being on 8080.
- **`CLAUDE.md`** and **`tests/helpers/fbe-test-api.ts`**: a note where the hook
  is described - it exists only under `import.meta.env.DEV`, so the specs need
  the dev server `npm run localpreview` starts, not `vp preview` /
  `preview:website`. `waitForEditor`'s doc comment now also calls out that a
  full 60s wait means "wrong server", not "slow machine".

## Verification

- `vp check` clean on the three files
- `vp build` then `vp preview`: binds `http://localhost:4173`, and `curl
  localhost:8080` is refused

🤖 Generated with [Claude Code](https://claude.com/claude-code)