### PR TITLE
Record that removing the software-rasterizer flag makes WSL worse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,6 +285,15 @@ unaffected and can be recorded here; **`overlay-container` and
 `sprite-generation` must be recorded from CI.** Re-check this table rather than
 assuming it, because which specs touch a canvas can change.
 
+**Do not try removing `--disable-software-rasterizer` to fix those two.** It
+sits next to `--use-gl=swiftshader` and reads as a contradiction, because
+SwiftShader is the software rasterizer, so it looks like the cause of the
+`drawImage` failure. Measured on WSL2 at `ece449f5`, it is not. With that one
+flag dropped and every other flag kept, the two specs go from 2 of their 4 tests
+failing to all 4, `drawImage` disappears from the log entirely, and
+`waitForEditor` times out after 120 s because the editor never initialises. The
+flag is load-bearing in the opposite direction from the guess.
+
 Two rules the specs cannot enforce:
 
 - A green suite says nothing about how a feature feels. For anything with a


### PR DESCRIPTION
A one-paragraph addition to the "Running the browser suite under WSL2" section that #335 added, so nobody repeats an experiment that has now been run.

## Why it is worth writing down

#335 documents that `overlay-container.spec.ts` and `sprite-generation.spec.ts` fail locally under software rendering with a `drawImage` TypeError, and must be recorded from CI instead. The flag list sitting a few lines above it contains both:

```
'--use-gl=swiftshader',
'--disable-software-rasterizer',
```

Those read as a contradiction. SwiftShader **is** the software rasterizer, so the second flag looks like it is switching off the very thing the first one asks for, and therefore looks like the cause of the `drawImage` failure. It is an obvious thing to try dropping. I tried it.

## The measurement

Run on Menehune's WSL2 at `ece449f5`. Control and probe differed by that one flag and nothing else. Every other flag was kept, because dropping those is what takes the whole VM down.

| | Control, committed config | Probe, `--disable-software-rasterizer` removed |
|---|---|---|
| Tests failing | 2 of 4 | **4 of 4** |
| `drawImage` in log | 17 occurrences | 0 |
| Failure mode | the documented TypeError | `waitForEditor` times out at 120 s |

Zero `drawImage` errors reads as an improvement until you check why: the editor never initialises, so nothing reaches a canvas at all. Both `overlay-container` tests sat for the full two minutes before timing out.

So the flag is load-bearing in the opposite direction from the guess, and #335's table stands. It is now backed by a measurement rather than an assumption.

## Scope

Documentation only. One paragraph in `CLAUDE.md`, no code and no config change.

```
$ vp check
pass: All 241 files are correctly formatted
pass: Found no warnings, lint errors, or type errors in 198 files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjHSoZikZZTHXwvMRmRAqZ
