### PR TITLE
Tell the user when painting fails, and layer every belt sprite

### DIFF
--- a/packages/editor/src/containers/BlueprintContainer.ts
+++ b/packages/editor/src/containers/BlueprintContainer.ts
@@ -38,6 +38,18 @@ export enum GridPattern {
     GRID = 'grid',
 }
 
+/**
+ * The item the user picked cannot be painted at all: `FD.items` has no entry
+ * for it, or it has one that places nothing (a science pack, a fluid barrel).
+ *
+ * Separate from the errors a `Paint*Container` constructor throws, which mean
+ * something different - the item *is* placeable and the editor failed to build
+ * a preview for it - and so earns a different message in `spawnPaintContainer`.
+ * A class rather than a message comparison because the messages carry the item
+ * name, and because `IllegalFlipError` next door already sets the pattern.
+ */
+export class UnplaceableItemError extends Error {}
+
 type MoveDirections = {
     up: boolean
     left: boolean
@@ -1151,14 +1163,18 @@ export class BlueprintContainer extends Container {
         try {
             if (typeof itemNameOrEntities === 'string') {
                 const itemData = FD.items[itemNameOrEntities]
-                if (!itemData) throw new Error(`Item data not found: ${itemNameOrEntities}`)
+                if (!itemData)
+                    throw new UnplaceableItemError(`Item data not found: ${itemNameOrEntities}`)
 
                 const wireResult =
                     ToolsPanel.Wires.includes(itemNameOrEntities) && itemNameOrEntities
                 const tileResult = itemData.place_as_tile && itemData.place_as_tile.result
                 const placeResult = itemData.place_result || tileResult || wireResult
 
-                if (!placeResult) throw new Error(`No place result for item: ${itemNameOrEntities}`)
+                if (!placeResult)
+                    throw new UnplaceableItemError(
+                        `No place result for item: ${itemNameOrEntities}`
+                    )
 
                 if (wireResult) {
                     this.paintContainer = this.wirePaintSlot.addChild(
@@ -1180,6 +1196,31 @@ export class BlueprintContainer extends Container {
             }
         } catch (e) {
             console.error('Failed to create paint container:', e)
+            /*
+                Without this the failure was completely silent: the console line
+                is not something a player sees, the mode drops straight back to
+                NONE, and clicking the item simply did nothing. Upstream PR #274
+                raised a toast here too, keyed off the message 'Not implemented!'
+                - a string this fork never produces, so the branch is on
+                UnplaceableItemError instead. That splits the two cases the way
+                they actually differ: an item that places nothing at all, versus
+                a placeable one whose paint preview could not be built (a missing
+                sprite field, getDirName on a diagonal, an unhandled prototype
+                shape).
+
+                `warning` rather than `error`, because nothing is broken and the
+                editor carries on. It also keeps this out of the persistent
+                class: both of the website's `timeout: Infinity` toasts are
+                `error`s that throw straight afterwards, and a mis-click must not
+                leave behind an overlay the user has to dismiss by hand.
+            */
+            G.logger({
+                text:
+                    e instanceof UnplaceableItemError
+                        ? 'Could not place this item.'
+                        : 'This entity is not supported yet.',
+                type: 'warning',
+            })
             this.setMode(EditorMode.NONE)
             this.cursor = 'inherit'
             return

--- a/packages/editor/src/containers/EntitySprite.ts
+++ b/packages/editor/src/containers/EntitySprite.ts
@@ -65,16 +65,21 @@ export class EntitySprite extends Sprite {
     private id: number
     /*
         The render layer, defaulted rather than left unset. `getParts` assigns
-        this per sprite, but its splitter/underground-belt/loader arm only does
-        so for the one sprite that is the main belt:
+        this per sprite, but its splitter/underground-belt/loader arm assigns
+        only to the belt sprites; the structure and patch sprites of those three
+        types fall out of the chain with nothing.
 
-            if (!foundMainBelt && data.filename.includes('transport-belt')) {
-
-        Every other sprite of those three types fell out with no value at all,
-        and `compareFn` then computed `undefined - undefined`, which is NaN -
-        an incoherent comparator, so their order was whatever the sort happened
-        to do. ENTITY_BASE is what the chain's own `else` gives everything not
+        They used to fall out with no value at all, and `compareFn` then
+        computed `undefined - undefined`, which is NaN - an incoherent
+        comparator, so their order was whatever the sort happened to do.
+        ENTITY_BASE is what the chain's own `else` gives everything not
         otherwise special, so it is the value they were meant to have.
+
+        Upstream PR #274 wrote it into that arm as an explicit `else` instead.
+        Measured across all 13 splitter/underground-belt/loader prototypes in
+        `data.json`, no `structure` or `structure_patch` filename contains
+        "transport-belt", so the two are the same thing and the default carries
+        it here.
     */
     private __zIndex: number = LAYER.ENTITY_BASE
     /** Overwritten by getParts for every sprite it builds; 0 is its first index. */
@@ -285,9 +290,42 @@ export class EntitySprite extends Sprite {
                 entity.type === 'underground-belt' ||
                 entity.type === 'loader'
             ) {
-                if (!foundMainBelt && data.filename.includes('transport-belt')) {
+                /*
+                    The same TRANSPORT_BELT/TRANSPORT_BELT_ABOVE pair the
+                    `transport-belt` arm above uses, and for the same sprites:
+                    all three of these draw functions build their belt art with
+                    `getBeltSprites`, which returns the main belt plus a start
+                    and/or end cap. Only the main belt was being layered, so
+                    every cap - and, on a splitter, the whole of the second
+                    lane - took the ENTITY_BASE default and sat with the
+                    machines instead of with the belts. Upstream PR #274.
+
+                    Not cosmetic. In `tests/__fixtures__/sprite-data.json` the
+                    smallest layer count any real splitter placement records is
+                    4, and a splitter is always belts + structure_patch +
+                    structure, so all 195 splitter placements in the corpus have
+                    at least 2 belt sprites and only ever had the first of them
+                    layered. That left a splitter's two lanes six layers apart
+                    while drawing the identical animation.
+
+                    It moves nothing within a splitter: every sprite of one
+                    entity shares `entityPos`, so `compareFn` falls through to
+                    `zOrder`, which is the index in the draw function's array,
+                    and the belt sprites already precede both structures there.
+                    What does move is `beltParts[1]` on an underground belt or a
+                    loader, which those two push *after* the structure and which
+                    therefore drew on top of it. Under the structure is where
+                    its own main belt already is, and where Factorio puts it.
+
+                    No committed fixture moves either way: `spriteDataDigest`
+                    hashes `getSpriteData`'s output, and `__zIndex` is assigned
+                    here, afterwards.
+                */
+                if (data.filename.includes('transport-belt')) {
+                    sprite.__zIndex = foundMainBelt
+                        ? LAYER.TRANSPORT_BELT_ABOVE
+                        : LAYER.TRANSPORT_BELT
                     foundMainBelt = true
-                    sprite.__zIndex = LAYER.TRANSPORT_BELT
                 }
             } else if (entity.type === 'pipe' || entity.type === 'infinity-pipe') {
                 sprite.__zIndex = LAYER.PIPE


### PR DESCRIPTION
Two small fixes carried over from upstream PR [teoxoy/factorio-blueprint-editor#274](https://github.com/teoxoy/factorio-blueprint-editor/pull/274), which was closed unmerged when that project was marked unmaintained. Upstream's author closed it with "this project is no longer maintained - @wormeyman might be interested in integrating this PR in his fork."

Part of #329.

Most of that PR is already here, arrived at independently: our `spawnPaintContainer` already try/catches and resets to `EditorMode.NONE`, and `EntitySprite.__zIndex` already has a default instead of being left unset. These are the two parts that were not.

## Failing to paint was silent

Our `catch` only called `console.error`. A user who clicked an item the editor cannot place saw nothing happen at all - no toast, no cursor change they could interpret, nothing.

Upstream keyed its message off an error message of `'Not implemented!'`. That string appears nowhere in this repo, so a straight port would have shipped dead code. Our catch sees three different kinds of failure instead, so this splits them with a new `UnplaceableItemError` (following the existing `IllegalFlipError` pattern) carried by our two pre-flight throws:

- `Item data not found: X` and `No place result for item: X` produce **"Could not place this item."**
- anything a `Paint*Container` constructor throws - a missing sprite field, `getDirName` on a diagonal, an unhandled prototype shape - produces **"This entity is not supported yet."**

`console.error` is kept, so the existing `editor-mode-input.spec.ts` assertion on that console line is unaffected. The toast is `type: 'warning'` deliberately: warnings never get `PERSISTENT_TOAST_CLASS`, and both `timeout: Infinity` toasts in the website are errors that throw immediately after.

## Only the first belt sprite on a splitter was layered

```ts
if (!foundMainBelt && data.filename.includes('transport-belt')) {
    foundMainBelt = true
    sprite.__zIndex = LAYER.TRANSPORT_BELT
}
```

Every later belt sprite fell through to the `ENTITY_BASE` default of 0. Three branches up, plain belts already give sprites from the *same helper* `i === 0 ? TRANSPORT_BELT : TRANSPORT_BELT_ABOVE`. So a splitter's left-lane belt sat at -6 and its right-lane belt at 0 - same animation, same entity, six layers apart.

Evidence this is reachable rather than theoretical:

- All three draw functions build belt art with `getBeltSprites`, which returns a main belt plus start and/or end caps, and `draw_splitter` calls it twice. From the `real` half of `tests/__fixtures__/sprite-data.json` the minimum layer count for any splitter placement is 4, and a splitter is always belts + `structure_patch` + `structure`, so all 195 splitter placements in the corpus carry at least two belt sprites.
- Within one splitter nothing actually moves: all sprites of an entity share `entityPos`, so `compareFn` falls through to `zOrder`, and belt sprites already precede both structures in the array.
- **One thing does move, and it is the point of the fix.** `draw_underground_belt` and `draw_loader` push the end cap *after* the structure sprites, so the cap drew on top of the ramp. It now sits under it, with its own main belt. The sprite boxes really do overlap - the underground structure sheet is 192x192 at scale 0.5 and the cap is shifted one tile.

Upstream also added an explicit `else` setting non-belt sprites to 0. That is a provable no-op here: `__zIndex` already defaults to `ENTITY_BASE`, and across all 13 splitter/underground-belt/loader prototypes in `data.json` no `structure` or `structure_patch` filename contains `transport-belt`. Left out, with a comment saying why.

**No fixture moves.** `spriteDataDigest` hashes `getSpriteData`'s output, and `__zIndex` is assigned later in `getParts` and is not among `DIGESTED_FIELDS`. No test in the repo references `zIndex`.

```
$ vp check
pass: All 235 files are correctly formatted
pass: Found no warnings, lint errors, or type errors in 192 files

$ vp test
 Test Files  20 passed (20)
      Tests  234 passed (234)
```

## What is not verified

Nobody has looked at a splitter in a browser - Playwright cannot run on the machine this was built on (headless Chromium crashes the WSL VM). The z-index reasoning is mechanism-level, from the draw functions and the committed sprite fixtures. If it is wrong the blast radius is bounded: belt art moves from the machine layer into the belt layer and nowhere else. **Worth a look at a splitter and an underground belt on the deploy preview before merging.**

Playwright risk was grepped rather than run and looks low: warning toasts are click-through in production (`.toasts-container { pointer-events: none }`), and the specs that harvest toasts never call `spawnPaintContainer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QS5ZtmQMHaxbbNaooudik
