### PR TITLE
Upgrade Wrangler so the configured Worker runs locally

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,10 +116,12 @@ over exact pins.
   consequence of `lockFileMaintenance: { enabled: false }` in `renovate.json5`.
 - Before acting on a transitive advisory, read the parent's declared range: an
   exact pin means it is not actionable, a range means it is.
-- `undici` has open advisories with no in-range fix. It is blocked upstream
-  behind two exact pins (`wrangler` → `miniflare` → `undici`) and is dev-only.
-  Do not run `npm audit fix`: measured, it does not fix `undici`, it pulls
-  `miniflare` to a major alpha, and `--force` downgrades `wrangler`.
+- Upgrade Wrangler and its pinned runtime dependencies together. Wrangler
+  4.126.0 brings workerd 1.20260825.1, Miniflare 5.20260825.0-alpha, and
+  undici 7.29.0; it accepts the configured 2026-08-25 compatibility date in
+  local development (#304). This also resolves the advisory reported against
+  the previous undici 7.28.0 pin. Do not use `npm audit fix --force` or override
+  Miniflare independently; validate the Worker with `wrangler dev --local`.
 - `ajv` is ~100 kB minified and nothing branches on its result; `bpString.ts`
   logs and loads whether validation passes or fails.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,23 @@ convenience is: started by hand, Vite without `--strictPort` quietly falls back
 to 8081 and then proxies `/data` to itself, which presents as the sprite server
 failing rather than as a port clash.
 
+### Running the Worker locally
+
+To exercise the production asset routing, redirects, and `/corsproxy`, build the
+website and start the Worker from the repo root:
+
+```shell
+npm run build:website
+npm --workspace=fbeworkeyman run dev -- --local
+```
+
+Wrangler serves this at <http://localhost:8787>. The pinned Wrangler runtime
+supports the configured compatibility date; no `--compatibility-date` override
+is needed (#304). This serves the production build, so the development-only
+Playwright test hook is absent. Use `localpreview` for the existing browser suite.
+To test the legacy-host redirect locally, also pass
+`--host fbeworkeyman.wormeyman.workers.dev` to the dev command.
+
 ### Checks
 
 | Command               | What it does                                                                      |

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,91 +87,6 @@
                 }
             }
         },
