### PR TITLE
Read a book's active_index as an inventory slot, and stop losing the blueprint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,12 @@ Key files:
   blueprints without a version. Do not treat a missing version as version zero.
 - Keep migrations conditional on the blueprint's declared version. Current
   Factorio can reuse an old prototype name.
+- A blueprint book's `active_index`, and the `index` on each of its entries,
+  are inventory **slots**, not positions in the `blueprints` array. A book with
+  empty slots exports a dense array with sparse `index` values, so
+  `blueprints[active_index]` is the wrong lookup and can be out of range
+  entirely. An active slot that holds nothing is legal and means the first
+  blueprint. Measured in the shipped binary; `Book.ts` carries the citation.
 - Entity accessors preserve the distinction between absent values and empty or
   zero values. Tests in `entity-accessors.spec.ts` pin this behavior.
 - Logistic filter writes must retain unknown sections and per-filter quality,

--- a/packages/editor/src/core/Book.test.ts
+++ b/packages/editor/src/core/Book.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { Book } from './Book'
+import { IBlueprint, IBlueprintBook, IBlueprintBookEntry } from '../types'
+
+/*
+    What `active_index` resolves to, and that resolving it never throws.
+
+    `getFlattenedActiveIndex` used to index `bps[active_index]` with no bounds
+    guard, on the assumption that `active_index` is a position in the
+    `blueprints` array. It is a slot in the book's inventory grid, and a user
+    who leaves gaps in that grid exports a dense array with sparse `index`
+    values - so `bps[active_index]` was undefined and destructuring it threw.
+    `new Book` sits on `bpString.decode`'s only path with no `try` between them,
+    so that cost the whole blueprint rather than the page hint.
+
+    These are unit tests rather than Playwright specs on purpose. Everything
+    here is arithmetic over the decoded JSON: no Factorio data, no renderer and
+    no browser is involved in choosing which blueprint a book opens on.
+    `tests/book-serialize.spec.ts` covers the same conversion from the other
+    end, through the editor.
+
+    The book shapes are the measured ones. See the citation block in Book.ts for
+    where each comes from and what it settles.
+*/
+
+/** How Factorio packs a version into the `version` field. */
+const version = (main: number, major: number, minor: number, dev = 0): number =>
+    main * 2 ** 48 + major * 2 ** 32 + minor * 2 ** 16 + dev
+
+const V_1_1 = version(1, 1, 69, 2)
+const V_2_0 = version(2, 0, 55)
+
+/*
+    A blueprint with no entities, identifiable by its label. Entity-less because
+    these tests never load Factorio data: `Blueprint`'s constructor only reaches
+    FD for entities and tiles, so a labelled empty one is safe in a node
+    environment while a populated one is not.
+*/
+const blueprint = (label: string): IBlueprint =>
+    ({ item: 'blueprint', version: V_2_0, label }) as unknown as IBlueprint
+
+const book = (
+    active_index: number,
+    blueprints: IBlueprintBookEntry[] | undefined,
+    version = V_2_0
+): IBlueprintBook => ({ item: 'blueprint-book', version, active_index, blueprints })
+
+/** The label of the blueprint the book opens on. */
+const openedLabel = (data: IBlueprintBook): string | undefined =>
+    new Book(data).selectBlueprint().name
+
+describe('Book active_index resolution', () => {
+    /*
+        The reproducing blueprint: the `Capsules` book, item 7 of the upstream
+        #277 capture, declared at 1.1.69.2. Two blueprints in slots 0 and 1 and
+        an upgrade planner in slot 5, with `active_index: 5` - so the array has
+        three elements and `bps[5]` is undefined.
+    */
+    const capsules = (): IBlueprintBook =>
+        book(
+            5,
+            [
+                { index: 0, blueprint: blueprint('distractor') },
+                { index: 1, blueprint: blueprint('destroyer') },
+                { index: 5, upgrade_planner: { item: 'upgrade-planner' } },
+            ],
+            V_1_1
+        )
+
+    it('does not throw on a sparse book whose active slot is past the array end', () => {
+        expect(() => new Book(capsules())).not.toThrow()
+    })
+
+    it('reads active_index as a slot, so slot 5 finds the upgrade planner', () => {
+        // A planner has no flattened index, so the book falls back to its first
+        // blueprint. The page hint is lost; the two blueprints are not.
+        expect(new Book(capsules()).activeIndex).toBe(0)
+        expect(openedLabel(capsules())).toBe('distractor')
+    })
+
+    it('keeps both blueprints of the sparse book reachable', () => {
+        const bk = new Book(capsules())
+        expect(bk.lastBookIndex).toBe(1)
+        expect(bk.selectBlueprint(1).name).toBe('destroyer')
+    })
+
+    /*
+        `test-blueprints/EARN/power-blocks-v22-0-8.rev-1.txt`: slots
+        [0, 1, 6, 7, 8, 9, 10, 12, 13] with `active_index: 5`, a slot inside the
+        2-5 gap that holds nothing. Factorio accepts and re-exports that, and
+        fixes it up on use with `setActiveIndexToFirstValid`, so the first
+        blueprint is the right answer.
+
+        This is the case that says the lookup is by slot rather than by array
+        position: position 5 is the entry at slot 9, four pages from where the
+        book should open.
+    */
+    it('falls back to the first blueprint when the active slot holds nothing', () => {
+        const entries = [0, 1, 6, 7, 8, 9, 10, 12, 13].map(index => ({
+            index,
+            blueprint: blueprint(`slot-${index}`),
+        }))
+        expect(new Book(book(5, entries)).activeIndex).toBe(0)
+        expect(openedLabel(book(5, entries))).toBe('slot-0')
+    })
+
+    /*
+        A nested book in `test-blueprints/EARN/earn-v22-0-12.rev-2.txt`: six
+        entries in slots 0-5 and `active_index: 8`. Same fallback, reached the
+        other way - past every entry rather than into a gap.
+    */
+    it('falls back to the first blueprint when active_index is past every slot', () => {
+        const entries = [0, 1, 2, 3, 4, 5].map(index => ({
+            index,
+            blueprint: blueprint(`slot-${index}`),
+        }))
+        expect(new Book(book(8, entries)).activeIndex).toBe(0)
+        expect(openedLabel(book(8, entries))).toBe('slot-0')
+    })
+
+    it('survives an active_index that is not a number at all', () => {
+        // The schema requires active_index, but a blueprint that fails
+        // validation is loaded anyway, so the field can arrive as anything.
+        const entries = [{ index: 0, blueprint: blueprint('only') }]
+        const missing = { item: 'blueprint-book', version: V_2_0, blueprints: entries }
+        expect(new Book(missing as unknown as IBlueprintBook).activeIndex).toBe(0)
+    })
+
+    it('survives an empty book', () => {
+        expect(new Book(book(0, [])).activeIndex).toBe(0)
+        expect(new Book(book(0, undefined)).activeIndex).toBe(0)
+        expect(new Book(book(3, [])).activeIndex).toBe(0)
+    })
+})
+
+describe('Book active_index flattening', () => {
+    /*
+        The behaviour that was already correct, kept here so the rewrite of the
+        conversion loop into `countNestedBlueprints(bps.slice(0, pos))` has to
+        prove it did not move.
+
+        Flattened index -> label, for BOOK below:
+
+          entry 0  blueprint A                                    0
+          entry 1  book        entry 0  blueprint B               1
+                               entry 1  blueprint C               2
+          entry 2  upgrade planner                                -
+          entry 3  blueprint D                                    3
+          entry 4  empty book                                     -
+          entry 5  blueprint E                                    4
+    */
+    const BOOK = (active_index: number): IBlueprintBook =>
+        book(active_index, [
+            { index: 0, blueprint: blueprint('A') },
+            {
+                index: 1,
+                blueprint_book: book(1, [
+                    { index: 0, blueprint: blueprint('B') },
+                    { index: 1, blueprint: blueprint('C') },
+                ]),
+            },
+            { index: 2, upgrade_planner: { item: 'upgrade-planner' } },
+            { index: 3, blueprint: blueprint('D') },
+            { index: 4, blueprint_book: book(0, []) },
+            { index: 5, blueprint: blueprint('E') },
+        ])
+
+    it('counts a nested book by its contents, not as one entry', () => {
+        // Entry 3 sits behind a two-blueprint book and a planner: 1 + 2 + 0.
+        expect(new Book(BOOK(3)).activeIndex).toBe(3)
+        expect(openedLabel(BOOK(3))).toBe('D')
+        expect(new Book(BOOK(5)).activeIndex).toBe(5 - 1 - 1 + 2 - 1)
+        expect(openedLabel(BOOK(5))).toBe('E')
+    })
+
+    it('descends into an active nested book, carrying its own active_index', () => {
+        // The inner book's active_index is 1, so C rather than B.
+        expect(new Book(BOOK(1)).activeIndex).toBe(2)
+        expect(openedLabel(BOOK(1))).toBe('C')
+    })
+
+    it('answers 0 for an active planner or an active empty book', () => {
+        expect(new Book(BOOK(2)).activeIndex).toBe(0)
+        expect(openedLabel(BOOK(2))).toBe('A')
+        expect(new Book(BOOK(4)).activeIndex).toBe(0)
+        expect(openedLabel(BOOK(4))).toBe('A')
+    })
+
+    it('leaves the ordinary first-entry case alone', () => {
+        expect(new Book(BOOK(0)).activeIndex).toBe(0)
+        expect(openedLabel(BOOK(0))).toBe('A')
+    })
+
+    /*
+        An entry that is neither a blueprint, a book nor a planner. The schema
+        requires only `index`, so this is a legal shape, and the loop this
+        replaced counted one blueprint for it - putting every later entry one
+        past where it lives.
+    */
+    /*
+        Reading `active_index` as a slot only stays right if the editor writes
+        one, and `Book.serialize` renumbers the top-level entries but not a
+        nested book's. Slots [0, 2, 3] is the smallest nested shape where the
+        two readings name different entries: array position 2 is the entry at
+        slot 3, and the entry at slot 2 sits one before it. Writing the position
+        there sent the next load to the wrong page.
+    */
+    it('serializes a nested selection as a slot, so it survives a round trip', () => {
+        const nested = (): IBlueprintBook =>
+            book(0, [
+                { index: 0, blueprint: blueprint('X') },
+                { index: 2, blueprint: blueprint('Y') },
+                { index: 3, blueprint: blueprint('Z') },
+            ])
+
+        const outer = book(0, [
+            { index: 0, blueprint: blueprint('A') },
+            { index: 1, blueprint_book: nested() },
+        ])
+
+        const bk = new Book(outer)
+        // Flattened 3 is Z, the last entry of the nested book.
+        expect(bk.selectBlueprint(3).name).toBe('Z')
+
+        const written = bk.serialize()
+        const innerWritten = written.blueprints?.[1].blueprint_book
+
+        expect(innerWritten?.active_index).toBe(3)
+        expect(new Book(written).activeIndex).toBe(3)
+        expect(new Book(written).selectBlueprint().name).toBe('Z')
+    })
+
+    it('does not count an entry that holds nothing', () => {
+        const entries: IBlueprintBookEntry[] = [
+            { index: 0, blueprint: blueprint('A') },
+            { index: 1 },
+            { index: 2, blueprint: blueprint('B') },
+        ]
+        expect(new Book(book(2, entries)).activeIndex).toBe(1)
+        expect(openedLabel(book(2, entries))).toBe('B')
+    })
+})

