### PR TITLE
Count unique visitors from both sides of the JavaScript boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,8 +307,15 @@ jobs:
       - name: Install dependencies
         run: vp install --frozen-lockfile
 
+      # CF_BEACON_TOKEN injects Cloudflare Web Analytics' beacon into
+      # index.html (packages/website/vite.config.js). Deploy-only on purpose:
+      # the `checks` job builds nothing that ships, and a PR build must not
+      # report page loads as though they were the live site. An unset secret
+      # omits the tag and the build is unchanged, so this stays green in a fork.
       - name: Build website
         run: npm run build:website
+        env:
+          CF_BEACON_TOKEN: ${{ secrets.CF_BEACON_TOKEN }}
 
       - name: Deploy worker to Cloudflare
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,33 @@ is `packages/worker/wrangler.jsonc`; GitHub Actions deploys after checks and e2e
 tests pass. Required secrets are `CLOUDFLARE_API_TOKEN` and
 `CLOUDFLARE_ACCOUNT_ID`.
 
+## Visitor counts
+
+Two counters measure the same thing from opposite sides, and they are meant to
+disagree.
+
+- Cloudflare Web Analytics. `packages/website/vite.config.js` injects the beacon
+  at build time when `CF_BEACON_TOKEN` is set, which only the deploy job does.
+  Unset, the tag is omitted and the build is otherwise identical. Read it in the
+  Cloudflare dashboard. It counts sessions that ran JavaScript, so ad blockers
+  and crawlers are missing from it.
+- A server-side count in the Worker. `packages/worker/src/visitorCount.ts` holds
+  the rules and the definition: one GET of `/` per IP + User-Agent +
+  Accept-Language per UTC day, deduped in the Cache API and written to the
+  `fbe_unique_visitors` Analytics Engine dataset. Nothing identifying is stored;
+  the fingerprint is a cache key and never reaches the dataset. Analytics Engine
+  has no dashboard, so read it over the SQL API with the query in the
+  `recordVisit` comment in `packages/worker/src/index.ts` - and note it has no
+  `uniq()` or `COUNT(DISTINCT)`, which is why deduplication happens at write
+  time and a query is a plain `SUM(_sample_interval)`.
+
+Neither number is exact. The Worker count runs high (per-colo dedupe, and it
+counts crawlers that send a browser's `Accept`); the beacon runs low. The gap
+between them is the useful part.
+
+`tests/visitor-count.test.ts` covers the pure rules and pins the beacon's hosts
+against the CSP in `packages/website/public/_headers` that permits them.
+
 ## Known limits
 
 - Mobile is a read-only viewer; editing remains desktop-only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,9 +250,9 @@ disagree.
   `uniq()` or `COUNT(DISTINCT)`, which is why deduplication happens at write
   time and a query is a plain `SUM(_sample_interval)`.
 
-Neither number is exact. The Worker count runs high (per-colo dedupe, and it
-counts crawlers that send a browser's `Accept`); the beacon runs low. The gap
-between them is the useful part.
+Neither number is exact. The Worker count runs high (per-colo dedupe, a
+check-then-act race inside that dedupe, and crawlers that send a browser's
+`Accept`); the beacon runs low. The gap between them is the useful part.
 
 `tests/visitor-count.test.ts` covers the pure rules and pins the beacon's hosts
 against the CSP in `packages/website/public/_headers` that permits them.

--- a/packages/website/vite.config.js
+++ b/packages/website/vite.config.js
@@ -9,6 +9,39 @@ const fullReloadAlways = {
     },
 }
 
+/*
+    Cloudflare Web Analytics' beacon.
+
+    Injected at build time from CF_BEACON_TOKEN rather than written into
+    index.html, for two reasons. The token is per-site and comes from the
+    Cloudflare dashboard, so a checkout without it still builds - it just builds
+    a site that reports nothing, which is the right failure. And a local `vp
+    build` does not quietly start sending a developer's page loads to the
+    production site's analytics: only the deploy job sets the variable
+    (.github/workflows/ci.yml).
+
+    The Content-Security-Policy in public/_headers already allows both hosts
+    this needs - static.cloudflareinsights.com to load the script and
+    cloudflareinsights.com to report to. That predates this and is why the tag
+    is one line rather than a header change too; tests/visitor-count.test.ts
+    pins the pair together so tightening one cannot silently kill the other.
+
+    The alternative, for the record: with the zone proxied, Cloudflare can inject
+    this beacon itself with no code at all. An explicit tag is preferred here
+    because it is visible in the repo and survives a change to the zone's
+    settings, and because auto-injection rewrites HTML on the way out for every
+    response rather than baking the tag into the one file that needs it.
+*/
+const beaconTag = token => ({
+    tag: 'script',
+    attrs: {
+        defer: true,
+        src: 'https://static.cloudflareinsights.com/beacon.min.js',
+        'data-cf-beacon': JSON.stringify({ token }),
+    },
+    injectTo: 'body',
+})
+
 export default defineConfig(async ({ command, mode }) => {
     const visualizerPlugin = process.env.VISUALIZE
         ? (await import('rollup-plugin-visualizer')).visualizer({
@@ -18,6 +51,13 @@ export default defineConfig(async ({ command, mode }) => {
               filename: 'dist/stats.html',
               title: 'FBE Bundle Analysis',
           })
+        : null
+    const beaconToken = command === 'build' ? process.env.CF_BEACON_TOKEN : undefined
+    const beaconPlugin = beaconToken
+        ? {
+              name: 'cf-web-analytics-beacon',
+              transformIndexHtml: () => [beaconTag(beaconToken)],
+          }
         : null
     const proxy = {
         '/corsproxy': {
@@ -64,6 +104,7 @@ export default defineConfig(async ({ command, mode }) => {
                       ],
                   })
                 : fullReloadAlways,
+            ...(beaconPlugin ? [beaconPlugin] : []),
             ...(visualizerPlugin ? [visualizerPlugin] : []),
         ]),
     }

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1,7 +1,24 @@
 import { checkProxyTarget, MAX_PROXY_BYTES } from './proxyTarget'
+import {
+    DEDUPE_WINDOW_SECONDS,
+    dedupeKey,
+    isPageView,
+    utcDay,
+    visitorFingerprint,
+} from './visitorCount'
 
 interface Env {
     ASSETS: Fetcher
+    /*
+        Optional, and that is the whole reason this counter can ship without a
+        dashboard visit first. An Analytics Engine dataset is created by its
+        first write, so the binding needs no id in wrangler.jsonc - but a
+        `wrangler dev` run started before the binding existed, or a future
+        deploy that drops it, then finds `undefined` here rather than throwing
+        on a page load. Optional plus the `?.` at the call site means the site
+        serves either way and only the count stops.
+    */
+    VISITS?: AnalyticsEngineDataset
 }
 
 const LEGACY_HOSTNAME = 'fbeworkeyman.wormeyman.workers.dev'
@@ -134,8 +151,93 @@ async function handleCorsProxy(request: Request, requestUrl: URL): Promise<Respo
     })
 }
 
