### PR TITLE
Draw the electromagnetic plant's core instead of only its shell

### DIFF
--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -1105,14 +1105,37 @@ function draw_artillery_wagon(
         return layers
     }
 }
+/**
+ * The electromagnetic plant's idle animation is only its shell - its core is a
+ * separate `working_visualisation` the draw never picked up, leaving a hole.
+ * Its one unconditional entry (`always_draw`, no `name`, no `enabled_by_name`)
+ * is that core.
+ *
+ * Only the electromagnetic plant. Other crafting machines' `always_draw`
+ * visualisations are `apply_runtime_tint` masks that read wrong without the
+ * base they tint (cryogenic-plant) or recipe-gated (`enabled_by_name`, foundry);
+ * folding those in is a wider change than fixing the hole this leaves.
+ */
+function restingCoreLayers(e: AssemblingMachinePrototype): readonly SpriteData[] {
+    if (e.name !== 'electromagnetic-plant') return []
+    const core = need(e, 'graphics_set').working_visualisations?.find(
+        wv => wv.always_draw && !wv.name && !wv.enabled_by_name && wv.animation
+    )
+    return core?.animation ? layersOf(core.animation) : []
+}
+
 function draw_assembling_machine(
     e: AssemblingMachinePrototype
 ): (data: IDrawData) => readonly SpriteData[] {
     return (data: IDrawData) => {
+        const core = restingCoreLayers(e)
         if (need(e, 'graphics_set').always_draw_idle_animation) {
-            return layersOf(need(e, 'graphics_set', 'idle_animation'))
+            return [...layersOf(need(e, 'graphics_set', 'idle_animation')), ...core]
         } else {
-            const out = [...layersOf(getAnimation(need(e, 'graphics_set', 'animation'), data.dir))]
+            const out = [
+                ...layersOf(getAnimation(need(e, 'graphics_set', 'animation'), data.dir)),
+                ...core,
+            ]
 
             const fbs = getFluidBoxes(
                 e,

--- a/tests/__fixtures__/sprite-data.json
+++ b/tests/__fixtures__/sprite-data.json
@@ -48,7 +48,7 @@
         "electric-energy-interface": ["2:cd86c7c5"],
         "electric-furnace": ["2:3723ab1a"],
         "electric-mining-drill": ["6:d8923149", "7:fff4ccce", "8:79587f6c", "8:ec214b2c"],
-        "electromagnetic-plant": ["2:8c86a981"],
+        "electromagnetic-plant": ["4:bd5246b8"],
         "elevated-curved-rail-a": ["4:48a23dfe", "4:5b56ba78", "4:8794c4a4", "4:bc5b6248"],
         "elevated-curved-rail-b": ["4:112bac66", "4:a2f12c22", "4:e2f0cd42", "4:eb1fd234"],
         "elevated-half-diagonal-rail": ["4:5b181fda", "4:873cd155"],
@@ -205,7 +205,7 @@
         "electric-energy-interface": ["2:cd86c7c5"],
         "electric-furnace": ["2:3723ab1a"],
         "electric-mining-drill": ["6:d8923149", "7:fff4ccce", "8:79587f6c", "8:ec214b2c"],
-        "electromagnetic-plant": ["2:8c86a981"],
+        "electromagnetic-plant": ["4:bd5246b8"],
         "elevated-curved-rail-a": ["4:48a23dfe", "4:5b56ba78", "4:8794c4a4", "4:bc5b6248"],
         "elevated-curved-rail-b": ["4:112bac66", "4:a2f12c22", "4:e2f0cd42", "4:eb1fd234"],
         "elevated-half-diagonal-rail": ["4:5b181fda", "4:873cd155"],
@@ -652,14 +652,14 @@
         "electric-energy-interface": ["2:cd86c7c5"],
         "electric-furnace": ["2:3723ab1a"],
         "electromagnetic-plant": [
-            "2:8c86a981",
-            "4:17441381",
-            "4:629e789d",
-            "4:ccb41809",
-            "4:ecfe1b35",
-            "5:96e66cf2",
-            "6:14404a45",
-            "6:b77425f5"
+            "4:bd5246b8",
+            "6:1898a258",
+            "6:69669f18",
+            "6:7415edc8",
+            "6:f9d9c260",
+            "7:9e7fcad5",
+            "8:101bcae8",
+            "8:8736b8f0"
         ],
         "elevated-curved-rail-a": [
             "4:42cad53b",
@@ -1171,11 +1171,11 @@
             "6:d8923149"
         ],
         "electromagnetic-plant": [
-            "2:8c86a981",
-            "2:8c86a981",
-            "2:8c86a981",
-            "2:8c86a981",
-            "2:8c86a981"
+            "4:bd5246b8",
+            "4:bd5246b8",
+            "4:bd5246b8",
+            "4:bd5246b8",
+            "4:bd5246b8"
         ],
         "elevated-curved-rail-a": [
             "4:5b56ba78",
@@ -1850,19 +1850,19 @@
         "electric-energy-interface": ["2:cd86c7c5"],
         "electric-furnace": ["2:3723ab1a"],
         "electromagnetic-plant": [
-            "2:8c86a981",
-            "3:a4f510ca",
-            "3:aaa39d9f",
-            "3:e52307e8",
-            "3:fbb88ddb",
-            "4:17441381",
-            "4:629e789d",
-            "4:ccb41809",
-            "4:ecfe1b35",
-            "5:309784dc",
-            "5:96e66cf2",
-            "5:a106069b",
-            "6:14404a45"
+            "4:bd5246b8",
+            "5:3a8241e3",
+            "5:97df3f84",
+            "5:988feaac",
+            "5:9f7d2f51",
+            "6:1898a258",
+            "6:69669f18",
+            "6:7415edc8",
+            "6:f9d9c260",
+            "7:7d139503",
+            "7:9e7fcad5",
+            "7:e15effdc",
+            "8:101bcae8"
         ],
         "elevated-curved-rail-a": [
             "4:42cad53b",


### PR DESCRIPTION
draw_assembling_machine returns idle_animation.layers for a machine with always_draw_idle_animation, and the electromagnetic plant's idle animation is only its outer shell - the rotating core is a separate working_visualisation the draw never reached, so the plant renders with a hole where the core should be.

Add back the plant's one unconditional working_visualisation (always_draw, no name, no enabled_by_name). Scoped to electromagnetic-plant by name on purpose: other crafting machines' always_draw entries are apply_runtime_tint masks that read wrong without the base they tint (cryogenic-plant) or are recipe-gated (foundry), so a general pass is a wider change than this hole.

sprite-data.json's electromagnetic-plant digests move accordingly - every one gains the two core layers (one is a shadow getParts drops).