### PR TITLE
Isolate exporter profiles and verify encoder repeatability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
       - name: Build
         run: cargo build --locked --manifest-path packages/exporter/Cargo.toml
 
+      - name: Test
+        run: cargo test --locked --manifest-path packages/exporter/Cargo.toml
+
       - name: Format
         if: ${{ !cancelled() }}
         run: cargo fmt --check --manifest-path packages/exporter/Cargo.toml
@@ -191,6 +194,9 @@ jobs:
 
       - name: Build
         run: cargo build --locked --manifest-path packages/exporter/Cargo.toml
+
+      - name: Test
+        run: cargo test --locked --manifest-path packages/exporter/Cargo.toml
 
   e2e:
     name: Playwright ${{ matrix.shard }}/${{ strategy.job-total }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,13 +169,26 @@ set `FACTORIO_DIR` in `packages/exporter/.env`:
 FACTORIO_DIR=/path/to/your/factorio/installation
 ```
 
-| Platform        | Example path                                                               |
-| --------------- | -------------------------------------------------------------------------- |
-| macOS (Steam)   | `/Users/<you>/Library/Application Support/Steam/steamapps/common/Factorio` |
-| Linux (Steam)   | `~/.steam/steam/steamapps/common/Factorio`                                 |
-| Windows (Steam) | `C:\Program Files (x86)\Steam\steamapps\common\Factorio`                   |
+| Platform         | Example path                                                               |
+| ---------------- | -------------------------------------------------------------------------- |
+| macOS (Steam)    | `/Users/<you>/Library/Application Support/Steam/steamapps/common/Factorio` |
+| macOS (download) | `/Users/<you>/Downloads/factorio_space_age_mac_2_0_77.app`                 |
+| Linux (Steam)    | `~/.steam/steam/steamapps/common/Factorio`                                 |
+| Windows (Steam)  | `C:\Program Files (x86)\Steam\steamapps\common\Factorio`                   |
 
 When `FACTORIO_DIR` is set, `FACTORIO_USERNAME` and `FACTORIO_TOKEN` are not needed.
+
+Each extraction uses a fresh temporary config, write-data directory and mod
+directory. It enables only the installed official modules (`base`, `quality`,
+`elevated-rails`, `space-age`) plus the export mod; it does not use your normal
+profile or its mod settings. Sprite padding writes separate scratch images,
+not the installation's PNGs. Temporary profiles, logs and padded images are
+retained at the printed paths; move them to Trash when finished inspecting them.
+
+Before regenerating committed data, follow the
+[exporter validation and dataset review checklist](packages/exporter/README.md).
+In particular, a game-version update is not a reason to re-record oracle
+fixtures wholesale.
 
 ### Option B: Download base game data (no DLC support)
 

--- a/packages/exporter/README.md
+++ b/packages/exporter/README.md
@@ -1,0 +1,81 @@
+# Exporter validation and dataset review
+
+See [CONTRIBUTING](../../CONTRIBUTING.md#regenerating-the-sprite-data-optional)
+for installation and invocation. `FACTORIO_DIR` selects the installed version;
+the download fallback still targets the version in `src/main.rs`. Accepting a
+2.1 installation does not mean the editor or export schema is 2.1-ready.
+
+## Isolation checks (no Factorio required)
+
+```shell
+cargo test --locked --manifest-path packages/exporter/Cargo.toml
+cargo fmt --check --manifest-path packages/exporter/Cargo.toml
+```
+
+Linux and Windows CI run the tests. Unix additionally runs fake executable
+tests that check the launch arguments, working directory, intentional nonzero
+exit, missing fresh dump and invalid JSON. These are not a real-game smoke test.
+Test workspaces are retained under the system temporary directory with the
+`fbe-export-test-` and `fbe-export-` prefixes.
+
+Every extraction passes explicit `--config` and `--mod-directory` paths, uses
+a fresh write-data directory, and accepts only that run's JSON dump. Installed
+official DLC is enabled explicitly; user mods, saves and mod settings are not
+copied. The temporary export mod derives its game series from `base/info.json`
+and loads after the installed DLC. The installation is read-only during local
+extraction, including when sprites need power-of-two padding. The download
+fallback's existing installation/cache management is separate from this local
+extraction guarantee.
+
+## Encoder repeatability probe
+
+From the repository root, on macOS ARM64 (the bundled encoder's platform):
+
+```shell
+node tools/check-basisu-determinism.mjs packages/website/public/favicon.png .github/preview.png
+```
+
+The probe runs the bundled `basisu` with the exporter's `-no_multithreading
+-mipmap` flags, encodes each image twice using different input and output paths,
+compares bytes, checks that the source is unchanged, and prints SHA-256 hashes.
+It retains outputs at the printed temporary path for inspection.
+
+Measured on 2026-09-05 with the bundled basisu v1.16.4:
+
+| Input | Output bytes | Identical across paths | Output SHA-256 |
+| --- | ---: | --- | --- |
+| `packages/website/public/favicon.png` | 6583 | yes | `5bd7f95dd6e1328f3fed0742a3c9784ad3b00299570c0dd39e38c31ea98ded9a` |
+| `.github/preview.png` | 295367 | yes | `b735ea3fb3079c1ce1f1e23dd848eff69a4f8b6a8a3cc0ae2d349014930c92d1` |
+
+This establishes repeatability for these samples only. It does not establish
+cross-platform/compiler repeatability or equivalence of every Factorio sprite.
+The probe encodes the supplied PNG directly; exporter padding is covered by the
+Rust tests. Repeat with representative sprites from the intended installation
+(and retained padded images) before relying on it for a dataset refresh.
+
+## Before committing a regenerated dataset
+
+1. Start with an unmodified installation of the intended game version and DLC.
+   Run the encoder probe on representative source and padded sprites. Keep the
+   hashes, encoder version and platform in the PR evidence.
+2. Smoke-test extraction with that real installation. Inspect the printed
+   temporary profile's `mods/mod-list.json`, `config.ini`, `factorio-current.log`
+   (under write-data) and `factorio-output.log`. Confirm the expected version and
+   enabled mods, and that the normal profile and installation remain unchanged.
+3. Review `data/output/data.json` separately from sprite changes. The current
+   metadata cache keys include absolute paths, sizes and mtimes, so a different
+   installation path can trigger recompression even when pixels are unchanged.
+   Do not commit local absolute-path metadata churn as a game-data change.
+4. Triage each changed oracle expectation against the game's output. Distinguish
+   genuine version changes from exporter or editor bugs; never bulk re-record
+   fixtures to make the suite green. Follow [the oracle guide](../../tools/oracle/README.md).
+5. Run `vp check`, `vp test` and the affected browser/oracle coverage. Keep a
+   data-only refresh separate from exporter changes and justify any sprite diff
+   with source/output evidence.
+
+The [2.0.77 refresh (#155)](https://github.com/FactoryGameFan/factorio-blueprint-editor/issues/155)
+and [2.1 migration (#187)](https://github.com/FactoryGameFan/factorio-blueprint-editor/issues/187)
+remain separate efforts. The latter also requires the stable-release and type
+metadata prerequisites tracked there. This work addresses their shared
+[exporter blockers (#351)](https://github.com/FactoryGameFan/factorio-blueprint-editor/issues/351);
+it does not regenerate data, change fixtures, or bump the game/type versions.

--- a/packages/exporter/src/setup.rs
+++ b/packages/exporter/src/setup.rs
@@ -25,14 +25,18 @@ lazy_static! {
         Regex::new(r"^__(.+?)__/").unwrap();
 }
 
-/// Returns the path to the Factorio executable given the install root.
-/// - macOS: {dir}/factorio.app/Contents/MacOS/factorio
-/// - Linux: {dir}/bin/x64/factorio
-/// - Windows: {dir}\bin\x64\factorio.exe
+/// Accept a Steam install root or a directly selected .app bundle.
+fn macos_bundle_path(factorio_dir: &Path) -> PathBuf {
+    if factorio_dir.extension().is_some_and(|ext| ext == "app") {
+        factorio_dir.to_path_buf()
+    } else {
+        factorio_dir.join("factorio.app")
+    }
+}
+
 pub fn local_executable_path(factorio_dir: &Path) -> PathBuf {
     match std::env::consts::OS {
-        "macos" => factorio_dir
-            .join("factorio.app")
+        "macos" => macos_bundle_path(factorio_dir)
             .join("Contents")
             .join("MacOS")
             .join("factorio"),
@@ -48,37 +52,32 @@ pub fn local_executable_path(factorio_dir: &Path) -> PathBuf {
 /// - Windows: {dir}\data
 pub fn local_game_data_path(factorio_dir: &Path) -> PathBuf {
     match std::env::consts::OS {
-        "macos" => factorio_dir
-            .join("factorio.app")
+        "macos" => macos_bundle_path(factorio_dir)
             .join("Contents")
             .join("data"),
         _ => factorio_dir.join("data"),
     }
 }
 
-/// Returns the Factorio user data directory (where mods/ and script-output/ live).
-/// - macOS: ~/Library/Application Support/factorio
-/// - Linux: ~/.factorio
-/// - Windows: %APPDATA%\Factorio
-pub fn user_data_dir() -> Result<PathBuf, Box<dyn Error>> {
-    match std::env::consts::OS {
-        "macos" | "linux" => {
-            let home = get_env_var!("HOME")?;
-            let path = match std::env::consts::OS {
-                "macos" => PathBuf::from(home)
-                    .join("Library")
-                    .join("Application Support")
-                    .join("factorio"),
-                _ => PathBuf::from(home).join(".factorio"),
-            };
-            Ok(path)
+/// Atomically reserve a fresh workspace. Keep it for inspection on success and
+/// failure; callers print the location so it can be moved to Trash afterwards.
+fn new_work_dir(parent: &Path, prefix: &str) -> std::io::Result<PathBuf> {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    for attempt in 0..100 {
+        let path = parent.join(format!("{prefix}-{}-{stamp}-{attempt}", std::process::id()));
+        match std::fs::create_dir(&path) {
+            Ok(()) => return Ok(path),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(e),
         }
-        "windows" => {
-            let appdata = get_env_var!("APPDATA")?;
-            Ok(PathBuf::from(appdata).join("Factorio"))
-        }
-        os => Err(format!("unsupported OS: {}", os).into()),
     }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        "could not reserve export workspace",
+    ))
 }
 
 /// Validates that FACTORIO_DIR points to a usable Factorio installation.
@@ -126,6 +125,10 @@ async fn get_info(path: &Path) -> Result<Info, Box<dyn Error>> {
     Ok(p)
 }
 
+#[cfg(test)]
+#[path = "setup_tests.rs"]
+mod tests;
+
 #[allow(clippy::needless_lifetimes)]
 async fn make_img_pow2<'a>(
     path: &'a Path,
@@ -152,8 +155,9 @@ async fn make_img_pow2<'a>(
         let mut buffer = std::io::Cursor::new(buffer);
         out.write_to(&mut buffer, format)?;
 
-        let tmp_path = tmp_dir.join(path);
-        tokio::fs::create_dir_all(tmp_path.parent().unwrap()).await?;
+        // An absolute path would discard tmp_dir and overwrite the original.
+        // Separate directories also prevent collisions between equal basenames.
+        let tmp_path = new_work_dir(tmp_dir, "image")?.join("padded.png");
         tokio::fs::write(&tmp_path, &buffer.into_inner()).await?;
         Ok(Cow::Owned(tmp_path))
     } else {
@@ -266,8 +270,8 @@ async fn compress_sprites(
     );
 
     let file_paths = Arc::new(Mutex::new(file_paths));
-    let tmp_dir = std::env::temp_dir().join("__FBE__");
-    tokio::fs::create_dir_all(&tmp_dir).await?;
+    let tmp_dir = new_work_dir(&std::env::temp_dir(), "fbe-sprites")?;
+    println!("Sprite scratch files retained at {}", tmp_dir.display());
     let available_parallelism =
         std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
 
@@ -285,108 +289,150 @@ async fn compress_sprites(
     let new_metadata = serde_json::to_vec(&*new_metadata.lock().unwrap())?;
     tokio::fs::write(metadata_path, new_metadata).await?;
     progress.finish();
-    tokio::fs::remove_dir_all(&tmp_dir).await?;
     Ok(())
 }
 
 pub async fn extract(output_dir: &Path, base_factorio_dir: &Path) -> Result<(), Box<dyn Error>> {
-    let factorio_data = base_factorio_dir.join("data");
-    let mod_dir = base_factorio_dir.join("mods/export-data");
+    extract_local(output_dir, base_factorio_dir).await
+}
+
+struct ExportWorkspace {
+    root: PathBuf,
+    mods: PathBuf,
+    config: PathBuf,
+    dump: PathBuf,
+}
+
+fn config_path(path: &Path) -> Result<String, Box<dyn Error>> {
+    let path = path.to_str().ok_or("Factorio config paths must be UTF-8")?;
+    if path.contains(['\r', '\n']) {
+        return Err("Factorio config paths cannot contain newlines".into());
+    }
+    // Windows canonicalize() produces verbatim paths; Factorio's INI expects
+    // ordinary drive/UNC paths rather than the \\?\ prefix.
+    let path = if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+        format!("//{rest}")
+    } else {
+        path.strip_prefix(r"\\?\").unwrap_or(path).to_string()
+    };
+    Ok(path.replace('\\', "/"))
+}
+
+async fn prepare_export(factorio_data: &Path) -> Result<ExportWorkspace, Box<dyn Error>> {
+    let factorio_data = tokio::fs::canonicalize(factorio_data).await?;
+    let version = get_info(&factorio_data.join("base/info.json"))
+        .await?
+        .version;
+    let series = version.split('.').take(2).collect::<Vec<_>>().join(".");
+    let root = new_work_dir(&std::env::temp_dir(), "fbe-export")?;
+    println!("Export profile and logs retained at {}", root.display());
+    let mods = root.join("mods");
+    let write_data = root.join("write-data");
+    let config = root.join("config.ini");
+    let mod_dir = mods.join("export-data");
     let scenario_dir = mod_dir.join("scenarios/export-data");
-    let extracted_data_path = base_factorio_dir.join("script-output/data.json");
-    let factorio_executable = base_factorio_dir.join("bin/x64/factorio");
-
-    let info = include_str!("export-data/info.json");
-    let script = include_str!("export-data/control.lua");
-    let data = include_str!("export-data/data-final-fixes.lua");
-    let locale = generate_locale(&factorio_data).await?;
-
     tokio::fs::create_dir_all(&scenario_dir).await?;
-    tokio::fs::write(mod_dir.join("info.json"), info).await?;
-    tokio::fs::write(mod_dir.join("locale.lua"), locale).await?;
-    tokio::fs::write(mod_dir.join("data-final-fixes.lua"), data).await?;
-    tokio::fs::write(scenario_dir.join("control.lua"), script).await?;
+    tokio::fs::create_dir_all(&write_data).await?;
 
-    println!("Generating defines.lua");
+    // Load only shipped vanilla/Space Age modules. Nothing is copied from the
+    // real profile, including its mod list, settings, saves, or credentials.
+    let mut mod_list = Vec::new();
+    let mut dependencies = vec!["base >= 2.0.0".to_string()];
+    for name in ["base", "quality", "elevated-rails", "space-age"] {
+        if factorio_data.join(name).join("info.json").is_file() {
+            mod_list.push(serde_json::json!({ "name": name, "enabled": true }));
+            if name != "base" {
+                // Run our data-final-fixes after the enabled DLC modules.
+                dependencies.push(format!("? {name}"));
+            }
+        }
+    }
+    mod_list.push(serde_json::json!({ "name": "export-data", "enabled": true }));
+    tokio::fs::write(
+        mods.join("mod-list.json"),
+        serde_json::to_vec(&serde_json::json!({ "mods": mod_list }))?,
+    )
+    .await?;
+    let mut info: serde_json::Value = serde_json::from_str(include_str!("export-data/info.json"))?;
+    info["factorio_version"] = series.into();
+    info["dependencies"] = serde_json::to_value(dependencies)?;
+    tokio::fs::write(mod_dir.join("info.json"), serde_json::to_vec(&info)?).await?;
+    tokio::fs::write(
+        mod_dir.join("locale.lua"),
+        generate_locale(&factorio_data).await?,
+    )
+    .await?;
+    tokio::fs::write(
+        mod_dir.join("data-final-fixes.lua"),
+        include_str!("export-data/data-final-fixes.lua"),
+    )
+    .await?;
+    tokio::fs::write(
+        scenario_dir.join("control.lua"),
+        include_str!("export-data/control.lua"),
+    )
+    .await?;
 
-    Command::new(factorio_executable)
+    // Absolute paths work for macOS bundles, Linux's bin/x64 layout and Windows.
+    tokio::fs::write(
+        &config,
+        format!(
+            "[path]\nread-data={}\nwrite-data={}\n[general]\n[other]\n",
+            config_path(&factorio_data)?,
+            config_path(&write_data)?
+        ),
+    )
+    .await?;
+    Ok(ExportWorkspace {
+        dump: write_data.join("script-output/data.json"),
+        root,
+        mods,
+        config,
+    })
+}
+
+async fn run_factorio_export(
+    factorio_executable: &Path,
+    work: &ExportWorkspace,
+) -> Result<String, Box<dyn Error>> {
+    println!("Running Factorio to generate data...");
+    let log_path = work.root.join("factorio-output.log");
+    let log = std::fs::File::create(&log_path)?;
+    let status = Command::new(tokio::fs::canonicalize(factorio_executable).await?)
+        .current_dir(&work.root)
+        .arg("--config")
+        .arg(&work.config)
+        .arg("--mod-directory")
+        .arg(&work.mods)
         .args(["--start-server-load-scenario", "export-data/export-data"])
-        .stdout(std::process::Stdio::null())
+        .stdout(log.try_clone()?)
+        .stderr(log)
+        .kill_on_drop(true)
         .spawn()?
         .wait()
         .await?;
 
-    let content = tokio::fs::read_to_string(&extracted_data_path).await?;
-    tokio::fs::create_dir_all(&output_dir).await?;
-    tokio::fs::write(output_dir.join("data.json"), &content).await?;
-
-    compress_sprites(output_dir, &factorio_data, &content).await?;
-    println!("DONE!");
-
-    Ok(())
+    // control.lua deliberately errors after writing the dump. A nonzero exit
+    // is expected; only a fresh, valid dump from this run is accepted.
+    let content = tokio::fs::read_to_string(&work.dump).await.map_err(|e| {
+        format!(
+            "Factorio produced no readable dump at {} ({status}): {e}. See {}",
+            work.dump.display(),
+            log_path.display()
+        )
+    })?;
+    serde_json::from_str::<serde_json::Value>(&content)?;
+    Ok(content)
 }
 
 pub async fn extract_local(output_dir: &Path, factorio_dir: &Path) -> Result<(), Box<dyn Error>> {
     let factorio_executable = local_executable_path(factorio_dir);
     let factorio_data = local_game_data_path(factorio_dir);
-    let user_data = user_data_dir()?;
-
-    let mod_dir = user_data.join("mods").join("export-data");
-    let scenario_dir = mod_dir.join("scenarios").join("export-data");
-    let extracted_data_path = user_data.join("script-output").join("data.json");
-
-    let info = include_str!("export-data/info.json");
-    let script = include_str!("export-data/control.lua");
-    let data = include_str!("export-data/data-final-fixes.lua");
-    let locale = generate_locale(&factorio_data).await?;
-
-    // Write export-data mod files
-    tokio::fs::create_dir_all(&mod_dir).await.map_err(|e| {
-        format!(
-            "Failed to write to mods directory \"{}\": {}. \
-             Check that the directory is writable.",
-            mod_dir.display(),
-            e
-        )
-    })?;
-    tokio::fs::create_dir_all(&scenario_dir).await?;
-
-    tokio::fs::write(mod_dir.join("info.json"), info).await?;
-    tokio::fs::write(mod_dir.join("locale.lua"), locale).await?;
-    tokio::fs::write(mod_dir.join("data-final-fixes.lua"), data).await?;
-    tokio::fs::write(scenario_dir.join("control.lua"), script).await?;
-
-    println!("Running Factorio to generate data...");
-
-    Command::new(&factorio_executable)
-        .args(["--start-server-load-scenario", "export-data/export-data"])
-        .stdout(std::process::Stdio::null())
-        .spawn()?
-        .wait()
-        .await?;
-
-    let content = tokio::fs::read_to_string(&extracted_data_path).await?;
-    tokio::fs::create_dir_all(&output_dir).await?;
+    let work = prepare_export(&factorio_data).await?;
+    let content = run_factorio_export(&factorio_executable, &work).await?;
+    tokio::fs::create_dir_all(output_dir).await?;
     tokio::fs::write(output_dir.join("data.json"), &content).await?;
-
     compress_sprites(output_dir, &factorio_data, &content).await?;
-
-    // Clean up export-data mod and scenario from user data dir
-    if let Err(e) = tokio::fs::remove_dir_all(&mod_dir).await {
-        eprintln!(
-            "Warning: failed to clean up mod directory \"{}\": {}",
-            mod_dir.display(),
-            e
-        );
-    }
-    if let Err(e) = tokio::fs::remove_dir_all(&scenario_dir).await {
-        eprintln!(
-            "Warning: failed to clean up scenario directory \"{}\": {}",
-            scenario_dir.display(),
-            e
-        );
-    }
-
     println!("DONE!");
     Ok(())
 }

--- a/packages/exporter/src/setup_tests.rs
+++ b/packages/exporter/src/setup_tests.rs
@@ -1,0 +1,238 @@
+use super::*;
+
+fn fixture_dir() -> PathBuf {
+    new_work_dir(&std::env::temp_dir(), "fbe-export-test").unwrap()
+}
+
+fn fake_game(mods: &[&str], version: &str) -> PathBuf {
+    let data = fixture_dir().join("game data");
+    for name in mods {
+        let dir = data.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("info.json"),
+            serde_json::to_vec(&serde_json::json!({ "name": name, "version": version })).unwrap(),
+        )
+        .unwrap();
+    }
+    data
+}
+
+fn read_json(path: &Path) -> serde_json::Value {
+    serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap()
+}
+
+#[tokio::test]
+async fn isolated_profile_enables_only_installed_official_mods() {
+    let data = fake_game(
+        &[
+            "base",
+            "quality",
+            "elevated-rails",
+            "space-age",
+            "foreign-mod",
+        ],
+        "2.0.77",
+    );
+    let work = prepare_export(&data).await.unwrap();
+    let second = prepare_export(&data).await.unwrap();
+    assert_ne!(work.root, second.root);
+    assert!(!work.dump.exists());
+    let config = std::fs::read_to_string(&work.config).unwrap();
+    assert!(config.contains(&format!(
+        "read-data={}",
+        config_path(&data.canonicalize().unwrap()).unwrap()
+    )));
+    assert!(config.contains(&format!(
+        "write-data={}",
+        config_path(&work.root.join("write-data")).unwrap()
+    )));
+    assert_eq!(
+        read_json(&work.mods.join("mod-list.json")),
+        serde_json::json!({
+            "mods": [
+                { "name": "base", "enabled": true },
+                { "name": "quality", "enabled": true },
+                { "name": "elevated-rails", "enabled": true },
+                { "name": "space-age", "enabled": true },
+                { "name": "export-data", "enabled": true }
+            ]
+        })
+    );
+    let info = read_json(&work.mods.join("export-data/info.json"));
+    assert_eq!(info["factorio_version"], "2.0");
+    assert_eq!(
+        info["dependencies"],
+        serde_json::json!([
+            "base >= 2.0.0",
+            "? quality",
+            "? elevated-rails",
+            "? space-age"
+        ])
+    );
+    assert!(work
+        .mods
+        .join("export-data/scenarios/export-data/control.lua")
+        .is_file());
+    assert!(!data.join("mods").exists());
+    assert!(!data.join("script-output").exists());
+}
+
+#[test]
+fn config_paths_handle_windows_canonical_paths_and_reject_newlines() {
+    for (input, expected) in [
+        (
+            r"\\?\C:\Program Files\Factorio\data",
+            "C:/Program Files/Factorio/data",
+        ),
+        (r"\\?\UNC\server\share\data", "//server/share/data"),
+        (r"C:\Factorio\data", "C:/Factorio/data"),
+        (
+            "/Applications/Factorio.app/Contents/data",
+            "/Applications/Factorio.app/Contents/data",
+        ),
+    ] {
+        assert_eq!(config_path(Path::new(input)).unwrap(), expected);
+    }
+    assert!(config_path(Path::new("/data\nwrite-data=/profile")).is_err());
+    assert!(config_path(Path::new("/data\rwrite-data=/profile")).is_err());
+}
+
+#[tokio::test]
+async fn base_only_install_does_not_enable_missing_dlc_and_uses_installed_series() {
+    let work = prepare_export(&fake_game(&["base"], "2.1.12"))
+        .await
+        .unwrap();
+    let info = read_json(&work.mods.join("export-data/info.json"));
+    assert_eq!(info["factorio_version"], "2.1");
+    assert_eq!(info["dependencies"], serde_json::json!(["base >= 2.0.0"]));
+    assert_eq!(
+        read_json(&work.mods.join("mod-list.json"))["mods"],
+        serde_json::json!([
+            { "name": "base", "enabled": true }, { "name": "export-data", "enabled": true }
+        ])
+    );
+}
+
+#[test]
+fn accepts_direct_macos_bundles_and_steam_install_roots() {
+    let bundle = Path::new("/downloads/factorio_space_age_mac_2_0_77.app");
+    assert_eq!(macos_bundle_path(bundle), bundle);
+    assert_eq!(
+        macos_bundle_path(Path::new("/steam/Factorio")),
+        Path::new("/steam/Factorio/factorio.app")
+    );
+    #[cfg(target_os = "macos")]
+    {
+        assert_eq!(
+            local_executable_path(bundle),
+            bundle.join("Contents/MacOS/factorio")
+        );
+        assert_eq!(local_game_data_path(bundle), bundle.join("Contents/data"));
+    }
+}
+
+#[tokio::test]
+async fn padding_preserves_source_pngs_and_separates_matching_basenames() {
+    let root = fixture_dir();
+    let scratch = root.join("scratch");
+    std::fs::create_dir(&scratch).unwrap();
+    let mut outputs = Vec::new();
+    for (name, color) in [("base", [255, 0, 0, 255]), ("quality", [0, 255, 0, 255])] {
+        let dir = root.join(name);
+        std::fs::create_dir(&dir).unwrap();
+        let source = dir.join("same.png");
+        image::RgbaImage::from_pixel(3, 5, image::Rgba(color))
+            .save(&source)
+            .unwrap();
+        let before = std::fs::read(&source).unwrap();
+        let output = make_img_pow2(&source, &scratch).await.unwrap().into_owned();
+        assert!(output.starts_with(&scratch));
+        assert_ne!(output, source);
+        assert_eq!(std::fs::read(&source).unwrap(), before);
+        let padded = image::open(&output).unwrap().into_rgba8();
+        assert_eq!(padded.dimensions(), (4, 8));
+        assert_eq!(padded.get_pixel(2, 4), &image::Rgba(color));
+        assert_eq!(padded.get_pixel(3, 7), &image::Rgba([0, 0, 0, 0]));
+        outputs.push(output);
+    }
+    assert_ne!(outputs[0], outputs[1]);
+}
+
+#[tokio::test]
+async fn power_of_two_image_is_borrowed_without_rewriting() {
+    let root = fixture_dir();
+    let source = root.join("sprite.png");
+    image::RgbaImage::new(4, 8).save(&source).unwrap();
+    let before = std::fs::read(&source).unwrap();
+    assert!(matches!(
+        make_img_pow2(&source, &root).await.unwrap(),
+        Cow::Borrowed(_)
+    ));
+    assert_eq!(std::fs::read(&source).unwrap(), before);
+}
+
+#[cfg(unix)]
+fn fake_factorio(body: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let executable = fixture_dir().join("fake factorio");
+    std::fs::write(&executable, format!("#!/bin/sh\n{body}\n")).unwrap();
+    std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o700)).unwrap();
+    executable
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn invokes_factorio_in_isolation_and_accepts_its_deliberate_error_exit() {
+    let work = prepare_export(&fake_game(&["base"], "2.0.77"))
+        .await
+        .unwrap();
+    let executable = fake_factorio(
+        "printf '%s\\n' \"$@\" > args.txt\nmkdir -p write-data/script-output\nprintf '{\"entities\":{}}' > write-data/script-output/data.json\nexit 1"
+    );
+    let content = run_factorio_export(&executable, &work).await.unwrap();
+    assert_eq!(content, "{\"entities\":{}}");
+    let args = std::fs::read_to_string(work.root.join("args.txt")).unwrap();
+    assert_eq!(
+        args.lines().collect::<Vec<_>>(),
+        vec![
+            "--config",
+            work.config.to_str().unwrap(),
+            "--mod-directory",
+            work.mods.to_str().unwrap(),
+            "--start-server-load-scenario",
+            "export-data/export-data"
+        ]
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn missing_dump_cannot_reuse_a_previous_runs_output() {
+    let data = fake_game(&["base"], "2.0.77");
+    let previous = prepare_export(&data).await.unwrap();
+    std::fs::create_dir_all(previous.dump.parent().unwrap()).unwrap();
+    std::fs::write(&previous.dump, "{\"old\":true}").unwrap();
+    let work = prepare_export(&data).await.unwrap();
+    let error = run_factorio_export(&fake_factorio("exit 0"), &work)
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("no readable dump"));
+    assert!(error.to_string().contains("factorio-output.log"));
+    assert_eq!(
+        std::fs::read_to_string(previous.dump).unwrap(),
+        "{\"old\":true}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn rejects_an_invalid_dump_even_when_factorio_exits_successfully() {
+    let work = prepare_export(&fake_game(&["base"], "2.0.77"))
+        .await
+        .unwrap();
+    let executable = fake_factorio(
+        "mkdir -p write-data/script-output\nprintf 'not json' > write-data/script-output/data.json\nexit 0"
+    );
+    assert!(run_factorio_export(&executable, &work).await.is_err());
+}

--- a/tools/check-basisu-determinism.mjs
+++ b/tools/check-basisu-determinism.mjs
@@ -1,0 +1,51 @@
+import { createHash } from 'node:crypto'
+import { copyFileSync, mkdtempSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath, URL } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+// Uses the exporter's encoding flags and a byte-identical copy at another path
+// for the second run. Outputs are retained; source images are never written.
+const inputs = process.argv.slice(2)
+if (inputs.length === 0) {
+    throw new Error('Usage: node tools/check-basisu-determinism.mjs <image.png> [more.png ...]')
+}
+const encoder = fileURLToPath(new URL('../packages/exporter/basisu', import.meta.url))
+const work = mkdtempSync(join(tmpdir(), 'fbe-basis-determinism-'))
+console.log('Encoder: ' + encoder + '\nOutputs retained at ' + work)
+const sha256 = bytes => createHash('sha256').update(bytes).digest('hex')
+
+for (const [index, input] of inputs.entries()) {
+    const source = resolve(input)
+    const before = readFileSync(source)
+    const copied = join(work, index + '-copied.png')
+    copyFileSync(source, copied)
+    const outputs = [source, copied].map((png, run) => {
+        const output = join(work, index + '-' + run + '.basis')
+        const result = spawnSync(
+            encoder,
+            ['-no_multithreading', '-mipmap', '-file', png, '-output_file', output],
+            { encoding: 'utf8' }
+        )
+        if (result.error || result.status !== 0) {
+            throw new Error('basisu failed: ' + result.stderr + '\n' + result.stdout, {
+                cause: result.error,
+            })
+        }
+        return readFileSync(output)
+    })
+    if (!before.equals(readFileSync(source))) throw new Error('Input changed: ' + source)
+    if (outputs[0].length === 0 || !outputs[0].equals(outputs[1])) {
+        throw new Error('Outputs differ or are empty: ' + source)
+    }
+    console.log(
+        JSON.stringify({
+            input,
+            inputSha256: sha256(before),
+            outputBytes: outputs[0].length,
+            outputSha256: sha256(outputs[0]),
+            identicalAcrossInputPaths: true,
+        })
+    )
+}


### PR DESCRIPTION
## Summary

Addresses the shared exporter prerequisites in #351, ahead of the separate #155 refresh and #187 migration.

- Run local and downloaded installations through one isolated extraction path: fresh config, write-data and mod directories; explicit official-module allowlist; no normal-profile reads/writes.
- Derive the temporary export mod's game series from the installed base metadata and load it after installed DLC.
- Accept directly downloaded macOS .app bundles as well as Steam install roots; normalize Windows canonical paths for config.ini.
- Fix power-of-two padding overwriting original PNGs when an absolute source path discarded the scratch directory. Give same-named sprites separate scratch paths.
- Add nine Rust regressions and run cargo test in both Linux and native Windows CI.
- Add a repeatable basisu byte-comparison probe and document measured results plus the entry-by-entry dataset/fixture review checklist.

Temporary profiles, logs and padded images are retained for inspection, with paths printed. No generated data, fixtures, game version or typed-factorio version changes.

## Validation

- cargo test --locked --manifest-path packages/exporter/Cargo.toml: 9 passed on macOS.
- cargo fmt --check: passed.
- cargo clippy --locked --manifest-path packages/exporter/Cargo.toml --all-targets: only the two pre-existing macOS download-path warnings documented by CI; no suppressions added. Linux retains its -D warnings gate.
- vp check --fix: passed.
- vp test: 294 passed in 24 files.
- Bundled basisu v1.16.4, macOS ARM64, exporter flags: favicon and preview PNGs each encoded twice using distinct input/output paths; byte-identical outputs and unchanged inputs. Output sizes 6,583 and 295,367 bytes; full hashes are in packages/exporter/README.md.

Unix fake-process tests verify actual launch arguments/current directory, acceptance of the deliberate error exit, rejection of missing fresh output and rejection of invalid JSON. Cross-platform tests cover workspace/mod isolation, Windows config paths, bundle paths, and source PNG preservation.

## Remaining validation / scope

No Factorio installation was available locally, so these are not real-game smoke-test results. Before regenerating data, run the documented isolation smoke test with the intended clean installation and repeat encoding on representative game sprites/padded inputs. Two sample images are not proof of whole-dataset or cross-toolchain determinism.

Keep #351 open as the coordination issue: #155 still requires data regeneration and individual fixture triage; #187 remains a separate migration with its stable-release/type-metadata prerequisites. No fixtures were bulk re-recorded.