+/*
+    Count this navigation, unless the visitor already counted today.
+
+    Runs inside ctx.waitUntil, so none of it is on the path to the response: the
+    Cache API lookup and the data point are work the runtime finishes after the
+    HTML has gone out. Nothing in here can fail the request either - the whole
+    body is wrapped, because an analytics counter that can take the site down
+    is a worse deal than no counter.
+
+    The two halves are deliberately different stores. Dedupe state goes in the
+    Cache API, which is per-colo, evictable and free; the count goes to Analytics
+    Engine, which is durable and queryable. visitorCount.ts explains what the
+    first of those costs in accuracy.
+
+    One place the dedupe does nothing at all: the Cache API is inert on
+    workers.dev, so a load of a versioned preview hostname counts on every
+    request rather than once a day. Production is a custom domain (`routes` in
+    wrangler.jsonc) and the bare legacy hostname 301s out above before reaching
+    here, so this affects preview traffic only - which is a handful of manual
+    loads, and worth knowing before reading a preview's numbers as real.
+
+    Reading the result. Analytics Engine has no dashboard view of its own - this
+    is the number the beacon in packages/website/index.html cannot see, and it
+    is read over the SQL API:
+
+        SELECT blob1 AS day, SUM(_sample_interval) AS uniques
+        FROM fbe_unique_visitors
+        WHERE timestamp > NOW() - INTERVAL '30' DAY
+        GROUP BY day ORDER BY day
+
+    posted to /accounts/<id>/analytics_engine/sql. One data point is one
+    deduped visitor-day, so that sum is the answer directly. It has to be
+    written that way round: Analytics Engine has no uniq() or COUNT(DISTINCT),
+    which is why the deduplication happens above at write time rather than in
+    the query.
+*/
+async function recordVisit(request: Request, url: URL, env: Env): Promise<void> {
+    try {
+        const day = utcDay(new Date())
+        const fingerprint = await visitorFingerprint({
+            ip: request.headers.get('cf-connecting-ip'),
+            userAgent: request.headers.get('user-agent'),
+            acceptLanguage: request.headers.get('accept-language'),
+            day,
+        })
+
+        const cache = caches.default
+        const key = new Request(dedupeKey(url.origin, day, fingerprint), { method: 'GET' })
+        if (await cache.match(key)) return
+
+        /*
+            A one-byte body rather than a bodiless 204. Only the presence of the
+            entry is read, and the byte costs nothing, but a cache that declines
+            to store an empty response would fail silently and count every
+            visitor on every load - the failure would look exactly like traffic.
+        */
+        await cache.put(
+            key,
+            new Response('1', {
+                status: 200,
+                headers: { 'cache-control': `max-age=${DEDUPE_WINDOW_SECONDS}` },
+            })
+        )
+
+        const country = typeof request.cf?.country === 'string' ? request.cf.country : 'XX'
+        env.VISITS?.writeDataPoint({
+            // The day is stored rather than derived from `timestamp` so a query
+            // groups on the same UTC boundary the dedupe window uses.
+            blobs: [day, country],
+            doubles: [1],
+            // Analytics Engine samples per index once a dataset gets busy, so
+            // this is what SUM(_sample_interval) scales back up. Country rather
+            // than the fingerprint: an index is a filter key, and putting a
+            // per-visitor value there would both store the identifier this
+            // design keeps out of the dataset and shard sampling per visitor.
+            indexes: [country],
+        })
+    } catch {
+        // Deliberately silent. Workers Logs is unsampled (wrangler.jsonc), and a
+        // counter that logs its own failure once per request would be the
+        // loudest thing in the log at exactly the moment something else is
+        // wrong.
+    }
+}
+
 export default {
-    async fetch(request: Request, env: Env): Promise<Response> {
+    async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
         const url = new URL(request.url)
 
         // Redirect the legacy workers.dev hostname to the custom domain,
@@ -147,6 +249,22 @@ export default {
         }
 
         if (url.pathname === '/corsproxy') return handleCorsProxy(request, url)
+
+        /*
+            Count the navigation, then serve the app. After the legacy-hostname
+            redirect above on purpose: a request that bounces to the custom
+            domain is followed by a request that lands on it, and counting both
+            would score one visitor twice.
+        */
+        if (
+            isPageView({
+                method: request.method,
+                pathname: url.pathname,
+                accept: request.headers.get('accept'),
+            })
+        ) {
+            ctx.waitUntil(recordVisit(request, url, env))
+        }
 
         // Serve static assets
         return env.ASSETS.fetch(request)

--- a/packages/worker/src/visitorCount.ts
+++ b/packages/worker/src/visitorCount.ts
@@ -26,6 +26,17 @@
     count that runs a few percent high. An Analytics Engine dataset, by
     contrast, is created by its first write.
 
+    The same store costs a second over-count, smaller than the first. Reading
+    the cache and writing to it are two steps, and index.ts can only do them in
+    order: ask, miss, write. Nothing holds the gap between those two calls, so
+    two requests from one visitor that land inside it both miss and both write,
+    scoring one visitor-day twice. A browser that prefetches `/` and then
+    navigates to it does exactly that, and so do two tabs restored at once. The
+    Cache API offers no compare-and-set to close the gap with, and closing it
+    properly needs the global store this design gave up on above. The window is
+    the few milliseconds between the two calls, so this is rarer than the colo
+    split and points the same way.
+
     No visitor identifier is ever stored. The fingerprint below exists only as a
     cache key inside the 24h dedupe window; the data point written to Analytics
     Engine carries the day, the country and the number 1, and nothing that

--- a/packages/worker/src/visitorCount.ts
+++ b/packages/worker/src/visitorCount.ts
@@ -1,0 +1,148 @@
+/*
+    Deciding whether a request counts as one visitor, and what key dedupes it.
+
+    Split out of index.ts for the same reason proxyTarget.ts was, and that file's
+    header explains it at length: `packages/worker` sits in `lint.ignorePatterns`
+    (vite.config.ts) and no test project collects from it, so a pure module is
+    the only part of this Worker a test can reach. tests/visitor-count.test.ts
+    runs everything below in the `unit` project. The Cache API lookup and the
+    writeDataPoint call stay in index.ts and run nowhere but production.
+
+    What "unique visitor" means here, stated plainly because every analytics
+    product means something different by it:
+
+      one GET of `/` per (IP + User-Agent + Accept-Language) per UTC day,
+      counted once per Cloudflare colo.
+
+    The colo qualifier is the honest part. The dedupe store is the Workers Cache
+    API, which is per-colo and evictable, so a visitor who moves between colos
+    inside a day - a phone leaving wifi, an anycast reroute - counts more than
+    once. The bias is one-directional: this over-counts, never under-counts, and
+    the overshoot is bounded by how many colos one person passes through in a
+    day, which is normally one. That was the price of needing no provisioning:
+    a KV namespace or a Durable Object would dedupe globally, but both need an
+    id pasted into wrangler.jsonc from the dashboard before a deploy works, and
+    a Worker whose deploy breaks on a missing binding id is a worse trade than a
+    count that runs a few percent high. An Analytics Engine dataset, by
+    contrast, is created by its first write.
+
+    No visitor identifier is ever stored. The fingerprint below exists only as a
+    cache key inside the 24h dedupe window; the data point written to Analytics
+    Engine carries the day, the country and the number 1, and nothing that
+    distinguishes one visitor from another. So there is nothing to leak from the
+    queryable side and nothing to subject-access-request, which is also why this
+    sets no cookie and needs no consent banner.
+*/
+
+/*
+    The dedupe window. A UTC day rather than a rolling 24 hours because the day
+    stamp is part of the fingerprint, so every visitor's window ends at the same
+    instant and a daily query does not straddle two windows.
+
+    The Cache API entry is given the same lifetime. It expiring early only
+    re-counts a visitor who returns later the same day; it cannot double-count
+    inside one page load, because a single navigation is a single request.
+*/
+export const DEDUPE_WINDOW_SECONDS = 86_400
+
+/*
+    What the Worker actually sees. `run_worker_first` in wrangler.jsonc is scoped
+    to ["/", "/corsproxy"], so every other path - all 9,097 asset files - is
+    served by ASSETS without this code running at all. That scoping is a cost
+    control (read the comment there), but it is also what makes this counter
+    cheap and accurate: the Worker runs about once per navigation, so counting
+    here needs no filtering of sprite and bundle traffic.
+
+    The editor is a single page app, so a deep link is still `/` with a query
+    string - `?source=<blueprint>` does not change the path. One navigation, one
+    candidate visit, whether the visitor typed the domain or followed a
+    blueprint link.
+*/
+export interface PageViewCandidate {
+    method: string
+    pathname: string
+    /** The request's `Accept` header, or null when it sent none. */
+    accept: string | null
+}
+
+/*
+    Three conditions, each of which excludes something real:
+
+    GET drops HEAD, which uptime checks and link unfurlers send and which no
+    human generates.
+
+    `/` drops `/corsproxy`. That path reaches this Worker too, and a blueprint
+    import fires one on top of the navigation that already counted - counting it
+    would score anyone who imports from pastebin twice.
+
+    An `Accept` that mentions HTML is what separates a browser navigating from a
+    fetch of the same URL. `text/html` is what a navigation sends; a wildcard
+    Accept is what a bare script or curl sends. This is a filter on shape, not a bot
+    check: a crawler that sends a browser's Accept header still counts, and the
+    only honest way to say how many of these are crawlers is to compare this
+    number against the Web Analytics beacon, which runs JavaScript and so counts
+    almost none of them. That divergence is the point of running both.
+*/
+export function isPageView({ method, pathname, accept }: PageViewCandidate): boolean {
+    if (method !== 'GET') return false
+    if (pathname !== '/') return false
+    return accept !== null && accept.includes('text/html')
+}
+
+/** `2026-09-03` in UTC. The dedupe window and the reporting bucket both. */
+export function utcDay(now: Date): string {
+    return now.toISOString().slice(0, 10)
+}
+
+export interface VisitorSignal {
+    /** `CF-Connecting-IP`. Absent on a request Cloudflare did not proxy. */
+    ip: string | null
+    userAgent: string | null
+    acceptLanguage: string | null
+    /** From utcDay(), so yesterday's fingerprint cannot match today's. */
+    day: string
+}
+
+/*
+    A fingerprint, not an identity. SHA-256 over the four fields below, hex, and
+    the day stamp is in the hash rather than beside it so the value itself
+    rotates every midnight UTC - a fingerprint kept past its window matches
+    nobody.
+
+    Deliberately not salted with a secret. A salt would make the hash harder to
+    reverse, and reversing it is not the risk worth defending against here: the
+    value never leaves the edge cache, never reaches Analytics Engine, and is
+    gone within a day. A secret would have to live in wrangler.jsonc or in a
+    Worker secret, which is one more thing to provision and rotate for a value
+    that is already unlinkable across days.
+
+    Missing headers collapse to empty strings rather than being rejected. Two
+    visitors behind one IP with no User-Agent at all would then share a
+    fingerprint and count once, which is the same direction as every other
+    approximation here and rarer than all of them.
+*/
+export async function visitorFingerprint({
+    ip,
+    userAgent,
+    acceptLanguage,
+    day,
+}: VisitorSignal): Promise<string> {
+    const material = [day, ip ?? '', userAgent ?? '', acceptLanguage ?? ''].join('\n')
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(material))
+    return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('')
+}
+
+/*
+    The cache key. Built on the deployment's own origin on purpose: the Workers
+    Cache API keys on a URL, and one inside the zone the Worker already serves
+    is the case Cloudflare documents. Nothing ever fetches it - `/__visitor/...`
+    is not a route, and a request for it would be served the SPA like any other
+    unknown path - so this reserves a key space rather than an endpoint.
+
+    The day is in the path as well as in the fingerprint, which is redundant for
+    matching and worth it for reading: a cache key that says which day it
+    belongs to can be reasoned about from a log line.
+*/
+export function dedupeKey(origin: string, day: string, fingerprint: string): string {
+    return `${origin}/__visitor/${day}/${fingerprint}`
+}

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -59,6 +59,30 @@
         "head_sampling_rate": 1,
     },
     /*
+        Unique-visitor counting. src/visitorCount.ts defines what "unique" means
+        here and what it costs in accuracy; this is why the binding looks like
+        this and what it bills.
+
+        No id, unlike a KV namespace or a D1 database. An Analytics Engine
+        dataset is created by its first write, so this deploys from a clean
+        checkout with nothing provisioned in the dashboard first - which is the
+        reason dedupe state lives in the Cache API rather than in KV. A binding
+        that needs an id pasted in from the dashboard turns a missing setup step
+        into a failed deploy of the whole site.
+
+        Cost: writes are billed as data points, and this writes at most one per
+        visitor per day per colo - not one per request, and not one per asset.
+        It is a fraction of the invocation count already discussed above, so if
+        the Worker's own request bill is acceptable this is noise beside it.
+
+        There is no dashboard for a dataset. Read it over the SQL API with the
+        query in the `recordVisit` comment in src/index.ts. The beacon in
+        packages/website/index.html is the half that does have a dashboard
+        (Web Analytics), and the two are meant to disagree: this counts requests
+        that never ran JavaScript, the beacon counts sessions that did.
+    */
+    "analytics_engine_datasets": [{ "binding": "VISITS", "dataset": "fbe_unique_visitors" }],
+    /*
         A guard against a runaway loop, not a cost control - worth saying
         plainly, because the name suggests otherwise. CPU is roughly 3% of
         what this Worker costs: requests bill at $0.30 per million and CPU at

--- a/tests/visitor-count.test.ts
+++ b/tests/visitor-count.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vite-plus/test'
 import * as fs from 'fs'
 import * as path from 'path'
 import {
-    DEDUPE_WINDOW_SECONDS,
     dedupeKey,
     isPageView,
     utcDay,
@@ -65,10 +64,6 @@ describe('utcDay - the dedupe window and the reporting bucket', () => {
     it('is the UTC calendar day, not the local one', () => {
         expect(utcDay(new Date('2026-09-03T23:59:59Z'))).toBe('2026-09-03')
         expect(utcDay(new Date('2026-09-04T00:00:00Z'))).toBe('2026-09-04')
-    })
-
-    it('matches the cache lifetime the Worker sets', () => {
-        expect(DEDUPE_WINDOW_SECONDS).toBe(24 * 60 * 60)
     })
 })
 
@@ -142,6 +137,50 @@ describe('dedupeKey - a cache key, not a route', () => {
     it('separates days, so yesterday’s entry cannot answer today', () => {
         const key = (day: string) => dedupeKey('https://fbe.factorygamefan.com', day, 'abc')
         expect(key('2026-09-03')).not.toBe(key('2026-09-04'))
+    })
+})
+
+/*
+    The cache entry has to stop being valid when the dedupe window closes, and
+    index.ts is where that is decided: the `cache.put` there sets the entry's
+    `max-age`. Nothing here can run that line - the Cache API exists only in the
+    Workers runtime, and `packages/worker` is collected by no test project, for
+    the reason at the top of this file.
+
+    Comparing DEDUPE_WINDOW_SECONDS against 24 * 60 * 60 is what this used to
+    do, and it proved nothing: index.ts imports that same constant, so the two
+    cannot disagree and the assertion only restated the literal. The failure
+    worth guarding is the lifetime being written out as a number, which then
+    keeps its old value on the day the constant changes. Nothing would fail -
+    the entry would just expire on the wrong schedule and re-count every
+    visitor, or hold past midnight and lose them.
+
+    So this reads the source instead, the same answer corsproxy.test.ts reached
+    for its User-Agent header.
+*/
+describe('the cache entry lives exactly as long as the dedupe window', () => {
+    const worker = fs.readFileSync(
+        path.resolve(process.cwd(), 'packages/worker/src/index.ts'),
+        'utf-8'
+    )
+
+    it('builds the entry’s max-age from the constant, never a literal', () => {
+        const put = worker.match(/await cache\.put\([\s\S]*?\n {8}\)/)
+        if (put === null) throw new Error('the cache.put call could not be located')
+        expect(put[0]).toMatch(/max-age=\$\{DEDUPE_WINDOW_SECONDS\}/)
+        expect(put[0]).not.toMatch(/max-age=\d/)
+    })
+
+    /*
+        And that it is the constant this file covers, not a second one of the
+        same name declared locally - which would satisfy the check above while
+        holding whatever value someone typed.
+    */
+    it('takes that constant from visitorCount.ts rather than redeclaring it', () => {
+        const imported = worker.match(/import \{[\s\S]*?\} from '\.\/visitorCount'/)
+        if (imported === null) throw new Error('the visitorCount import could not be located')
+        expect(imported[0]).toContain('DEDUPE_WINDOW_SECONDS')
+        expect(worker).not.toMatch(/(?:const|let|var) DEDUPE_WINDOW_SECONDS/)
     })
 })
 

