### PR TITLE
Put the beacon supply area on the beacon, at its real 9x9

### DIFF
--- a/packages/editor/src/UI/EntityInfoPanel.ts
+++ b/packages/editor/src/UI/EntityInfoPanel.ts
@@ -1,4 +1,4 @@
-import { Container, Rectangle, Text } from 'pixi.js'
+import { Container, Text } from 'pixi.js'
 import FD, {
     getModule,
     isBeacon,
@@ -15,6 +15,7 @@ import { Entity } from '../core/Entity'
 import F from './controls/functions'
 import { Panel } from './controls/Panel'
 import { styles } from './style'
+import { suppliesEntity } from '../core/supplyArea'
 import { beltThroughput, inserterThroughput } from '../core/throughput'
 
 /*
@@ -360,25 +361,26 @@ export class EntityInfoPanel extends Panel {
         this.position.set(G.app.screen.width - this.width + 1, 0)
     }
 
+    /*
+        Which beacons reach this entity, so the panel can fold their modules into
+        the crafting speed and power figures it prints.
+
+        The geometry lives in `core/supplyArea.ts`, shared with the underlay that
+        draws the same square (#263). What stood here built the aura as
+        `Rectangle(beacon.position.x, beacon.position.y, 1, 1)` padded by
+        `supply_area_distance + 1` - 9 tiles wide, which is right, but hung off
+        the beacon's centre as though that were a top-left corner, so the whole
+        square sat half a tile south and east of the beacon. It also read
+        `FD.entities.beacon` rather than the beacon in hand, and tested four
+        corners for containment rather than testing the two footprints for
+        overlap.
+    */
     private findNearbyBeacons(entity: Entity): Entity[] {
-        const entityRect = new Rectangle(entity.position.x, entity.position.y)
-        entityRect.pad(entity.size.x / 2, entity.size.y / 2)
-
         return entity.Blueprint.entities.filter((beacon: Entity): boolean => {
-            if (beacon.type !== 'beacon') {
-                return false
-            }
+            const beaconData = beacon.entityData
+            if (!isBeacon(beaconData)) return false
 
-            const beaconAura = new Rectangle(beacon.position.x, beacon.position.y, 1, 1)
-            const beaconProto = FD.entities.beacon
-            beaconAura.pad((isBeacon(beaconProto) ? beaconProto.supply_area_distance : 0) + 1)
-
-            return (
-                beaconAura.contains(entityRect.left, entityRect.top) ||
-                beaconAura.contains(entityRect.right, entityRect.top) ||
-                beaconAura.contains(entityRect.left, entityRect.bottom) ||
-                beaconAura.contains(entityRect.right, entityRect.bottom)
-            )
+            return suppliesEntity(beaconData, beacon.position, entity.position, entity.size)
         })
     }
 }

--- a/packages/editor/src/containers/UnderlayContainer.ts
+++ b/packages/editor/src/containers/UnderlayContainer.ts
@@ -7,6 +7,7 @@ import FD, {
     isBeacon,
     isMiningDrill,
 } from '../core/factorioData'
+import { supplyAreaHalfExtent } from '../core/supplyArea'
 import { IPoint } from '../types'
 import { VisualizationArea } from './VisualizationArea'
 
