### PR TITLE
Render the railgun turret at its diagonal facings

### DIFF
--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -996,12 +996,29 @@ function draw_ammo_turret(e: AmmoTurretPrototype): (data: IDrawData) => readonly
         duplicateAndSetPropertyUsing(layersOf(e.folded_animation)[1], 'y', 'height', data.dir / 4),
     ]
 }
+/**
+ * RotatedAnimation8Way / Sprite8Way direction keys, underscored - the shape
+ * railgun-turret's base_visualisation.animation and folded_animation use.
+ * util.getDirName8Way produces the un-underscored rail-picture keys instead,
+ * and util.getDirName throws outright on the four diagonal facings.
+ */
+const ROTATED_8WAY_KEYS = [
+    'north',
+    'north_east',
+    'east',
+    'south_east',
+    'south',
+    'south_west',
+    'west',
+    'north_west',
+] as const
+
 function draw_railgun_turret(e: AmmoTurretPrototype): (data: IDrawData) => readonly SpriteData[] {
     return (data: IDrawData) => {
-        const dirName = util.getDirName(data.dir)
-        const base = (e as any).graphics_set.base_visualisation.animation[dirName]?.layers || []
-        const folded = (e as any).folded_animation[dirName]?.layers || []
-        return [...base, ...folded]
+        const key = ROTATED_8WAY_KEYS[(data.dir >> 1) & 7]
+        const bv = need(e, 'graphics_set', 'base_visualisation')
+        const animation = (Array.isArray(bv) ? bv[0] : bv).animation
+        return [...dirLayers(animation, key), ...dirLayers(need(e, 'folded_animation'), key)]
     }
 }
 function draw_arithmetic_combinator(

--- a/tests/railgun-turret-diagonal.spec.ts
+++ b/tests/railgun-turret-diagonal.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprint as encode, packVersion as version } from './helpers/encode-blueprint'
+import { waitForEditor, loadBlueprint } from './helpers/fbe-test-api'
+
+/*
+    railgun-turret is the one turret Space Age lets you face diagonally, and its
+    base_visualisation / folded_animation are 8-way maps keyed north, north_east,
+    east ... . draw_railgun_turret indexed them with util.getDirName, which is
+    cardinals only and throws outright on 2, 6, 10 and 14 - so getSpriteData's
+    try/catch swallowed it and the four diagonal facings rendered the
+    SPRITE_GENERATION_FAILED placeholder.
+
+    sprite-data.spec.ts's own header records why nothing there caught it: its
+    DIRECTIONS are [0, 4, 8, 12], and the committed corpus only ever places a
+    railgun at direction 8. This is that gap, closed with the four facings the
+    fixture cannot carry.
+*/
+
+const DIAGONALS = [2, 6, 10, 14] as const
+
+const RAILGUNS = encode({
+    item: 'blueprint',
+    version: version(2, 0, 55),
+    entities: DIAGONALS.map((direction, i) => ({
+        entity_number: i + 1,
+        name: 'railgun-turret',
+        position: { x: i * 4, y: 0 },
+        direction,
+    })),
+})
+
+test('a railgun turret renders at every diagonal facing', async ({ page }) => {
+    const pageErrors: string[] = []
+    page.on('pageerror', e => pageErrors.push(String(e)))
+
+    await waitForEditor(page)
+    await loadBlueprint(page, RAILGUNS)
+
+    const digests = await page.evaluate(
+        () => window.__fbe_test.spriteDataTally()['railgun-turret'] ?? []
+    )
+
+    // One per placement, none the FAILED placeholder, and each facing its own
+    // 8-layer draw (3 base + 5 folded) rather than all collapsing to one.
+    expect(digests).toHaveLength(DIAGONALS.length)
+    expect(digests.filter(d => d === 'FAILED')).toEqual([])
+    expect(digests.every(d => d.startsWith('8:'))).toBe(true)
+    expect(new Set(digests).size).toBe(DIAGONALS.length)
+
+    expect(pageErrors, `page errors: ${pageErrors.join(' | ')}`).toEqual([])
+})


### PR DESCRIPTION
railgun-turret is the Space Age turret that supports all 8 directions. Its base_visualisation.animation and folded_animation use 8-way maps keyed by north, north_east, east, etc.

draw_railgun_turret was indexing those maps with util.getDirName, which only supports the cardinal directions. It throws for directions 2, 6, 10, and 14, and getSpriteData catches the error and falls back to the SPRITE_GENERATION_FAILED placeholder. As a result, the four diagonal facings were rendering the placeholder instead of the turret.

This changes the lookup to use the underscored RotatedAnimation8Way keys directly.

The existing sprite-data.spec.ts directions are cardinal-only, and the committed corpus only has a railgun at direction 8, so the bug wasn't covered by the existing tests. The new spec adds a railgun at each diagonal and verifies that each facing renders its actual sprite rather than the placeholder.