-        "node_modules/@cloudflare/workerd-darwin-64": {
-            "version": "1.20260722.1",
-            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260722.1.tgz",
-            "integrity": "sha512-vZOP8vIS3NwnuaO+gz0FZ7kIGeiO3bZmxV35Ph9zOXKSREhDFlH7wQ7mkCdhW3O4jnXsew+XT7b+DNEI2CcJGQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@cloudflare/workerd-darwin-arm64": {
-            "version": "1.20260722.1",
-            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260722.1.tgz",
-            "integrity": "sha512-EmIQymihDq6WNdER4+LF8Qn80yqayBUpJ+tkOO7wmY8pmgfyXjIUFNXotl21AHovTeu2seR7HdVUgeN/BilCWw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@cloudflare/workerd-linux-64": {
-            "version": "1.20260722.1",
-            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260722.1.tgz",
-            "integrity": "sha512-jvZ3k9fxcnEn04s80CgIYxQfpOyAiz/8qC42DP8EBa9tR27qWyg9wmm31zIobVlrgBZn/+8NfdP73avRGcQOjQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@cloudflare/workerd-linux-arm64": {
-            "version": "1.20260722.1",
-            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260722.1.tgz",
-            "integrity": "sha512-BOSB55SMNdy+DA5uj2WirgiNanpHGis5PVvXH1wSfvjRKr4JGgWK+EZzxz0RFUo6QjjQQC/NimEzNZ7va7jmKg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@cloudflare/workerd-windows-64": {
-            "version": "1.20260722.1",
-            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260722.1.tgz",
-            "integrity": "sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=16"
-            }
-        },
         "node_modules/@cspotcode/source-map-support": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -2132,9 +2047,9 @@
             }
         },
         "node_modules/@speed-highlight/core": {
-            "version": "1.2.17",
-            "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
-            "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+            "version": "1.2.24",
+            "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+            "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
             "dev": true,
             "license": "CC0-1.0"
         },
@@ -4923,49 +4838,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/miniflare": {
-            "version": "4.20260722.1",
-            "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260722.1.tgz",
-            "integrity": "sha512-FJIg4omaCb2wwSyOeRosEdmVRi3JzGAOOH3pa3twmmtvWECl6BVZMIDwJbjByLKRyU+mrfk0M/n3oSiojFZvSA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@cspotcode/source-map-support": "0.8.1",
-                "sharp": "0.35.2",
-                "undici": "7.28.0",
-                "workerd": "1.20260722.1",
-                "ws": "8.21.0",
-                "youch": "4.1.0-beta.10"
-            },
-            "bin": {
-                "miniflare": "bootstrap.js"
-            },
-            "engines": {
-                "node": ">=22.0.0"
-            }
-        },
-        "node_modules/miniflare/node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": ">=5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/minimatch": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -6073,9 +5945,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6480,78 +6352,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/workerd": {
-            "version": "1.20260722.1",
-            "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260722.1.tgz",
-            "integrity": "sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "workerd": "bin/workerd"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "optionalDependencies": {
-                "@cloudflare/workerd-darwin-64": "1.20260722.1",
-                "@cloudflare/workerd-darwin-arm64": "1.20260722.1",
-                "@cloudflare/workerd-linux-64": "1.20260722.1",
-                "@cloudflare/workerd-linux-arm64": "1.20260722.1",
-                "@cloudflare/workerd-windows-64": "1.20260722.1"
-            }
-        },
-        "node_modules/wrangler": {
-            "version": "4.115.0",
-            "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.115.0.tgz",
-            "integrity": "sha512-+upG2VW66M1sjb43yzgUZ6Ss8iYpJ6+7F3U4GF8TY5EYd+08sYdS54d24AEwCnhuef3J9KlSPusqiqR9WYy1UA==",
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "dependencies": {
-                "@cloudflare/kv-asset-handler": "0.5.0",
-                "@cloudflare/unenv-preset": "2.16.1",
-                "blake3-wasm": "2.1.5",
-                "esbuild": "0.28.1",
-                "miniflare": "4.20260722.1",
-                "path-to-regexp": "6.3.0",
-                "unenv": "2.0.0-rc.24",
-                "workerd": "1.20260722.1"
-            },
-            "bin": {
-                "cf-wrangler": "bin/cf-wrangler.js",
-                "wrangler": "bin/wrangler.js",
-                "wrangler2": "bin/wrangler.js"
-            },
-            "engines": {
-                "node": ">=22.0.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "2.3.3"
-            },
-            "peerDependencies": {
-                "@cloudflare/workers-types": "^5.20260722.1"
-            },
-            "peerDependenciesMeta": {
-                "@cloudflare/workers-types": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/wrangler/node_modules/fsevents": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
         "node_modules/wrap-ansi": {
             "version": "9.0.2",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
@@ -6787,7 +6587,204 @@
             "version": "0.0.1",
             "devDependencies": {
                 "typescript": "^7.0.2",
-                "wrangler": "^4.115.0"
+                "wrangler": "^4.126.0"
+            }
+        },
+        "packages/worker/node_modules/@cloudflare/workerd-darwin-64": {
+            "version": "1.20260825.1",
+            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260825.1.tgz",
+            "integrity": "sha512-oHu38dwaUuzAilyTb0QkQ1YxU/kzqzIQybCvQKAhiK1CGtQS9h0MmjIZYogv3g8cFGGY2k+Wxs0wV9hHK8z78g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/worker/node_modules/@cloudflare/workerd-darwin-arm64": {
+            "version": "1.20260825.1",
+            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260825.1.tgz",
+            "integrity": "sha512-ak5zh8YGEjxQQ78bVo7gzU+tcg2fSFxMIjOPZtWk56a/rIYLbGu6ECcliqnYfMUlragg68H0JuVpfdr3BR5Alw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/worker/node_modules/@cloudflare/workerd-linux-64": {
+            "version": "1.20260825.1",
+            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260825.1.tgz",
+            "integrity": "sha512-bNQvzz6NemWAwixDRz1fQa5T+E5lS4xpB7A/H/72ULxrjVpHmq8CGFPSbdmRp3dvgBjZTgp7wHdGLISLSVd9Gg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/worker/node_modules/@cloudflare/workerd-linux-arm64": {
+            "version": "1.20260825.1",
+            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260825.1.tgz",
+            "integrity": "sha512-a5E61YsnNCHHQMnmYsbVXInzeYqFqAMwm/wo16dWW4klXDr6T1bm7u1h5G7ZkxVM7+rtc69oe0yVHjDEqzpYVg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/worker/node_modules/@cloudflare/workerd-windows-64": {
+            "version": "1.20260825.1",
+            "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260825.1.tgz",
+            "integrity": "sha512-EokzVY2suzRSzeURi2HpHnySR5mo6aF5V1klFIqFOZp2YJyXXTI8AvQgYzhlmGTZY3LNL41jjkUQunOM2OErgQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "packages/worker/node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "packages/worker/node_modules/miniflare": {
+            "version": "5.20260825.0-alpha",
+            "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260825.0-alpha.tgz",
+            "integrity": "sha512-ZwlF6LuX43ilx9EwMRDKHenoGXiNdcKSyGx5aPaJhuozujVZasb2lRR7t3ojJZSnVzwDPsBBYCu8lLnc+/KIgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@cspotcode/source-map-support": "0.8.1",
+                "sharp": "0.35.2",
+                "undici": "7.29.0",
+                "workerd": "1.20260825.1",
+                "ws": "8.21.0",
+                "youch": "4.1.0-beta.10"
+            },
+            "engines": {
+                "node": ">=22.0.0"
+            }
+        },
+        "packages/worker/node_modules/workerd": {
+            "version": "1.20260825.1",
+            "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260825.1.tgz",
+            "integrity": "sha512-ccS6TEaaRxgONKawiYGnFYUVGfr2pmN1b7mrNtw0ADVhFaYsEIVoCHnQ4UjhM9EJDzuaNgAWFY82nzVrjWpuOA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "workerd": "bin/workerd"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "optionalDependencies": {
+                "@cloudflare/workerd-darwin-64": "1.20260825.1",
+                "@cloudflare/workerd-darwin-arm64": "1.20260825.1",
+                "@cloudflare/workerd-linux-64": "1.20260825.1",
+                "@cloudflare/workerd-linux-arm64": "1.20260825.1",
+                "@cloudflare/workerd-windows-64": "1.20260825.1"
+            }
+        },
+        "packages/worker/node_modules/wrangler": {
+            "version": "4.126.0",
+            "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.126.0.tgz",
+            "integrity": "sha512-glDq/nxaeQwue0XMIeupfwlu2jVxnFs+wjDFT71DQuURN5LsVdCwu0Af/1ep10U5xr1rKPGhHDEDkKG9nxE/dg==",
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "dependencies": {
+                "@cloudflare/kv-asset-handler": "0.5.0",
+                "@cloudflare/unenv-preset": "2.16.1",
+                "blake3-wasm": "2.1.5",
+                "esbuild": "0.28.1",
+                "miniflare": "5.20260825.0-alpha",
+                "path-to-regexp": "6.3.0",
+                "unenv": "2.0.0-rc.24",
+                "workerd": "1.20260825.1"
+            },
+            "bin": {
+                "cf-wrangler": "bin/cf-wrangler.js",
+                "wrangler": "bin/wrangler.js",
+                "wrangler2": "bin/wrangler.js"
+            },
+            "engines": {
+                "node": ">=22.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.3"
+            },
+            "peerDependencies": {
+                "@cloudflare/workers-types": "^5.20260825.1"
+            },
+            "peerDependenciesMeta": {
+                "@cloudflare/workers-types": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/worker/node_modules/ws": {
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         }
     }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -10,6 +10,6 @@
     },
     "devDependencies": {
         "typescript": "^7.0.2",
-        "wrangler": "^4.115.0"
+        "wrangler": "^4.126.0"
     }
 }


### PR DESCRIPTION
`wrangler dev` could not start because its bundled runtime was older than the configured `2026-08-25` compatibility date. Upgrade Wrangler from 4.115.0 to 4.126.0, whose pinned workerd 1.20260825.1 accepts that date, and document the local production-build workflow in CONTRIBUTING.

The dependency update also brings Wrangler's pinned Miniflare 5.20260825.0-alpha and undici 7.29.0. No independent transitive overrides are used. Refresh the development guide's obsolete advisory note; npm audit now reports zero vulnerabilities. The production compatibility date, routing, observability, and CPU limit are unchanged.

Validation:

- `vp check --fix`: no format, lint, or type errors.
- `vp test`: 294 tests passed across 24 files.
- `npm run build:website`: passed.
- `wrangler dev --local`: reached ready with the configured compatibility date, without a date override. Root HTML, JavaScript, source map, and sprite requests returned 200; `/corsproxy` without a URL returned 400.
- Local dev with `--host fbeworkeyman.wormeyman.workers.dev`: `/?source=example` returned 301 to `https://fbe.factorygamefan.com/?source=example`.
- `wrangler deploy --dry-run`: passed, 7.07 KiB Worker upload. No production deployment was performed.

Closes #304. Addresses local Worker validation in #352. Source-map policy and executable-bundle checks are handled in #323; the cost check in #312 remains scheduled for September 7.