--- a/tests/visitor-count.test.ts
+++ b/tests/visitor-count.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vite-plus/test'
+import * as fs from 'fs'
+import * as path from 'path'
+import {
+    DEDUPE_WINDOW_SECONDS,
+    dedupeKey,
+    isPageView,
+    utcDay,
+    visitorFingerprint,
+} from '../packages/worker/src/visitorCount'
+
+/*
+    The unique-visitor counter's decisions, which are the half of it a test can
+    reach. tests/corsproxy.test.ts explains why that split exists at all:
+    `packages/worker` is linted, type-checked and collected by nothing, so only
+    a pure module imported from here runs in CI.
+
+    Uncovered, and it is the half that touches the network: the Cache API
+    lookup, the writeDataPoint call and ctx.waitUntil all live in index.ts and
+    run nowhere but production. A green run here says the rules below hold, not
+    that a visit was counted.
+
+    Same path convention as corsproxy.test.ts, for the reason written there.
+*/
+
+const pageView = (over: Partial<Parameters<typeof isPageView>[0]> = {}) =>
+    isPageView({ method: 'GET', pathname: '/', accept: 'text/html,*/*;q=0.8', ...over })
+
+describe('isPageView - what counts as one visit', () => {
+    it('counts a browser navigating to the editor', () => {
+        expect(pageView()).toBe(true)
+    })
+
+    /*
+        The editor is a single page app, so a blueprint deep link is `/` with a
+        query string. The Worker sees the same path either way, and a visitor
+        who arrives on a shared blueprint is as much a visitor as one who typed
+        the domain.
+    */
+    it('counts a deep link, which is still the root path', () => {
+        expect(pageView({ pathname: '/' })).toBe(true)
+    })
+
+    it('ignores HEAD, which uptime checks and unfurlers send', () => {
+        expect(pageView({ method: 'HEAD' })).toBe(false)
+    })
+
+    /*
+        /corsproxy reaches this Worker too - it is the other half of
+        `run_worker_first` in wrangler.jsonc. A blueprint import fires one on
+        top of the navigation that already counted.
+    */
+    it('ignores the proxy endpoint an import calls after the page loaded', () => {
+        expect(pageView({ pathname: '/corsproxy' })).toBe(false)
+    })
+
+    it('ignores a fetch that does not ask for HTML', () => {
+        expect(pageView({ accept: '*/*' })).toBe(false)
+        expect(pageView({ accept: 'application/json' })).toBe(false)
+        expect(pageView({ accept: null })).toBe(false)
+    })
+})
+
+describe('utcDay - the dedupe window and the reporting bucket', () => {
+    it('is the UTC calendar day, not the local one', () => {
+        expect(utcDay(new Date('2026-09-03T23:59:59Z'))).toBe('2026-09-03')
+        expect(utcDay(new Date('2026-09-04T00:00:00Z'))).toBe('2026-09-04')
+    })
+
+    it('matches the cache lifetime the Worker sets', () => {
+        expect(DEDUPE_WINDOW_SECONDS).toBe(24 * 60 * 60)
+    })
+})
+
+describe('visitorFingerprint - one visitor, one day', () => {
+    const visitor = {
+        ip: '203.0.113.7',
+        userAgent: 'Mozilla/5.0 (X11; Linux x86_64) Firefox/141.0',
+        acceptLanguage: 'en-GB,en;q=0.9',
+        day: '2026-09-03',
+    }
+
+    it('gives one value for the same visitor on the same day', async () => {
+        expect(await visitorFingerprint(visitor)).toBe(await visitorFingerprint(visitor))
+    })
+
+    /*
+        The day is inside the hash rather than beside it, so a value cannot be
+        carried across midnight to match the same person tomorrow. This is what
+        makes the fingerprint unlinkable over time, and it is the reason the
+        design needs no salt.
+    */
+    it('rotates at midnight UTC', async () => {
+        expect(await visitorFingerprint({ ...visitor, day: '2026-09-04' })).not.toBe(
+            await visitorFingerprint(visitor)
+        )
+    })
+
+    it('separates two visitors who differ in any one signal', async () => {
+        const mine = await visitorFingerprint(visitor)
+        expect(await visitorFingerprint({ ...visitor, ip: '203.0.113.8' })).not.toBe(mine)
+        expect(await visitorFingerprint({ ...visitor, userAgent: 'curl/8.7.1' })).not.toBe(mine)
+        expect(await visitorFingerprint({ ...visitor, acceptLanguage: 'de' })).not.toBe(mine)
+    })
+
+    /*
+        A request Cloudflare did not proxy, or one from a client that sends no
+        User-Agent, still has to produce a key rather than throw on the response
+        path. Everyone in that bucket collapses to one fingerprint, which
+        under-counts - the one place this design does.
+    */
+    it('handles a request that is missing every header', async () => {
+        const blank = await visitorFingerprint({
+            ip: null,
+            userAgent: null,
+            acceptLanguage: null,
+            day: visitor.day,
+        })
+        expect(blank).toMatch(/^[0-9a-f]{64}$/)
+        expect(blank).not.toBe(await visitorFingerprint(visitor))
+    })
+
+    /*
+        No visitor identifier is stored anywhere queryable, so what the hash is
+        made of matters less than that it is a hash. This pins the shape rather
+        than the value: a digest, not the material.
+    */
+    it('is a hex SHA-256 digest, never the inputs', async () => {
+        const fingerprint = await visitorFingerprint(visitor)
+        expect(fingerprint).toMatch(/^[0-9a-f]{64}$/)
+        expect(fingerprint).not.toContain('203.0.113.7')
+    })
+})
+
+describe('dedupeKey - a cache key, not a route', () => {
+    it('is built on the deployment’s own origin', () => {
+        expect(dedupeKey('https://fbe.factorygamefan.com', '2026-09-03', 'abc')).toBe(
+            'https://fbe.factorygamefan.com/__visitor/2026-09-03/abc'
+        )
+    })
+
+    it('separates days, so yesterday’s entry cannot answer today', () => {
+        const key = (day: string) => dedupeKey('https://fbe.factorygamefan.com', day, 'abc')
+        expect(key('2026-09-03')).not.toBe(key('2026-09-04'))
+    })
+})
+
+/*
+    The beacon and the header that permits it, pinned together.
+
+    packages/website/vite.config.js injects a script from
+    static.cloudflareinsights.com which reports to cloudflareinsights.com. The
+    Content-Security-Policy in public/_headers already allowed both before this
+    counter existed, so nothing in the beacon change had to touch it - and that
+    is exactly the arrangement that breaks quietly. Tightening the CSP would not
+    fail a build, would not fail a Playwright run, and would stop analytics
+    reaching Cloudflare with no error anywhere but a visitor's console.
+
+    A source-reading test for a production-only interaction, the same answer
+    corsproxy.test.ts reached for its User-Agent header.
+*/
+describe('the Web Analytics beacon is permitted by the CSP that ships with it', () => {
+    const read = (relative: string) =>
+        fs.readFileSync(path.resolve(process.cwd(), relative), 'utf-8')
+
+    const headers = read('packages/website/public/_headers')
+    const viteConfig = read('packages/website/vite.config.js')
+
+    it('serves the beacon script from a host script-src allows', () => {
+        expect(viteConfig).toContain('https://static.cloudflareinsights.com/beacon.min.js')
+        expect(headers).toContain('script-src')
+        expect(headers).toContain('https://static.cloudflareinsights.com')
+    })
+
+    it('lets the beacon report back through connect-src', () => {
+        expect(headers).toContain('connect-src')
+        expect(headers).toContain('https://cloudflareinsights.com')
+    })
+
+    /*
+        The token comes from the environment, never from the repo. A literal in
+        vite.config.js would be a working site token committed in public - not a
+        credential that can write anything, but one anybody could point their
+        own traffic at to poison the numbers.
+    */
+    it('takes its site token from the environment', () => {
+        expect(viteConfig).toContain('process.env.CF_BEACON_TOKEN')
+    })
+})