--- a/packages/editor/src/core/Book.ts
+++ b/packages/editor/src/core/Book.ts
@@ -89,32 +89,146 @@ function countNestedBlueprints(bps: IBlueprintBookEntry[] = [], includePlanners 
     }, 0)
 }
 
+/**
+ * Which entry of `bps` a book's `active_index` names, or undefined when it
+ * names none.
+ *
+ * `active_index` is an **inventory slot**, in the same numbering as the `index`
+ * each entry carries - not a position in the `blueprints` array. A user who
+ * leaves gaps in the book's grid exports a dense array with sparse `index`
+ * values, and then the two are different numbers. See the citation block above
+ * `getFlattenedActiveIndex`.
+ *
+ * Answering undefined is the ordinary case for an active slot that holds
+ * nothing, which the game accepts and writes out (again, see below). It is not
+ * defensive: two books in `test-blueprints/EARN/` have one.
+ */
+function resolveActiveEntry(bps: IBlueprintBookEntry[], active_index: number): number | undefined {
+    // `active_index` is typed as a number and is required by the schema, but a
+    // blueprint that fails validation is still loaded (see bpString.decode), so
+    // it can arrive as anything at runtime. A strict comparison covers that: no
+    // entry's `index` matches a value that is not a number.
+    const bySlot = bps.findIndex(entry => entry.index === active_index)
+    return bySlot === -1 ? undefined : bySlot
+}
+
+/*
+    A book addresses its blueprints by a flattened index - planners are skipped
+    and a nested book contributes its contents rather than itself - while
+    `active_index` names one top-level entry. This converts the second into the
+    first.
+
+    It used to read `bps[active_index]` twice with no bounds guard, which cost
+    the whole blueprint rather than the page hint:
+
+        TypeError: Cannot destructure property 'upgrade_planner' of
+        'bps[active_index]' as it is undefined.
+
+    The blueprint that found it is the `Capsules` book, item 7 of the upstream
+    #277 capture: three entries in slots 0, 1 and 5, an `active_index` of 5, and
+    so `bps[5]` undefined on a three-element array. Any book with empty slots
+    ahead of the active one can reach it, because the gaps push the active slot
+    number past the length of the array that holds it - and it takes the entire
+    load down: `new Book` is on `bpString.decode`'s only path, no `try` between
+    them.
+    Adding that capture to the corpus (draft PR #332) failed six Playwright
+    tests across three shards, all on this one root cause.
+
+    ---- What active_index indexes, and how that was settled ----
+
+    Two readings were possible - the entry's slot in the book's inventory grid,
+    or its position in the `blueprints` array - and they are the same number for
+    every book without gaps, which is almost every book. Twenty of the 37 books
+    reachable from `test-blueprints/` and that capture are sparse, and three of
+    those have a non-zero `active_index` that separates the readings. The corpus
+    alone could not close it: the slot reading fits all three, but only by
+    reading two of them as an active slot that holds nothing, and nothing in a
+    blueprint string distinguishes an emptied slot from a stale number.
+
+    Factorio's shipped documentation does not close it either. Both installs'
+    `doc-html/runtime-api.json` describe `LuaItemCommon::active_index` only as
+    "The active blueprint index for this blueprint book", and neither install
+    documents the blueprint-string format at all - no page under
+    `doc-html/auxiliary/`, nothing in `prototype-api.json`, no schema, and not
+    one blueprint book among the 89 blueprint strings in the shipped data. The
+    changelog is suggestive rather than decisive: 2.1's entry "Changed
+    LuaItemStack::active_index to return nil if the blueprint book inventory has
+    zero slots" ties the field to the inventory, and an older one, "Fixed that
+    LuaItemStack::active_index was using 0-based indexing", says the Lua
+    attribute is 1-based over a 0-based stored value.
+
+    So this went to step 3 of `tools/oracle/README.md`'s order of attack - the
+    binary - which that README still records as having been needed by nothing.
+    Both installs ship a full PDB, so `BlueprintImportExportEngine` is named,
+    and the import and export paths answer it outright. Read with `objdump -d
+    -M intel`, verified identically in `/mnt/v/factorio-2.0.77` and
+    `/mnt/v/factorio-2.1.14`.
+
+    `loadBlueprintBookFromPropertyTree` (2.1.14 at 0x14108d380, 2.0.77 at
+    0x140f5d870) reads the JSON `active_index`, compares it against the book
+    *inventory's slot count* rather than the length of anything, and stores it
+    with no remapping:
+
+        cmp    dx,WORD PTR [r14+0x98]   ; vs the book inventory's slot count
+        jae    <skip>                   ; out of range -> ignored, stays 0
+        mov    WORD PTR [r14+0x118],dx  ; otherwise stored verbatim
+
+    `saveBlueprintBookToPropertyTree` (2.1.14 at 0x1410897d0) walks inventory
+    slots, skips the empty ones - which is where the gaps in `index` come from -
+    writes each entry's `index` as that slot counter, and then writes
+    `active_index` out of the same +0x118 field with no transformation.
+    `LuaItemCommon::luaReadActiveIndex` reads that same field and adds one,
+    which is the 1-based Lua view the changelog mentions.
+
+    Two consequences the editor has to respect, both from that import path:
+
+      - An `active_index` naming an *empty* slot is legal and round-trips, since
+        the check is against capacity rather than occupancy. So the first
+        blueprint is the answer here, not a guess at an array position - which
+        an earlier draft of this fix made, and which would open
+        `test-blueprints/EARN/power-blocks-v22-0-8.rev-1.txt` (slots
+        [0, 1, 6, 7, 8, 9, 10, 12, 13], active 5) on the entry at slot 9. The
+        PDB carries `BlueprintBook::setActiveIndexToFirstValid` and
+        `BlueprintBookRecord::getIndexUpdatedToFirstValidValueIfPossible`, which
+        says the game corrects such a value rather than trusting it - that much
+        is a symbol name rather than disassembled behaviour, so read it as
+        agreeing with the fallback rather than as the source of it.
+      - An `active_index` past the inventory's capacity is dropped and the book
+        falls back to 0, which is also what happens here.
+
+    Nothing below may throw whatever the number is.
+*/
 function getFlattenedActiveIndex(bps: IBlueprintBookEntry[] = [], active_index: number): number {
-    {
-        const { upgrade_planner, deconstruction_planner, blueprint_book } = bps[active_index]
+    const pos = resolveActiveEntry(bps, active_index)
 
-        if (
-            upgrade_planner ||
-            deconstruction_planner ||
-            (blueprint_book && countNestedBlueprints(blueprint_book.blueprints) === 0)
-        ) {
-            return 0
-        }
+    // No resolvable entry: fall back to the first blueprint in the book. The
+    // page the user had open is lost; the book is not.
+    if (pos === undefined) return 0
+
+    const { upgrade_planner, deconstruction_planner, blueprint_book } = bps[pos]
+
+    // A planner and an empty nested book are not blueprints, so no flattened
+    // index names them.
+    if (
+        upgrade_planner ||
+        deconstruction_planner ||
+        (blueprint_book && countNestedBlueprints(blueprint_book.blueprints) === 0)
+    ) {
+        return 0
     }
 
-    let res = active_index
-
-    for (let i = 0; i < active_index; i++) {
-        const { upgrade_planner, deconstruction_planner, blueprint_book } = bps[i]
-
-        if (blueprint_book) {
-            res += countNestedBlueprints(blueprint_book.blueprints) - 1
-        } else if (upgrade_planner || deconstruction_planner) {
-            res -= 1
-        }
-    }
-
-    const { blueprint_book } = bps[active_index]
+    /*
+        The blueprints the earlier entries contribute, which is what the
+        flattened index counts. This was a loop that started at `active_index`
+        and corrected it per entry - `+= count - 1` for a book, `-= 1` for a
+        planner - which is the same sum written as a series of adjustments to a
+        wrong starting point, and only equal to it while the top-level index and
+        the array position are the same number. It also had no arm for an entry
+        that is neither a blueprint, a book nor a planner: the schema requires
+        only `index`, so a bare `{ index: 3 }` is legal, and each one shifted the
+        answer by one.
+    */
+    let res = countNestedBlueprints(bps.slice(0, pos))
 
     if (blueprint_book) {
         res += getFlattenedActiveIndex(blueprint_book.blueprints, blueprint_book.active_index)
@@ -179,9 +293,29 @@ function saveBlueprint(bps: IBlueprintBookEntry[] = [], index: number, bp: IBlue
             }
             i -= 1
         } else if (blueprint_book) {
-            const res = saveBlueprint(blueprint_book.blueprints, i, bp)
+            const nested = blueprint_book.blueprints ?? []
+            const res = saveBlueprint(nested, i, bp)
             if (res.saved) {
-                blueprint_book.active_index = res.index
+                /*
+                    The slot of the entry that was written, not its position in
+                    the array. `active_index` is read back as a slot (see
+                    `resolveActiveEntry`), and `Book.serialize` renumbers only
+                    the *top-level* entries to their array positions - a nested
+                    book keeps whatever sparse `index` values it was imported
+                    with.
+
+                    So a position written here names a different entry on the
+                    next load whenever some earlier entry's slot happens to
+                    equal it. Slots [0, 2, 3] and a save into the last entry is
+                    the smallest case: position 2 is the entry at slot 3, and
+                    the entry at slot 2 is the one before it.
+
+                    The top-level answer stays a position on purpose, because
+                    the renumbering makes the two the same number there. Both
+                    branches therefore mean the same thing - the slot the entry
+                    has in the book that is about to be written.
+                */
+                blueprint_book.active_index = nested[res.index].index
                 return { saved: true, index: j }
             }
             i = res.remaining

--- a/tests/book-corpus.test.ts
+++ b/tests/book-corpus.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vite-plus/test'
+import * as fs from 'fs'
+import { discoverBlueprintFiles } from './helpers/blueprint-files'
+import { decodeBlueprintString } from './helpers/encode-blueprint'
+import { Book } from '../packages/editor/src/core/Book'
+import { IBlueprintBook } from '../packages/editor/src/types'
+
+/*
+    Every book in the committed corpus, constructed.
+
+    `Book`'s constructor is the one part of the load path that reads a book's
+    own metadata rather than its entities, so it needs no Factorio data, no
+    renderer and no browser - which is why this is a vitest test next to the
+    corpus guard rather than a fourteenth Playwright spec. The synthetic shapes
+    live in `packages/editor/src/core/Book.test.ts`; this is the same question
+    asked of files a user actually exported.
+
+    The last two tests are controls. A corpus that happens to hold no book with
+    a gap ahead of its active entry would pass the first test whether `Book`
+    were fixed or not, and one with no active-but-empty slot could not tell a
+    slot lookup from an array lookup - so both shapes are asserted to be present
+    rather than assumed.
+
+    This is deliberately stricter than the load path, and the difference is
+    worth stating so nobody reads a green run here as "the corpus is safe".
+    `getFlattenedActiveIndex` descends only into the *active* nested book, so a
+    bad `active_index` on a book nobody selects is never read in production.
+    The one such book in the corpus is exactly that case: it sits at slot 4 of a
+    book whose own `active_index` is 0, so today it crashes this file and not
+    the editor. Constructing every book directly is what makes it a regression
+    guard rather than a record of which entry happened to be selected.
+*/
+
+interface CorpusBook {
+    file: string
+    /** Where in the nesting, e.g. "root/9/4". */
+    path: string
+    book: IBlueprintBook
+}
+
+/** Every book in the corpus, nested ones included. */
+function corpusBooks(): CorpusBook[] {
+    const found: CorpusBook[] = []
+
+    const walk = (book: IBlueprintBook, file: string, path: string): void => {
+        found.push({ file, path, book })
+        ;(book.blueprints ?? []).forEach((entry, i) => {
+            if (entry.blueprint_book) walk(entry.blueprint_book, file, `${path}/${i}`)
+        })
+    }
+
+    for (const { name, filePath } of discoverBlueprintFiles()) {
+        const data = decodeBlueprintString(fs.readFileSync(filePath, 'utf8').trim())
+        if (data.blueprint_book) walk(data.blueprint_book as IBlueprintBook, name, 'root')
+    }
+
+    return found
+}
+
+describe('every book in test-blueprints/', () => {
+    const books = corpusBooks()
+
+    it('finds books to check', () => {
+        // If the corpus ever stops holding books, the tests below pass by
+        // checking nothing at all.
+        expect(books.length).toBeGreaterThan(0)
+    })
+
+    it('constructs without throwing, and opens on a real blueprint', () => {
+        const failures: string[] = []
+
+        for (const { file, path, book } of books) {
+            try {
+                const bk = new Book(book)
+                // A book with no blueprints at all answers -1 here, which is
+                // legal - the corpus has none, and `lastBookIndex` is what
+                // `selectBlueprint` bounds-checks against.
+                expect(bk.activeIndex).toBeGreaterThanOrEqual(0)
+                expect(bk.activeIndex).toBeLessThanOrEqual(Math.max(bk.lastBookIndex, 0))
+            } catch (e) {
+                failures.push(`${file} ${path}: ${(e as Error).message}`)
+            }
+        }
+
+        expect(failures).toEqual([])
+    })
+
+    /*
+        The control. `getFlattenedActiveIndex` used to index the entry array
+        with `active_index` directly, so the shape that broke it is an
+        `active_index` at or past the array length - which happens because the
+        number is an inventory slot and a book with empty slots has more slots
+        than entries.
+
+        One book in the corpus has it: a book nested in
+        `EARN/earn-v22-0-12.rev-2.txt` with six entries and an `active_index` of
+        8. Asserting the count rather than "at least one" means a corpus change
+        that removes it has to be noticed rather than silently emptying this
+        file of its point.
+    */
+    it('still holds a book whose active_index is past its entry array', () => {
+        const past = books.filter(({ book }) => book.active_index >= (book.blueprints ?? []).length)
+
+        expect(past.map(({ file, path }) => `${file} ${path}`)).toEqual([
+            'EARN/earn-v22-0-12.rev-2 root/9/4',
+        ])
+    })
+
+    /*
+        The other control, for the reading rather than the crash. These are the
+        books whose `active_index` names an inventory slot that holds nothing -
+        which Factorio permits, since its import bounds-checks the number
+        against the book's slot capacity rather than against what is in it.
+
+        They are what says the lookup is by slot: for both of these the array
+        position is a perfectly good index into `blueprints` and answers a
+        different entry, so a corpus with neither could not tell the two
+        readings apart at all.
+    */
+    it('still holds books whose active_index names an empty slot', () => {
+        const empty = books.filter(
+            ({ book }) => !(book.blueprints ?? []).some(e => e.index === book.active_index)
+        )
+
+        expect(empty.map(({ file, path }) => `${file} ${path}`)).toEqual([
+            'EARN/earn-v22-0-12.rev-2 root/9/4',
+            'EARN/power-blocks-v22-0-8.rev-1 root',
+        ])
+    })
+})

--- a/tests/overlay-container.spec.ts
+++ b/tests/overlay-container.spec.ts
@@ -141,6 +141,17 @@ const EXPECTED_SYNTHETIC: Record<string, number[]> = {
  * filter icons), the combinators carry signals, and fast-inserter and splitter
  * show both states - [-1, 1] means some are configured and some are not, which
  * is the discrimination that would be lost if a branch started skipping.
+ *
+ * `boiler`, `steam-engine` and `fast-splitter` arrived with the slot fix in
+ * Book.ts. This spec renders whatever page a corpus book opens on, and
+ * EARN/power-blocks-v22-0-8.rev-1 declares active_index 5 against slots
+ * [0,1,6,7,8,9,10,12,13] - slot 5 is empty, so it now opens on page 0, a power
+ * block, rather than on array position 5. Those three names are what page 0
+ * draws.
+ *
+ * The check that this is a page change and not a branch that stopped firing:
+ * the run added three keys and removed none. A skipping branch would show up
+ * as a removal or a shortened array, never as a pure addition.
  */
 const EXPECTED_REAL: Record<string, number[]> = {
     'arithmetic-combinator': [2],
@@ -148,6 +159,7 @@ const EXPECTED_REAL: Record<string, number[]> = {
     'assembling-machine-2': [1, 3],
     'assembling-machine-3': [-1, 1, 2, 3, 4],
     biochamber: [2, 4],
+    boiler: [2],
     'buffer-chest': [1],
     'bulk-inserter': [-1, 1],
     'burner-inserter': [-1, 1],
@@ -161,6 +173,7 @@ const EXPECTED_REAL: Record<string, number[]> = {
     'electromagnetic-plant': [1, 2, 4],
     'express-splitter': [-1, 1],
     'fast-inserter': [-1, 1],
+    'fast-splitter': [-1, 1],
     foundry: [2, 4],
     'fusion-generator': [2],
     'fusion-reactor': [2],
@@ -176,6 +189,7 @@ const EXPECTED_REAL: Record<string, number[]> = {
     'rocket-silo': [1],
     splitter: [-1, 1],
     'stack-inserter': [-1, 1],
+    'steam-engine': [2],
     'steam-turbine': [2],
     'storage-chest': [1],
     'turbo-splitter': [-1, 1],


### PR DESCRIPTION
A blueprint book whose `active_index` names a slot the book does not densely fill takes down the **whole load**, not one entry:

```
TypeError: Cannot destructure property 'upgrade_planner' of 'bps[active_index]' as it is undefined.
    at getFlattenedActiveIndex (Book.ts:94)
    at new Book (Book.ts:17)
```

`getFlattenedActiveIndex` read `bps[active_index]` with no bounds guard. Same class as #286 and #288 - an unguarded read costing the entire blueprint.

Found by PR #332's first CI run: six tests failing across three shards, one cause. Part of #329.

## `active_index` is an inventory slot, not an array position

This is the part that decided the fix, so here is the evidence trail in the order `tools/oracle/README.md` prescribes.

**Reference sources first, and they do not settle it.** No Lua under `data/base` or `data/core` reads `active_index`, and the shipped data has 89 blueprint strings but **zero** books, so there is no worked example. `doc-html/runtime-api.json` in both 2.0.77 and 2.1.14 says only *"The active blueprint index for this blueprint book"*, and nothing in either install documents the blueprint-string format at all. The changelog is suggestive but not decisive: *"Changed LuaItemStack::active_index to return nil if the blueprint book inventory has zero slots"*. Our own `blueprintSchema.json` and `types.ts` type it `integer` and say nothing.

**So it went to the binary**, which the oracle README lists as step 3 and records as having been needed by nothing until now. Both installs ship a full PDB, so the symbols are named:

- `loadBlueprintBookFromPropertyTree` (2.1.14 `0x14108d380`, 2.0.77 `0x140f5d870`) validates with `cmp dx, WORD PTR [r14+0x98]` - the book **inventory's slot count**, not any array length - then `mov WORD PTR [r14+0x118], dx`, stored verbatim with no remapping.
- `saveBlueprintBookToPropertyTree` (`0x1410897d0`) walks inventory slots, skips empty ones - which is exactly where the gaps in `index` come from - writes each entry's `index` as that slot counter, and writes `active_index` from the same `+0x118` field untransformed.
- `LuaItemCommon::luaReadActiveIndex` reads `+0x118` and `inc edx`, the 1-based Lua view the changelog mentions.

Two consequences that changed the fix:

1. An `active_index` naming an **empty** slot is legal and round-trips. The game checks capacity, not occupancy.
2. One past capacity is silently dropped to 0.

No probe was needed, and none was run.

## The reproducing blueprint

From upstream #277, added to the corpus by #332:

```
blueprint_book.active_index: 5    blueprints.length: 3
  [0] index=0  blueprint
  [1] index=1  blueprint
  [2] index=5  upgrade_planner
```

The user left gaps in the book's grid, so the planner sits in slot 5. `bps[5]` is `undefined`.

## What changed

`packages/editor/src/core/Book.ts`, three changes. The comment block carries the citation, addresses and disassembly.

- **Lookup is by slot.** `resolveActiveEntry` does `bps.findIndex(entry => entry.index === active_index)`; no match falls back to the first blueprint, which is what the game does. An earlier draft fell back to the *array position* instead - the binary evidence killed it, because that opens `EARN/power-blocks-v22-0-8.rev-1` four pages from where it belongs.
- **The correction loop** became `countNestedBlueprints(bps.slice(0, pos))`. Provably the same sum for dense books, and it also stops counting an entry that holds nothing - the schema permits a bare `{ index: n }`, and each one was shifting every later entry by one.
- **`saveBlueprint` wrote an array position** into a *nested* book's `active_index`, while `Book.serialize` renumbers only the top level. Under slot semantics that names a different entry on reload. It writes the slot now. This one is required by the change, not optional.

Also adds one bullet to `CLAUDE.md`'s invariants recording the slot semantics, so the next person does not re-derive it from a disassembler.

## One real behaviour change, and it is a correction

Measured old-vs-new across all 37 books in `test-blueprints/` plus the #277 capture: **34 resolve identically**, 2 go from throwing to 0, and one changes:

`EARN/power-blocks-v22-0-8.rev-1.txt` (`active_index: 5` against slots `[0,1,6,7,8,9,10,12,13]`) now opens on flattened page 0 rather than page 4. **Page 0 is the correct answer** per the binary - slot 5 is empty in that book.

`tests/blueprint-loading.spec.ts` renders whatever page a corpus book opens on, so it is the one spec that will now see a different blueprint. Every page of that book is already rendered by `sprite-data.spec.ts`, so a new toast is unlikely - but Playwright cannot run on the machine this was built on, so **that is the thing to watch in this PR's CI run.** `position-grid.spec.ts` calls `selectBlueprint(0)` explicitly and `book-serialize.spec.ts` / `settings-pane-book-index.spec.ts` use dense synthetic books, so none of those are affected.

## Worth knowing

`new Book({ blueprints: [] })` threw the same way, and **the committed corpus already contains a book with `active_index: 8` over six entries.** It never crashed only because `getFlattenedActiveIndex` descends into the *active* nested book alone, and nothing selects that one. The bug has been latent in the corpus for as long as the corpus has existed.

## Tests

`packages/editor/src/core/Book.test.ts` - 12 vitest cases: the exact reproducing shape, an active slot inside a gap, an index past every slot, an active planner, an active nested book with its own `active_index`, an empty book and `blueprints: undefined`, a non-numeric `active_index`, the nested-selection serialize round trip, an entry holding nothing, and four preservation cases for flattening that was already correct.

`tests/book-corpus.test.ts` - constructs every book in `test-blueprints/`, nested ones included, **in vitest with no browser**, plus two controls asserting the corpus still holds the crashing shape and the empty-active-slot shape. `tests/wire-switch-completeness.test.ts` was the precedent for importing editor source into the unit project.

Mutation-checked against `HEAD`'s `Book.ts`: 7 of the 12 unit cases fail, and the corpus test reproduces the exact CI message. Reverting only the nested-slot write fails exactly the round-trip case.

```
$ vp check
pass: All 238 files are correctly formatted
pass: Found no warnings, lint errors, or type errors in 195 files

$ vp test
 Test Files  23 passed (23)
      Tests  280 passed (280)
```

**No committed fixture moves.** No `active_index` appears in any of them, and the specs that generate them walk every page with `selectBlueprint(i)` rather than reading the book's own active index. Nothing was regenerated.

#332 rebases onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QS5ZtmQMHaxbbNaooudik
