### PR TITLE
Say why a Node version manager cannot satisfy this repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ closing references such as `Closes #123` in the pull request body.
 
 ## Setup and commands
 
-The pinned toolchain is Vite+ 0.3.0 with its managed Node/npm. Put
-`~/.vite-plus/bin` on `PATH`; the root package requires npm 12.
+The pinned toolchain is Vite+ 0.3.0 with its managed Node/npm. Prepend
+`~/.vite-plus/bin` to `PATH`; the root package requires npm 12.
 
 ```sh
 curl -fsSL https://vite.plus -o vp-install.sh
@@ -38,6 +38,32 @@ vp install
 layout and puts the binaries in `~/.local/share/vite-plus/bin`, so dropping it
 makes the `PATH` line above wrong and `vp` looks missing rather than misplaced.
 `.github/actions/setup-vp/action.yml` pins the same layout for the same reason.
+
+Prepend rather than append, because Vite+ works through shims. It installs
+`node`, `npm`, `npx` and `corepack` into that one directory, and each of them
+resolves a version per directory at the moment you run it. Any other `node` or
+`npm` earlier on `PATH` wins instead, and the shims are then never consulted.
+
+Node and npm are two separate pins, which is the part worth knowing. The Node
+version comes from `.node-version` (24.20.0). The npm version comes from
+`devEngines.packageManager` in the root `package.json`, and Vite+ keeps it in
+`~/.vite-plus/package_manager/npm/<version>/` rather than using the one inside
+the Node install. That matters because the npm bundled inside Node 24.20.0 is
+11.19.0. A Node version manager on its own - fnm, nvm, asdf - therefore cannot
+satisfy this repo whichever Node it selects, because npm 12 comes from Vite+
+and from nowhere else.
+
+The symptom when something else's npm wins is `EBADDEVENGINES`:
+
+```
+npm error EBADDEVENGINES Invalid semver version "^12" does not match "11.19.0"
+```
+
+Every `npm` and `npx` command fails that way, including the `npx tsc` line
+below, which reads as a broken repository rather than a misordered `PATH`.
+`vp env doctor` identifies it - the PATH section marks each tool `(vp shim)` or
+`(not vp shim)` - but it reports the mismatch as a warning and still ends in
+`All checks passed`, so read that section rather than the verdict.
 
 Common commands:
 


### PR DESCRIPTION
`CLAUDE.md` said to put `~/.vite-plus/bin` on `PATH` without saying it has to go first. That is not a nit: Vite+ works through shims, so appending silently leaves the pinned toolchain unused.

## What was wrong

Vite+ installs `node`, `npm`, `npx` and `corepack` into that one directory, and each resolves a version per directory at the moment you run it. Any other `node` or `npm` earlier on `PATH` wins and the shims are never consulted.

## The part that costs time

Node and npm are **two separate pins**:

| tool | version | comes from |
| --- | --- | --- |
| Node | 24.20.0 | `.node-version` |
| npm | 12.0.1 | `devEngines.packageManager`, kept in `~/.vite-plus/package_manager/npm/<version>/` |

The npm bundled inside Node 24.20.0 is **11.19.0**. So selecting the right Node is not enough, and a Node version manager on its own - fnm, nvm, asdf - cannot satisfy the root package's `npm ^12` whichever Node it picks. npm 12 comes from Vite+ and nowhere else.

## Why it needed writing down

It does not present as a `PATH` problem. Every `npm` and `npx` command dies with:

```
npm error EBADDEVENGINES Invalid semver version "^12" does not match "11.19.0"
```

That includes the `npx tsc --noEmit -p packages/editor/tsconfig.json` line this same section recommends, so the repository reads as broken.

`vp env doctor` does identify it - the PATH section marks each tool `(vp shim)` or `(not vp shim)` - but it treats the mismatch as a warning and still ends in a green `All checks passed`. The verdict line is not the thing to read.

## Verification

Measured on a machine where Homebrew's node preceded the shims:

- `npx tsc --noEmit -p packages/editor/tsconfig.json` exited **1** with `EBADDEVENGINES`; after prepending `~/.vite-plus/bin`, the identical command exited **0**, with no other change.
- `vp env doctor` went from three `(not vp shim)` warnings to all `(vp shim)`.
- `vp check .` clean, `vp test` 234 passed. Documentation-only; no code or config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ovfCqWvjoQ69u8eUuCNF7