### PR DESCRIPTION
Nothing measured visitors. Workers metrics count requests — the figures `wrangler.jsonc` quotes — and requests are not people: 9,097 asset files and a crawler spike move that number with no visitor behind it.

Two counters, deliberately disagreeing. The Worker counts requests that never ran JavaScript; the beacon counts sessions that did. Neither is exact, and the gap between them is the useful part.

## The beacon

`packages/website/vite.config.js` injects Cloudflare Web Analytics at build time when `CF_BEACON_TOKEN` is set, which only the deploy job does. Unset, the tag is omitted and the build is otherwise identical — so a fork stays green and a developer's page loads never reach the production site's analytics.

The CSP in `public/_headers` already allowed both hosts this needs, from before this change. That is exactly the arrangement that breaks quietly: tightening it would fail no build, fail no Playwright run, and stop analytics reaching Cloudflare with no error anywhere but a visitor's console. `tests/visitor-count.test.ts` pins the tag and the header together.

## The Worker count

One GET of `/` per IP + User-Agent + Accept-Language per UTC day, deduped in the Cache API and written to the `fbe_unique_visitors` Analytics Engine dataset.

Three choices worth keeping:

- **Dedupe at write time, not in the query.** Analytics Engine has no `uniq()` and no `COUNT(DISTINCT)`, so a data point has to already mean one visitor-day; reading it is then `SUM(_sample_interval)`.
- **Cache API, not KV, for the dedupe store.** KV would dedupe globally where the cache is per-colo, but a KV binding needs an id pasted in from the dashboard before a deploy works. A count that runs a few percent high beats a deploy of the whole site failing on a missing setup step. An Analytics Engine dataset needs no id at all — its first write creates it.
- **No visitor identifier is stored.** The fingerprint is a cache key inside its 24h window and never reaches the dataset, which carries the day, the country and the number 1. No cookie, so no consent banner.