@@ -65,7 +66,7 @@ export class UnderlayContainer extends Container {
             return [
                 {
                     type: 'poles',
-                    radius: ed.supply_area_distance,
+                    radius: supplyAreaHalfExtent(ed),
                     color: 0x3755d9,
                     alpha: VisualizationArea.ALPHA,
                 },
@@ -75,7 +76,7 @@ export class UnderlayContainer extends Container {
             return [
                 {
                     type: 'beacons',
-                    radius: ed.supply_area_distance + 1,
+                    radius: supplyAreaHalfExtent(ed),
                     color: 0xd9c037,
                     alpha: VisualizationArea.ALPHA,
                 },

--- a/packages/editor/src/core/supplyArea.test.ts
+++ b/packages/editor/src/core/supplyArea.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vite-plus/test'
+import {
+    BeaconPrototype,
+    ElectricPolePrototype,
+    EntityWithOwnerPrototype,
+} from 'factorio:prototype'
+import { supplyAreaBounds, supplyAreaHalfExtent, suppliesEntity } from './supplyArea'
+
+/*
+    The beacon supply area (#263, and upstream #263's twin here).
+
+    Nothing asserted either of these numbers before, which is why a beacon drew
+    an 8x8 square and reported its modules over a 9x9 one shifted half a tile
+    south and east - two different wrong answers to the same question, and both
+    of them looked exactly like right ones.
+
+    The prototype values below are the real ones out of
+    `packages/exporter/data/output/data.json`, printed from that file rather than
+    remembered. The expected areas are the game's own published figures: a
+    beacon covers 9x9, a small pole 5x5, a medium 7x7, a big 4x4 and a
+    substation 18x18.
+*/
+
+const pole = (name: string, supply_area_distance: number, box: number): ElectricPolePrototype =>
+    ({
+        type: 'electric-pole',
+        name,
+        supply_area_distance,
+        collision_box: [
+            [-box, -box],
+            [box, box],
+        ],
+    }) as unknown as ElectricPolePrototype
+
+const beacon = (supply_area_distance: number, box: number): BeaconPrototype =>
+    ({
+        type: 'beacon',
+        name: 'beacon',
+        supply_area_distance,
+        collision_box: [
+            [-box, -box],
+            [box, box],
+        ],
+    }) as unknown as BeaconPrototype
+
+/** data.json: supply_area_distance 3, collision box 2.4x2.4, so a 3x3 entity. */
+const BEACON = beacon(3, 1.2)
+
+/** data.json: 2.5 and a 0.3 box, so 1x1. */
+const SMALL_POLE = pole('small-electric-pole', 2.5, 0.15)
+/** data.json: 3.5 and a 0.3 box, so 1x1. */
+const MEDIUM_POLE = pole('medium-electric-pole', 3.5, 0.15)
+/** data.json: 2 and a 1.3 box, so 2x2. */
+const BIG_POLE = pole('big-electric-pole', 2, 0.65)
+/** data.json: 9 and a 1.4 box, so 2x2. */
+const SUBSTATION = pole('substation', 9, 0.7)
+
+/** A hypothetical even-sized beacon; no such prototype ships, but the formula must hold. */
+const EVEN_BEACON = beacon(3, 1)
+
+/**
+ * An entity's centre, given the top-left tile it occupies and its size. An
+ * odd-sized entity centres on a tile centre, an even-sized one on a tile corner.
+ */
+const centre = (leftTile: number, topTile: number, size: number): { x: number; y: number } => ({
+    x: leftTile + size / 2,
+    y: topTile + size / 2,
+})
+
+describe('supplyAreaHalfExtent', () => {
+    /*
+        The beacon is the one this fix is about. `supply_area_distance` is
+        measured out from its footprint, so 3 tiles of beacon plus 3 either side
+        is 9, and the half-extent from its centre is 4.5 - not the 4 the underlay
+        drew.
+    */
+    it('reaches 4.5 tiles from the centre of a beacon, for a 9x9 area', () => {
+        expect(supplyAreaHalfExtent(BEACON)).toBe(4.5)
+        expect(supplyAreaHalfExtent(BEACON) * 2).toBe(9)
+    })
+
+    /*
+        The pole's field means the other thing: it already IS the half-extent,
+        and the pole's own size never enters. These four are the check that the
+        beacon's formula must not be applied to a pole - it would give a small
+        pole 6x6 and a big pole 6x6, where the game gives 5x5 and 4x4.
+    */
+    it('takes an electric pole distance as the half-extent, size and all', () => {
+        expect(supplyAreaHalfExtent(SMALL_POLE) * 2).toBe(5)
+        expect(supplyAreaHalfExtent(MEDIUM_POLE) * 2).toBe(7)
+        expect(supplyAreaHalfExtent(BIG_POLE) * 2).toBe(4)
+        expect(supplyAreaHalfExtent(SUBSTATION) * 2).toBe(18)
+    })
+
+    /*
+        Odd and even differ only in where the centre sits, and the half-extent
+        carries the size term either way: 3 + 2/2 = 4 for a 2x2 beacon, an 8x8
+        area, which is 2 + 3 + 3.
+    */
+    it('carries the size term for an even-sized beacon too', () => {
+        expect(supplyAreaHalfExtent(EVEN_BEACON)).toBe(4)
+        expect(supplyAreaHalfExtent(EVEN_BEACON) * 2).toBe(8)
+    })
+
+    it('answers undefined for an entity that supplies nothing', () => {
+        const assembler = {
+            type: 'assembling-machine',
+            name: 'assembling-machine-1',
+        } as unknown as EntityWithOwnerPrototype
+        expect(supplyAreaHalfExtent(assembler)).toBeUndefined()
+    })
+})
+
+describe('supplyAreaBounds', () => {
+    /*
+        Tile spans, not just a number. A beacon on tiles 0..2 in both axes has
+        its centre at (1.5, 1.5), and the area it supplies runs from tile -3 to
+        tile 5 inclusive - left -3, right 6 as an exclusive edge.
+
+        The old panel produced left -3 and right 6 from a centre of 1.5 too, but
+        by padding a 1x1 rectangle pinned at (1.5, 1.5): left -2.5, right 6.5.
+        Same width, half a tile out.
+    */
+    it('puts a beacon on tiles 0..2 over tiles -3..5', () => {
+        const bounds = supplyAreaBounds(BEACON, centre(0, 0, 3))
+
+        expect(bounds).toEqual({ left: -3, top: -3, right: 6, bottom: 6 })
+    })
+
+    it('keeps the beacon area centred as the beacon moves', () => {
+        const bounds = supplyAreaBounds(BEACON, centre(10, 20, 3))
+
+        expect(bounds).toEqual({ left: 7, top: 17, right: 16, bottom: 26 })
+    })
+
+    it('puts a small pole on tile 0,0 over tiles -2..2', () => {
+        const bounds = supplyAreaBounds(SMALL_POLE, centre(0, 0, 1))
+
+        expect(bounds).toEqual({ left: -2, top: -2, right: 3, bottom: 3 })
+    })
+
+    it('puts a substation on tiles 0..1 over tiles -8..9', () => {
+        const bounds = supplyAreaBounds(SUBSTATION, centre(0, 0, 2))
+
+        expect(bounds).toEqual({ left: -8, top: -8, right: 10, bottom: 10 })
+    })
+
+    /*
+        The cheap cross-check on both formulas at once, and the reason to be
+        confident they are not swapped. A supply area lines up with the tile
+        grid, so every edge has to be a whole number - and it only is when each
+        prototype gets its own rule. Give a 1x1 pole the beacon's formula and its
+        edges land on x.5; give the 3x3 beacon the pole's and the same happens.
+    */
+    it('lands every real supplier on whole tile edges', () => {
+        const cases: [ElectricPolePrototype | BeaconPrototype, number][] = [
+            [BEACON, 3],
+            [SMALL_POLE, 1],
+            [MEDIUM_POLE, 1],
+            [BIG_POLE, 2],
+            [SUBSTATION, 2],
+        ]
+
+        for (const [proto, size] of cases) {
+            const bounds = supplyAreaBounds(proto, centre(0, 0, size))
+            for (const edge of [bounds.left, bounds.top, bounds.right, bounds.bottom]) {
+                expect(Number.isInteger(edge)).toBe(true)
+            }
+        }
+    })
+})
+
+describe('suppliesEntity', () => {
+    /** A beacon on tiles 0..2, so covering tiles -3..5 in both axes. */
+    const beaconCentre = centre(0, 0, 3)
+    const oneByOne = { x: 1, y: 1 }
+
+    /** A 1x1 entity sitting on the given tile. */
+    const at = (tileX: number, tileY: number): { x: number; y: number } => centre(tileX, tileY, 1)
+
+    it('reaches the last tile inside the area on every side', () => {
+        expect(suppliesEntity(BEACON, beaconCentre, at(-3, 1), oneByOne)).toBe(true)
+        expect(suppliesEntity(BEACON, beaconCentre, at(5, 1), oneByOne)).toBe(true)
+        expect(suppliesEntity(BEACON, beaconCentre, at(1, -3), oneByOne)).toBe(true)
+        expect(suppliesEntity(BEACON, beaconCentre, at(1, 5), oneByOne)).toBe(true)
+    })
+
+    /*
+        One tile further out on each side. East and south are the two the panel
+        got wrong: its aura sat half a tile that way, so tile 6 fell inside it
+        and an entity a full tile outside the beacon's reach was credited with
+        the beacon's modules. West and north it happened to get right, the half
+        tile of slack there being smaller than a tile.
+
+        They are asserted all four the same way because the west and north pair
+        is what the old corner test would have got wrong the moment the aura was
+        placed correctly: tile -4's east edge lands exactly on the aura's west
+        edge, and `Rectangle.contains` counts that touch as containment.
+    */
+    it('stops one tile past the area on every side', () => {
+        expect(suppliesEntity(BEACON, beaconCentre, at(-4, 1), oneByOne)).toBe(false)
+        expect(suppliesEntity(BEACON, beaconCentre, at(6, 1), oneByOne)).toBe(false)
+        expect(suppliesEntity(BEACON, beaconCentre, at(1, -4), oneByOne)).toBe(false)
+        expect(suppliesEntity(BEACON, beaconCentre, at(1, 6), oneByOne)).toBe(false)
+    })
+
+    it('reaches a 3x3 assembler tucked into the area corner', () => {
+        expect(suppliesEntity(BEACON, beaconCentre, centre(3, 3, 3), { x: 3, y: 3 })).toBe(true)
+        expect(suppliesEntity(BEACON, beaconCentre, centre(6, 6, 3), { x: 3, y: 3 })).toBe(false)
+    })
+
+    /*
+        The case four corners cannot see: a long entity crossing the area with
+        every corner of its own outside it. Nothing this shape supplies modules
+        today, so this pins the predicate rather than a bug anyone has hit.
+    */
+    it('reaches an entity long enough to cross the area with its corners outside', () => {
+        // Tile column 1, tile rows -7..12: every corner is outside the aura's
+        // -3..5, but the middle of it runs straight through.
+        const long = { x: 1, y: 20 }
+        expect(suppliesEntity(BEACON, beaconCentre, { x: 1.5, y: 3 }, long)).toBe(true)
+    })
+
+    it('answers false for a supplier with no supply area', () => {
+        const assembler = {
+            type: 'assembling-machine',
+            name: 'assembling-machine-1',
+        } as unknown as EntityWithOwnerPrototype
+        expect(suppliesEntity(assembler, beaconCentre, at(0, 0), oneByOne)).toBe(false)
+    })
+})

--- a/packages/editor/src/core/supplyArea.ts
+++ b/packages/editor/src/core/supplyArea.ts
@@ -1,0 +1,134 @@
+/*
+    Where an electric pole's or a beacon's supply area actually falls (#263).
+
+    Two callers need this and both had their own copy of it, both wrong for the
+    beacon in different ways: `UnderlayContainer` drew an 8x8 square where the
+    game shows 9x9, and `EntityInfoPanel` built a 9x9 rectangle but hung it off
+    the beacon's centre as though that were its top-left tile corner, so the
+    module effects it reported were shifted half a tile south and east.
+
+    The trap under both is that `supply_area_distance` does NOT mean the same
+    thing on the two prototypes that carry it, and nothing in the field name
+    says so:
+
+      - ElectricPolePrototype.supply_area_distance is the radius, half the
+        supply area's side. typed-factorio quotes the docs directly: "Corresponds
+        to *half* of the 'supply area' in the item tooltip. If this is 3.5, the
+        pole will have a 7x7 supply area." The entity's own size does not enter
+        into it.
+
+      - BeaconPrototype.supply_area_distance is measured outward from the
+        beacon's footprint, so the entity's size does enter into it. The beacon
+        is 3 tiles across with a distance of 3 and covers 9x9, which is
+        3 + 3 + 3.
+
+    So one formula cannot serve both, and the reason poles look right today is
+    not that they are small - it is that the pole branch never applied the
+    beacon's formula in the first place. Applying it would break them: a small
+    pole would read 2.5 + 0.5 = 3, a 6x6 area where the game gives 5x5, and a
+    big pole 2 + 1 = 3, a 6x6 where the game gives 4x4.
+
+    A cheap check that both readings are right: a supply area always lines up
+    with the tile grid, so a correct half-extent added to an entity's centre must
+    land on a whole number. A 1x1 pole sits at a tile centre (x.5) and its
+    distances are the half-integers 2.5 and 3.5; a 2x2 pole sits on a tile corner
+    and its distances are the integers 2 and 9; a 3x3 beacon sits at x.5 and gets
+    3 + 1.5 = 4.5. All three land on the grid, and swapping the two formulas
+    breaks every one of them. `supplyArea.test.ts` asserts exactly that.
+
+    Pure - no pixi, no FD lookups, no globals - so it is unit tested rather than
+    left to the browser suite, following throughput.ts and zoomLevels.ts.
+*/
+
+import {
+    BeaconPrototype,
+    ElectricPolePrototype,
+    EntityWithOwnerPrototype,
+} from 'factorio:prototype'
+import { IPoint } from '../types'
+import { getEntitySize, isBeacon, isElectricPole } from './factorioData'
+
+/** The two prototypes that carry `supply_area_distance`, each meaning its own thing by it. */
+type SupplyingPrototype = ElectricPolePrototype | BeaconPrototype
+
+/** A tile-grid rectangle. `right` and `bottom` are exclusive, as tile edges are. */
+export interface IArea {
+    left: number
+    top: number
+    right: number
+    bottom: number
+}
+
+/**
+ * Tiles from an entity's centre to the edge of the area it supplies, or
+ * `undefined` for an entity that supplies nothing.
+ *
+ * This is the one number both callers were getting wrong. Multiply it by two
+ * for the area's side in tiles.
+ */
+export function supplyAreaHalfExtent(e: SupplyingPrototype): number
+export function supplyAreaHalfExtent(e: EntityWithOwnerPrototype): number | undefined
+export function supplyAreaHalfExtent(e: EntityWithOwnerPrototype): number | undefined {
+    // The pole's distance already IS the half-extent - see the note above.
+    if (isElectricPole(e)) return e.supply_area_distance
+
+    if (isBeacon(e)) {
+        const size = getEntitySize(e)
+        /*
+            Measured out from the footprint, so half of it joins the distance.
+            Every supplying entity in data.json is square; `max` only decides
+            what a modded oblong beacon would get, and the larger side is the
+            side whose reach the drawn square has to cover.
+        */
+        return e.supply_area_distance + Math.max(size.x, size.y) / 2
+    }
+
+    return undefined
+}
+
+/**
+ * The tiles an entity supplies, given where it stands, or `undefined` for an
+ * entity that supplies nothing.
+ */
+export function supplyAreaBounds(e: SupplyingPrototype, position: IPoint): IArea
+export function supplyAreaBounds(e: EntityWithOwnerPrototype, position: IPoint): IArea | undefined
+export function supplyAreaBounds(e: EntityWithOwnerPrototype, position: IPoint): IArea | undefined {
+    const halfExtent = supplyAreaHalfExtent(e)
+    if (halfExtent === undefined) return undefined
+
+    return {
+        left: position.x - halfExtent,
+        top: position.y - halfExtent,
+        right: position.x + halfExtent,
+        bottom: position.y + halfExtent,
+    }
+}
+
+/**
+ * Whether a supplier standing at `position` reaches an entity of `size` centred
+ * on `targetPosition`.
+ *
+ * Overlap of the two footprints, not "is a corner of the target inside the
+ * area". Moving the aura onto the beacon's centre is not on its own enough,
+ * because the corner test would then count a neighbour whose own east or south
+ * edge merely touches the aura - `Rectangle.contains` reads its left and top
+ * edges as inclusive. It also misses an entity long enough to cross the aura
+ * with all four of its own corners outside it.
+ */
+export function suppliesEntity(
+    e: EntityWithOwnerPrototype,
+    position: IPoint,
+    targetPosition: IPoint,
+    targetSize: IPoint
+): boolean {
+    const area = supplyAreaBounds(e, position)
+    if (area === undefined) return false
+
+    const left = targetPosition.x - targetSize.x / 2
+    const right = targetPosition.x + targetSize.x / 2
+    const top = targetPosition.y - targetSize.y / 2
+    const bottom = targetPosition.y + targetSize.y / 2
+
+    // Strict, so footprints that only share an edge do not count as overlapping.
+    return left < area.right && right > area.left && top < area.bottom && bottom > area.top
+}


### PR DESCRIPTION
The beacon's supply area is drawn one tile too small and counted half a tile off centre. This is upstream issue [teoxoy/factorio-blueprint-editor#263](https://github.com/teoxoy/factorio-blueprint-editor/issues/263), and it reproduces here.

Part of #329 (§4.4).

## Ground truth

From `data.json`: the beacon has `supply_area_distance = 3` and `collision_box = [[-1.2,-1.2],[1.2,1.2]]`, so a 3x3 entity with a **9x9** supply area. Neither 2.0 nor 2.1 changed it.

## The triage's premise was half right

It said "electric poles are correct under the same formula because they are 1x1 or 2x2". They are not correct under the same formula - **they are correct because the pole branch never used the beacon's formula**. `supply_area_distance` means two different things on the two prototypes, and typed-factorio quotes the docs verbatim for the pole:

> `ElectricPolePrototype.supply_area_distance` - "Corresponds to **half** of the 'supply area' in the item tooltip. If this is 3.5, the pole will have a 7x7 supply area."

Entity size plays no part there. On `BeaconPrototype` the distance is measured outward from the footprint, so size does count.

Applying the suggested `supply_area_distance + tile_size/2` to poles would have broken all four: small pole `2.5 + 0.5` = 6x6 where the game gives 5x5, big pole `2 + 1` = 6x6 where the game gives 4x4. The proposed formula is right **for the beacon only**.

## The formula, and how it was checked

- Beacon: `halfExtent = supply_area_distance + max(width, height) / 2` → `3 + 1.5` = **4.5**, a 9x9 area.
- Pole: `halfExtent = supply_area_distance`, unchanged.

A supply area lines up with the tile grid, so `centre ± halfExtent` has to be a whole number. A 1x1 pole sits at `x.5` with distances 2.5/3.5; a 2x2 pole sits on a corner with 2/9; a 3x3 beacon sits at `x.5` and gets 4.5; a hypothetical 2x2 beacon sits on a corner and gets `3 + 1` = 4. All land on the grid. Swap the two rules and every one lands on `x.5`. That parity check is in the test suite, not just in this description.

Verified against `data.json`: beacon 3 / 3x3; small pole 2.5 / 1x1; medium 3.5 / 1x1; big 2 / 2x2; substation 9 / 2x2 - giving 5x5, 7x7, 4x4 and 18x18, matching the game's published figures. Those five are the only entities carrying the field.

## What changed

`packages/editor/src/core/supplyArea.ts` (new) is the one place the number now lives - `supplyAreaHalfExtent`, `supplyAreaBounds`, `suppliesEntity`. Pure, no pixi, no globals, following `throughput.ts` and `zoomLevels.ts`. Overloads return a plain `number` inside an `isBeacon`/`isElectricPole` guard so neither call site needs a fallback.

- **`UnderlayContainer.ts`** - both branches take their radius from the helper. Pole values are unchanged; the beacon goes 4 → 4.5, so the drawn square goes 8x8 → 9x9.
- **`EntityInfoPanel.ts`** - `findNearbyBeacons` is now one `suppliesEntity` call. Two further corrections beyond the geometry: it read `FD.entities.beacon` rather than the beacon in hand, and it tested four corners for containment instead of testing footprints for overlap.

That second one matters. **Fixing the rectangle alone would have introduced a new bug**: `Rectangle.contains` treats its left and top edges as inclusive, so a neighbour merely touching them would have been counted.

Precise old-vs-new for the panel: the shipped aura was `[cx-2.5, cx+6.5)` for a beacon at `cx=1.5`. West and north came out right by luck - half a tile of slack is less than a tile. East and south were **one tile too far**, so an entity a full tile outside the beacon's reach was credited with its modules.

## Tests

`packages/editor/src/core/supplyArea.test.ts`, 14 cases built from the real `data.json` numbers: beacon half-extent and an even-sized synthetic beacon, all four poles asserted at 5x5 / 7x7 / 4x4 / 18x18, actual tile spans rather than just "returns something", the whole-tile grid parity check across all five real suppliers, `suppliesEntity` boundaries on all four sides (last tile in true, one past false), a 3x3 assembler in the aura corner, and a 1x20 entity crossing the aura with all four corners outside.

Reverting the beacon formula to the old `+ 1` turns 4 of the 14 red.

```
$ vp check
pass: All 237 files are correctly formatted
pass: Found no warnings, lint errors, or type errors in 194 files

$ vp test
 Test Files  21 passed (21)
      Tests  248 passed (248)

$ npx tsc --noEmit -p packages/editor/tsconfig.json
0 errors
```

## Fixtures

**Nothing pinned moves.** `supply_area_distance` occurs in only those two source files. The five beacon mentions in `tests/__fixtures__/sprite-data.json` are sprite layers. `core/generators/beacon.ts` hardcodes its own 3x3 logic and never reads the field, so `generators/__fixtures__/expected-output.json` is unaffected. No spec references `UnderlayContainer` or `findNearbyBeacons`.

## Not verified

The 9x9 underlay square is checked by arithmetic here, never by eye - Playwright cannot run on the machine this was built on. Per CLAUDE.md's "drive the editor and print numbers" rule, **worth one look at a beacon on the deploy preview before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QS5ZtmQMHaxbbNaooudik
