### PR TITLE
Finish the 16-way direction migration in getOpposingEntity

### DIFF
--- a/packages/editor/src/common/util.test.ts
+++ b/packages/editor/src/common/util.test.ts
@@ -160,6 +160,28 @@ describe('getDirName', () => {
     })
 })
 
+describe('getDirOffset', () => {
+    /*
+        Y grows downwards, so north is -Y. The four answers here are what
+        PositionGrid.getOpposingEntity walks the grid by, and what the old
+        8-way arithmetic got wrong for east and west (#329).
+    */
+    it.each([
+        [0, { x: 0, y: -1 }],
+        [4, { x: 1, y: 0 }],
+        [8, { x: 0, y: 1 }],
+        [12, { x: -1, y: 0 }],
+    ])('direction %i steps by %o', (dir, expected) => {
+        expect(util.getDirOffset(dir)).toEqual(expected)
+    })
+
+    // unlike getDirName it degrades rather than throwing, because its callers
+    // are walking a blueprint and one odd direction should cost one connection
+    it('a diagonal direction has no offset', () => {
+        expect(util.getDirOffset(2)).toBeUndefined()
+    })
+})
+
 describe('vectorToTuple', () => {
     it('passes a tuple through', () => {
         expect(util.vectorToTuple([1, 2])).toEqual([1, 2])

--- a/packages/editor/src/common/util.ts
+++ b/packages/editor/src/common/util.ts
@@ -93,6 +93,34 @@ const transformConnectionPosition = (position: IPoint, direction: number): IPoin
     return rotatePointBasedOnDir(position, direction)
 }
 
+/**
+ * One tile of movement along a 16-way cardinal direction.
+ *
+ * Factorio's Y axis grows downwards, so north (0) is -Y, east (4) is +X, south
+ * (8) is +Y and west (12) is -X - the same four values `getDirName` accepts.
+ *
+ * Answers undefined rather than throwing for anything else. Every caller is
+ * walking the grid looking for a partner entity, and a blueprint that stores a
+ * diagonal direction on an underground belt should cost that one entity its
+ * connection line, not the whole blueprint. Non-cardinals are unreachable
+ * through the UI: `getPossibleRotations` gives an underground belt, a loader
+ * and a pipe-to-ground [0, 4, 8, 12].
+ */
+const getDirOffset = (dir: number): IPoint | undefined => {
+    switch (dir) {
+        case 0:
+            return { x: 0, y: -1 }
+        case 4:
+            return { x: 1, y: 0 }
+        case 8:
+            return { x: 0, y: 1 }
+        case 12:
+            return { x: -1, y: 0 }
+        default:
+            return undefined
+    }
+}
+
 const getDirName = (dir: number): NamedDirection => {
     switch (dir) {
         case 0:
@@ -200,6 +228,7 @@ export default {
     getRelativeDirection,
     rotatePointBasedOnDir,
     transformConnectionPosition,
+    getDirOffset,
     getDirName,
     getDirName8Way,
     nearestPowerOf2,

--- a/packages/editor/src/containers/OverlayContainer.ts
+++ b/packages/editor/src/containers/OverlayContainer.ts
@@ -555,9 +555,10 @@ export class OverlayContainer extends Container {
         searchDirection: number
         /*
             undefined whenever there is no line to draw: the entity is not an
-            underground, has no partner in range, or the partner faces the same
-            way. Every caller already stores the result in a `Container |
-            undefined` field and checks it.
+            underground, has no partner in range, the partner faces the same
+            way, or searchDirection is not one of the four 16-way cardinals and
+            so names no axis to draw along. Every caller already stores the
+            result in a `Container | undefined` field and checks it.
         */
     ): Container | undefined {
         const fd = FD.entities[name]
@@ -574,23 +575,32 @@ export class OverlayContainer extends Container {
                     ? undefined
                     : this.bpc.bp.entities.get(opposingEntityNumber)
 
-            if (otherEntity) {
-                // Return if directionTypes are the same
+            const step = util.getDirOffset(searchDirection)
+
+            if (otherEntity && step) {
+                /*
+                    Return if the two connections run the same way - two inputs
+                    or two outputs, which is not a pair.
+
+                    This read `otherEntity.direction + (8 % 16)` until #329. The
+                    misplaced bracket makes it `direction + 8`, which agrees
+                    with the intended `(direction + 8) % 16` only below 8: a
+                    south-facing output gave 16 and a west-facing one 20, and
+                    neither can equal a searchDirection, so the guard silently
+                    stopped firing on half the directions and a line was drawn
+                    between two entities that are not partners.
+                */
                 if (
                     fd.type === 'underground-belt' &&
-                    (otherEntity.directionType === 'input'
-                        ? otherEntity.direction
-                        : otherEntity.direction + (8 % 16)) === searchDirection
+                    otherEntity.undergroundSearchDirection === searchDirection
                 ) {
                     return
                 }
 
-                const searchingAlongY = searchDirection % 4 === 0
-                const distance = searchingAlongY
-                    ? Math.abs(otherEntity.position.y - position.y)
-                    : Math.abs(otherEntity.position.x - position.x)
-
-                const sign = searchDirection === 0 || searchDirection === 6 ? -1 : 1
+                const distance =
+                    step.x === 0
+                        ? Math.abs(otherEntity.position.y - position.y)
+                        : Math.abs(otherEntity.position.x - position.x)
 
                 const lineParts = new Container()
                 lineParts.x = position.x * 32
@@ -608,15 +618,15 @@ export class OverlayContainer extends Container {
                         s.scale.set(data.scale)
                     }
                     s.anchor.set(0.5)
-                    s.x = searchingAlongY ? 0 : sign * i * 32
-                    s.y = searchingAlongY ? sign * i * 32 : 0
+                    s.x = step.x * i * 32
+                    s.y = step.y * i * 32
                     lineParts.addChild(s)
                 }
 
                 const otherEntityCursorBox = this.createCursorBox(
                     {
-                        x: searchingAlongY ? 0 : sign * distance * 32,
-                        y: searchingAlongY ? sign * distance * 32 : 0,
+                        x: step.x * distance * 32,
+                        y: step.y * distance * 32,
                     },
                     otherEntity.size,
                     'pair'

--- a/packages/editor/src/core/Entity.ts
+++ b/packages/editor/src/core/Entity.ts
@@ -362,6 +362,19 @@ export class Entity extends EventEmitter<EntityEvents> {
             .commit()
     }
 
+    /**
+     * The 16-way direction this entity's hidden underground connection runs in,
+     * which is also the direction its partner has to be searched for in.
+     *
+     * An input faces the way it points; an output's connection comes from
+     * behind it. Anything without a directionType - a pipe-to-ground, which
+     * stores none - takes the output form, which is the convention every caller
+     * already used before this getter collected them.
+     */
+    public get undergroundSearchDirection(): number {
+        return this.directionType === 'input' ? this.direction : (this.direction + 8) % 16
+    }
+
     /** Entity recipe */
     public get recipe(): string | undefined {
         return this.m_rawEntity.recipe
@@ -1311,7 +1324,7 @@ export class Entity extends EventEmitter<EntityEvents> {
                         this.name,
                         this.direction,
                         this.position,
-                        this.directionType === 'input' ? this.direction : (this.direction + 8) % 16,
+                        this.undergroundSearchDirection,
                         isUndergroundBelt(this.entityData)
                             ? this.entityData.max_distance
                             : undefined

--- a/packages/editor/src/core/PositionGrid.test.ts
+++ b/packages/editor/src/core/PositionGrid.test.ts
@@ -1,0 +1,435 @@
+import { beforeAll, describe, expect, it } from 'vite-plus/test'
+import { IPoint } from '../types'
+import { Blueprint } from './Blueprint'
+import { loadData } from './factorioData'
+
+/*
+    Underground pairing: PositionGrid.getOpposingEntity, the one lookup that
+    decides whether two undergrounds are partners.
+
+    Nothing tested it, and that is how #329 4.1 survived. The method carried
+    Factorio 1.1's 8-way direction arithmetic:
+
+        const horizontal = searchDirection % 4 !== 0
+        const sign = searchDirection === 0 || searchDirection === 6 ? -1 : 1
+
+    Our directions are 16-way (north 0, east 4, south 8, west 12), so every
+    cardinal is a multiple of 4 and `horizontal` was false for all of them - an
+    east or west underground searched up and down the Y axis and could never
+    find its partner. 6 is not a direction in the 16-way scheme either, so west
+    walked towards +X. Only north and south still worked, north because its
+    sign was in the special case and south because +1 was already right.
+
+    The last two lines of the same method were already 16-way
+    ((direction + 8) % 16), which is what made this a half-finished migration
+    rather than an obviously stale file.
+
+    These run under vitest rather than Playwright because the lookup is pure
+    grid arithmetic - it reads entity numbers out of a Map and never touches a
+    sprite - so a fake dataset with the four prototypes is enough.
+*/
+
+// the real values out of data.json, so the boundary cases below are the game's
+const MAX_DISTANCE = {
+    'underground-belt': 5,
+    'fast-underground-belt': 7,
+    'express-underground-belt': 9,
+    'turbo-underground-belt': 11,
+}
+
+const beltPrototype = (name: string, max_distance: number): unknown => ({
+    type: 'underground-belt',
+    name,
+    max_distance,
+    collision_box: [
+        [-0.4, -0.4],
+        [0.4, 0.4],
+    ],
+})
+
+beforeAll(() => {
+    // loadData permanently replaces FD's accessors; vitest's per-file module
+    // isolation keeps this synthetic dataset out of the other test files.
+    loadData(
+        JSON.stringify({
+            items: {},
+            fluids: {},
+            signals: {},
+            recipes: {},
+            entities: {
+                'underground-belt': beltPrototype('underground-belt', 5),
+                'fast-underground-belt': beltPrototype('fast-underground-belt', 7),
+                'express-underground-belt': beltPrototype('express-underground-belt', 9),
+                'turbo-underground-belt': beltPrototype('turbo-underground-belt', 11),
+                /*
+                    pipe-to-ground has no max_distance of its own - the overlay
+                    passes 10 for it - but it reaches the same lookup, so the
+                    fix covers it and so do the cases below. Loaders reach it
+                    too, from Entity.rotate, which passes undefined for anything
+                    that is not an underground belt; that is the no-reach case.
+                */
+                'pipe-to-ground': {
+                    type: 'pipe-to-ground',
+                    name: 'pipe-to-ground',
+                    collision_box: [
+                        [-0.29, -0.29],
+                        [0.29, 0.2],
+                    ],
+                },
+            },
+            tiles: {},
+            inventoryLayout: [],
+            utilitySprites: {},
+            utilityConstants: {},
+            guiStyle: {},
+            defines: {},
+        })
+    )
+})
+
+interface Placement {
+    name: string
+    /** tile centre, the form a real blueprint stores a 1x1 entity at */
+    x: number
+    y: number
+    direction: number
+    directionType?: 'input' | 'output'
+}
+
+/**
+ * A blueprint of 1x1 entities, numbered from 1 in the order given.
+ *
+ * The constructor recentres everything it is handed, so the positions that come
+ * back are not the ones passed in - only the offsets between them survive.
+ * Every case below therefore searches from `positionOf(bp, 1)` rather than from
+ * a literal.
+ */
+const blueprintOf = (...placements: Placement[]): Blueprint =>
+    new Blueprint({
+        entities: placements.map((p, i) => ({
+            entity_number: i + 1,
+            name: p.name,
+            position: { x: p.x, y: p.y },
+            direction: p.direction,
+            type: p.directionType,
+        })),
+    })
+
+const positionOf = (bp: Blueprint, entityNumber: number): IPoint => {
+    const entity = bp.entities.get(entityNumber)
+    if (entity === undefined) throw new Error(`no entity ${entityNumber} in this blueprint`)
+    return entity.position
+}
+
+const NORTH = 0
+const EAST = 4
+const SOUTH = 8
+const WEST = 12
+
+describe('getOpposingEntity pairs along all four cardinals', () => {
+    /*
+        One input and one output of the same name, facing the same way, four
+        tiles apart. Both halves of a real pair are asked here: the input looks
+        forwards along its own direction, and the output looks backwards, which
+        is the (direction + 8) % 16 its callers pass.
+
+        Before the fix, east and west answered undefined in both halves.
+    */
+    const cases = [
+        { dir: NORTH, name: 'north', dx: 0, dy: -4 },
+        { dir: EAST, name: 'east', dx: 4, dy: 0 },
+        { dir: SOUTH, name: 'south', dx: 0, dy: 4 },
+        { dir: WEST, name: 'west', dx: -4, dy: 0 },
+    ]
+
+    for (const { dir, name, dx, dy } of cases) {
+        it(`finds the output of an input facing ${name}`, () => {
+            const bp = blueprintOf(
+                {
+                    name: 'underground-belt',
+                    x: 0.5,
+                    y: 0.5,
+                    direction: dir,
+                    directionType: 'input',
+                },
+                {
+                    name: 'underground-belt',
+                    x: 0.5 + dx,
+                    y: 0.5 + dy,
+                    direction: dir,
+                    directionType: 'output',
+                }
+            )
+
+            expect(
+                bp.entityPositionGrid.getOpposingEntity(
+                    'underground-belt',
+                    dir,
+                    positionOf(bp, 1),
+                    dir,
+                    MAX_DISTANCE['underground-belt']
+                )
+            ).toBe(2)
+        })
+
+        it(`finds the input of an output facing ${name}`, () => {
+            const bp = blueprintOf(
+                {
+                    name: 'underground-belt',
+                    x: 0.5,
+                    y: 0.5,
+                    direction: dir,
+                    directionType: 'output',
+                },
+                {
+                    name: 'underground-belt',
+                    x: 0.5 - dx,
+                    y: 0.5 - dy,
+                    direction: dir,
+                    directionType: 'input',
+                }
+            )
+
+            // an output searches backwards, which is what Entity.rotate and the
+            // overlay both pass as searchDirection
+            expect(
+                bp.entityPositionGrid.getOpposingEntity(
+                    'underground-belt',
+                    dir,
+                    positionOf(bp, 1),
+                    (dir + 8) % 16,
+                    MAX_DISTANCE['underground-belt']
+                )
+            ).toBe(2)
+        })
+    }
+
+    it('does not find a partner that sits on the other axis', () => {
+        // the shape of the old bug: an east-west pair, searched along Y
+        const bp = blueprintOf(
+            { name: 'underground-belt', x: 0.5, y: 0.5, direction: EAST, directionType: 'input' },
+            { name: 'underground-belt', x: 0.5, y: 4.5, direction: EAST, directionType: 'output' }
+        )
+
+        expect(
+            bp.entityPositionGrid.getOpposingEntity(
+                'underground-belt',
+                EAST,
+                positionOf(bp, 1),
+                EAST,
+                MAX_DISTANCE['underground-belt']
+            )
+        ).toBeUndefined()
+    })
+})
+
+describe('getOpposingEntity reach', () => {
+    const pairAtDistance = (
+        name: string,
+        distance: number,
+        maxDistance: number | undefined
+    ): number | undefined => {
+        const bp = blueprintOf(
+            { name, x: 0.5, y: 0.5, direction: EAST, directionType: 'input' },
+            { name, x: 0.5 + distance, y: 0.5, direction: EAST, directionType: 'output' }
+        )
+        return bp.entityPositionGrid.getOpposingEntity(
+            name,
+            EAST,
+            positionOf(bp, 1),
+            EAST,
+            maxDistance
+        )
+    }
+
+    /*
+        The loop runs i = 1..maxDistance inclusive, so max_distance is the
+        largest gap in tiles between the two entities themselves - 5 for the
+        basic belt, and 7, 9 and 11 for the three faster ones.
+    */
+    for (const [name, max] of Object.entries(MAX_DISTANCE)) {
+        it(`${name} pairs at exactly ${max} tiles and not at ${max + 1}`, () => {
+            expect(pairAtDistance(name, max, max)).toBe(2)
+            expect(pairAtDistance(name, max + 1, max)).toBeUndefined()
+        })
+    }
+
+    it('answers undefined when there is no reach to search along', () => {
+        /*
+            The loader path. Entity.rotate reads max_distance off the prototype
+            and only an underground belt has one, so a loader asks with
+            undefined and the search never runs. A loader pair is therefore
+            still not modelled - the fix does not change that, and this pins it
+            so a later change to loaders has to say so.
+        */
+        expect(pairAtDistance('underground-belt', 2, undefined)).toBeUndefined()
+    })
+
+    it('answers undefined for a diagonal search direction', () => {
+        // unreachable through the UI - getPossibleRotations gives these
+        // entities [0, 4, 8, 12] - but a blueprint file can hold one, and it
+        // must cost no more than this one connection
+        const bp = blueprintOf(
+            { name: 'underground-belt', x: 0.5, y: 0.5, direction: 2, directionType: 'input' },
+            { name: 'underground-belt', x: 4.5, y: 0.5, direction: 2, directionType: 'output' }
+        )
+
+        expect(
+            bp.entityPositionGrid.getOpposingEntity(
+                'underground-belt',
+                2,
+                positionOf(bp, 1),
+                2,
+                MAX_DISTANCE['underground-belt']
+            )
+        ).toBeUndefined()
+    })
+})
+
+describe('getOpposingEntity blocking and mismatches', () => {
+    it('is blocked by a belt of the same name facing the other way', () => {
+        // Factorio's own rule: an underground of the same tier pointing back at
+        // you, between the two ends, breaks the connection
+        const bp = blueprintOf(
+            { name: 'underground-belt', x: 0.5, y: 0.5, direction: EAST, directionType: 'input' },
+            { name: 'underground-belt', x: 2.5, y: 0.5, direction: WEST, directionType: 'input' },
+            { name: 'underground-belt', x: 4.5, y: 0.5, direction: EAST, directionType: 'output' }
+        )
+
+        expect(
+            bp.entityPositionGrid.getOpposingEntity(
+                'underground-belt',
+                EAST,
+                positionOf(bp, 1),
+                EAST,
+                MAX_DISTANCE['underground-belt']
+            )
+        ).toBeUndefined()
+    })
+
+    it('walks past a belt of a different tier', () => {
+        const bp = blueprintOf(
+            { name: 'underground-belt', x: 0.5, y: 0.5, direction: EAST, directionType: 'input' },
+            {
+                name: 'fast-underground-belt',
+                x: 2.5,
+                y: 0.5,
+                direction: WEST,
+                directionType: 'input',
+            },
+            { name: 'underground-belt', x: 4.5, y: 0.5, direction: EAST, directionType: 'output' }
+        )
+
+        expect(
+            bp.entityPositionGrid.getOpposingEntity(
+                'underground-belt',
+                EAST,
+                positionOf(bp, 1),
+                EAST,
+                MAX_DISTANCE['underground-belt']
+            )
+        ).toBe(3)
+    })
+
+    it('answers undefined when nothing of that name is in reach', () => {
+        const bp = blueprintOf({
+            name: 'underground-belt',
+            x: 0.5,
+            y: 0.5,
+            direction: EAST,
+            directionType: 'input',
+        })
+
+        expect(
+            bp.entityPositionGrid.getOpposingEntity(
+                'underground-belt',
+                EAST,
+                positionOf(bp, 1),
+                EAST,
+                MAX_DISTANCE['underground-belt']
+            )
+        ).toBeUndefined()
+    })
+})
+
+describe('getOpposingEntity for pipes to ground', () => {
+    /*
+        The same method under a different convention. A pipe-to-ground stores no
+        directionType, so its search direction is always (direction + 8) % 16,
+        and the overlay asks for a partner facing that same way - two pipes
+        whose undergrounds run towards each other. The reach is the overlay's
+        fixed 10, because the prototype carries no max_distance.
+    */
+    const findPipe = (bp: Blueprint, direction: number): number | undefined =>
+        bp.entityPositionGrid.getOpposingEntity(
+            'pipe-to-ground',
+            (direction + 8) % 16,
+            positionOf(bp, 1),
+            (direction + 8) % 16,
+            10
+        )
+
+    it('pairs an east-facing pipe with the west-facing one behind it', () => {
+        const bp = blueprintOf(
+            { name: 'pipe-to-ground', x: 0.5, y: 0.5, direction: EAST },
+            { name: 'pipe-to-ground', x: -5.5, y: 0.5, direction: WEST }
+        )
+
+        expect(findPipe(bp, EAST)).toBe(2)
+    })
+
+    it('pairs a north-facing pipe with the south-facing one below it', () => {
+        const bp = blueprintOf(
+            { name: 'pipe-to-ground', x: 0.5, y: 0.5, direction: NORTH },
+            { name: 'pipe-to-ground', x: 0.5, y: 5.5, direction: SOUTH }
+        )
+
+        expect(findPipe(bp, NORTH)).toBe(2)
+    })
+
+    it('does not pair two pipes whose undergrounds run the same way', () => {
+        const bp = blueprintOf(
+            { name: 'pipe-to-ground', x: 0.5, y: 0.5, direction: EAST },
+            { name: 'pipe-to-ground', x: -5.5, y: 0.5, direction: EAST }
+        )
+
+        expect(findPipe(bp, EAST)).toBeUndefined()
+    })
+})
+
+describe('Entity.undergroundSearchDirection', () => {
+    /*
+        The direction the hidden connection runs in, which four call sites used
+        to spell out. One of them, the overlay's "not a pair" guard, spelled it
+        `direction + (8 % 16)` - a misplaced bracket that reads as
+        `direction + 8`. That agrees with the real answer only below 8, so a
+        south-facing output gave 16 and a west-facing one 20 (#329).
+    */
+    const entityAt = (direction: number, directionType?: 'input' | 'output') =>
+        blueprintOf({
+            name: 'underground-belt',
+            x: 0.5,
+            y: 0.5,
+            direction,
+            directionType,
+        }).entities.get(1)
+
+    it('is the entity direction for an input', () => {
+        for (const dir of [NORTH, EAST, SOUTH, WEST]) {
+            expect(entityAt(dir, 'input')?.undergroundSearchDirection).toBe(dir)
+        }
+    })
+
+    it('wraps to the opposite direction for an output', () => {
+        expect(entityAt(NORTH, 'output')?.undergroundSearchDirection).toBe(SOUTH)
+        expect(entityAt(EAST, 'output')?.undergroundSearchDirection).toBe(WEST)
+        // the two the misplaced bracket got wrong: 16 and 20 rather than 0 and 4
+        expect(entityAt(SOUTH, 'output')?.undergroundSearchDirection).toBe(NORTH)
+        expect(entityAt(WEST, 'output')?.undergroundSearchDirection).toBe(EAST)
+    })
+
+    it('takes the output form when there is no direction type', () => {
+        // pipe-to-ground stores none, and every caller already treated it so
+        expect(entityAt(SOUTH)?.undergroundSearchDirection).toBe(NORTH)
+    })
+})

--- a/packages/editor/src/core/PositionGrid.ts
+++ b/packages/editor/src/core/PositionGrid.ts
@@ -725,6 +725,22 @@ export class PositionGrid {
         return entity
     }
 
+    /**
+     * The entity number of the underground partner of an entity, if it has one.
+     *
+     * Walks `searchDirection` one tile at a time out to `maxDistance`, and stops
+     * at the first entity of the same name it meets: that entity is the partner
+     * when it faces `direction`, and blocks the pair when it faces the opposite
+     * way, exactly as Factorio's own underground connections do.
+     *
+     * `searchDirection` is a 16-way direction (north 0, east 4, south 8, west
+     * 12), which is what all three callers pass. It used to be read as Factorio
+     * 1.1's 8-way scheme - `searchDirection % 4 !== 0` for a horizontal search
+     * and a negative step for 0 or 6 - and neither test survives the 16-way
+     * values: every cardinal is a multiple of 4, so an east or west underground
+     * searched along Y and could never find its partner, and 6 is not a
+     * direction at all, so west searched towards +X (issue #329).
+     */
     public getOpposingEntity(
         name: string,
         direction: number,
@@ -735,12 +751,13 @@ export class PositionGrid {
         // no reach to search along; the loop below already expressed this by not running
         if (maxDistance === undefined) return undefined
 
-        const horizontal = searchDirection % 4 !== 0
-        const sign = searchDirection === 0 || searchDirection === 6 ? -1 : 1
+        const step = util.getDirOffset(searchDirection)
+        // a diagonal has no axis to walk, so nothing can be its partner
+        if (step === undefined) return undefined
 
         for (let i = 1; i <= maxDistance; i++) {
-            const X = Math.floor(position.x) + (horizontal ? i * sign : 0)
-            const Y = Math.floor(position.y) + (horizontal ? 0 : i * sign)
+            const X = Math.floor(position.x) + step.x * i
+            const Y = Math.floor(position.y) + step.y * i
             const cell = this.grid.get(`${X},${Y}`)
 
             if (typeof cell === 'number') {


### PR DESCRIPTION
Underground belts have never paired east-west. `getOpposingEntity` searched the wrong axis for every direction, so an east or west underground could not find its partner at all.

Part of #329 (§4.1).

## The cause is a half-finished migration, not a typo

Commit `9d8b840c` ("update direction to be 0..16") moved the codebase from Factorio 1.1's 8-way directions to 16-way. In `getOpposingEntity` it changed the last two lines:

```diff
-if ((entity.direction + 4) % 8 === direction) return undefined
+if ((entity.direction + 8) % 16 === direction) return undefined
```

and left the two lines above them alone:

```ts
const horizontal = searchDirection % 4 !== 0
const sign = searchDirection === 0 || searchDirection === 6 ? -1 : 1
```

Our cardinals are N=0, E=4, S=8, W=12. Every one of them satisfies `% 4 === 0`, so `horizontal` was **always false** and an east/west underground searched down the Y axis. And `6` is not a direction in the 16-way scheme, so west got `sign = 1` and searched the wrong way as well. Only north and south worked, and they worked by accident.

This explains three separate reports in upstream issue #277: "horizontal underground belts connect vertically", "underground belts won't work horizontally", and "don't link top-to-bottom but side-to-side is fine" (that reporter had the axes inverted).

## Two more defects in the same family

Both in `OverlayContainer.ts`, both the same 8-way arithmetic left behind:

- `otherEntity.direction + (8 % 16)` - a misplaced bracket. `8 % 16` is 8, so this computes `direction + 8`, which equals the intended `(direction + 8) % 16` only below direction 8. South produced 16 and west produced 20, and no search direction is ever either value, so the "these two are not a pair" guard **silently stopped firing on half the directions** and drew a connection line between entities that are not partners. It predates the 16-way migration - it was `direction + (4 % 8)`, wrong the same way above 4.
- A second copy of the 8-way `sign` test, controlling where the line sprites and the partner cursor box are drawn.

## What changed

- `common/util.ts` - new `getDirOffset(dir)` returning the unit step for each cardinal, and `undefined` for anything else. It degrades rather than throwing the way `getDirName` does: a diagonal on an underground belt should cost one connection, not the whole blueprint.
- `core/PositionGrid.ts` - `getOpposingEntity` steps by that offset and returns `undefined` for a non-cardinal search direction.
- `core/Entity.ts` - new `undergroundSearchDirection` getter. The expression `input ? direction : (direction + 8) % 16` was written out in four places; it now lives once.
- `containers/OverlayContainer.ts` - guard, sprite positions and cursor box all use the shared helpers.

## Tests

New `packages/editor/src/core/PositionGrid.test.ts`, 24 cases: pairing on all four cardinals from both ends, the "pair on the other axis is not found" shape of the old bug, real `max_distance` boundaries per tier (5/7/9/11), a same-tier belt facing back blocking the pair, pipe-to-ground pairing, and diagonal degradation. Plus a `getDirOffset` block in `util.test.ts`.

**Negative control:** restoring the old `horizontal`/`sign` lines fails 12 of the 24 cases; the fix passes all of them. Nothing in `tests/` or any `*.test.ts` touched underground pairing before this, which is why the bug survived the migration.

```
$ vp check
pass: All 236 files are correctly formatted
pass: Found no warnings, lint errors, or type errors in 193 files

$ vp test
 Test Files  21 passed (21)
      Tests  263 passed (263)
```

Playwright was not run - headless Chromium crashes the WSL VM this was built on. CI covers it.

## Not in this PR

`PaintEntityContainer.ts` passes `(this.direction + 8) % 16` as the wanted direction while searching along `this.direction`, so painting an east-facing underground belt looks east for a west-facing belt and cannot see the input just placed behind it. That call is unchanged from upstream and predates the migration, so it is a behaviour question rather than a migration slip. Left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QS5ZtmQMHaxbbNaooudik