Counting runs in `ctx.waitUntil` with the whole body wrapped, so it is off the response path and cannot fail a page load. `isPageView`, the fingerprint and the cache key live in a pure module for the reason `proxyTarget.ts` does: `packages/worker` is linted and collected by nothing, so a pure module is the only part a test can reach.

## Known inaccuracies, all documented in the source

- Per-colo dedupe over-counts a visitor who crosses colos in one day. One direction only, and normally one colo per person.
- The Cache API is inert on `workers.dev`, so a versioned preview hostname counts every request rather than once a day. Production is a custom domain, so this affects preview traffic only.
- `cache.match` and `cache.put` are two calls with nothing holding the gap between them, so a prefetch racing the navigation that follows it can write one visitor-day twice. Same direction as the other two; the window is the few milliseconds between the calls.

## Verification

- `vp check .` clean: 235 files formatted, 0 warnings/lint/type errors in 192 files.
- 18 new unit tests pass (233 → 234 across the suite); `tsc --noEmit` at 0 for both the worker and editor projects.
- The two source-reading tests are mutation-checked: writing `max-age` as a literal, dropping the `cache-control` header, and redeclaring `DEDUPE_WINDOW_SECONDS` locally each turn them red.
- A build with `CF_BEACON_TOKEN` set emits the beacon tag; one without emits nothing. Both checked in the built `dist/index.html`.
- The two failures in `scripts/localpreview.test.mjs` are the test container having no IPv6 (`EAFNOSUPPORT ::1`) and fail identically at the branch point.

Not verifiable from here: the Cache API lookup, the `writeDataPoint` call and `ctx.waitUntil` run nowhere but production — the same gap `tests/corsproxy.test.ts` records for the proxy.

## After merge, or nothing reports

1. ~~Create the Web Analytics site in the Cloudflare dashboard and add its token as the `CF_BEACON_TOKEN` repo secret.~~ Done — the secret exists, so the deploy that follows this merge injects the beacon.
2. Analytics Engine has no dashboard view. Read that number over the SQL API with the query in the `recordVisit` comment in `packages/worker/src/index.ts`, or through Cloudflare's Grafana plugin. The zone's Analytics & Logs → Traffic tab already shows IP-based unique visitors retroactively, with no deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kftg4y5VSxEvkFFez2KZbs
