### PR TITLE
Add persistent multi-entity selection, drag-to-move, and in-place mirror

### DIFF
--- a/packages/editor/src/Editor.ts
+++ b/packages/editor/src/Editor.ts
@@ -188,12 +188,49 @@ export class Editor {
 
     /**
      * The interaction mode the canvas is in, by name - NONE, EDIT, PAINT, PAN,
-     * COPY or DELETE. Exposed for tests/editor-mode-input.spec.ts, which is the
-     * first spec to drive real pointer and keyboard input (issue #44); the name
-     * rather than the enum member so a test does not have to import it.
+     * COPY, DELETE, SELECT or MOVE. Exposed for tests/editor-mode-input.spec.ts,
+     * which is the first spec to drive real pointer and keyboard input (issue
+     * #44); the name rather than the enum member so a test does not have to
+     * import it.
      */
     public get mode(): string {
         return EditorMode[G.BPC.mode]
+    }
+
+    /**
+     * The entity numbers in the persistent selection, in insertion order. The
+     * only way a spec can see what an Alt-drag swept, since the selection is
+     * not a mode - `mode` reads NONE once the drag is released. See
+     * tests/persistent-selection.spec.ts.
+     */
+    public get selectedEntityNumbers(): number[] {
+        return G.BPC.selectedEntityNumbers
+    }
+
+    /** Whether the entity's selection box is tinted as blocked. See tests/persistent-selection.spec.ts. */
+    public selectionHighlightBlocked(entityNumber: number): boolean {
+        return G.BPC.selectionHighlightBlocked(entityNumber)
+    }
+
+    /**
+     * Whether the entity-info overlay (the AltLeft toggle) is showing. Needed
+     * to prove a tap of Alt still toggles it while an Alt-drag selection does
+     * not - see `BlueprintContainer.consumeAltUsedForDrag`. See
+     * tests/persistent-selection.spec.ts.
+     */
+    public get infoOverlayVisible(): boolean {
+        return G.BPC.infoOverlayVisible
+    }
+
+    /**
+     * `History.revision`. A group move or mirror has to be *one* undo step, and
+     * counting transactions is the only way a spec can tell one from two - the
+     * end state of the entities is the same either way. See
+     * tests/persistent-selection.spec.ts, and `revision`'s own doc comment for
+     * what this number does and does not promise.
+     */
+    public get historyRevision(): number {
+        return G.bp.history.revision
     }
 
     /**
@@ -515,6 +552,19 @@ export class Editor {
                     onRelease: () => G.BPC.exitDeleteMode(),
                 },
             },
+            // any -> SELECT; the swept entities stay selected after release
+            selectGroup: {
+                trigger: {
+                    button: MouseButton.Left,
+                },
+                modifiers: {
+                    alt: true,
+                },
+                callbacks: {
+                    onPress: () => G.BPC.enterSelectMode(),
+                    onRelease: () => G.BPC.exitSelectMode(),
+                },
+            },
 
             moveUp: {
                 trigger: {
@@ -552,14 +602,22 @@ export class Editor {
                     onRelease: () => G.BPC.moveEnd('right'),
                 },
             },
+            // A tap of Alt shows the overlay; holding it to Alt-drag a
+            // selection (selectGroup, below) must not also toggle it. Both
+            // bind plain AltLeft with no way to tell them apart at press time
+            // - `enterSelectMode` cannot know yet whether this Alt is headed
+            // for a drag - so the toggle itself waits for the key-up, and is
+            // skipped exactly when a selection sweep happened in between.
             showInfo: {
                 trigger: {
                     code: 'AltLeft',
                 },
                 callbacks: {
-                    onPress: () => {
-                        G.BPC.overlayContainer.toggleEntityInfoVisibility()
-                        return true
+                    onPress: () => true,
+                    onRelease: () => {
+                        if (!G.BPC.consumeAltUsedForDrag()) {
+                            G.BPC.overlayContainer.toggleEntityInfoVisibility()
+                        }
                     },
                 },
             },
@@ -569,7 +627,12 @@ export class Editor {
                 },
                 callbacks: {
                     onPress: () => {
-                        Dialog.closeLast()
+                        // A dialog is on top of the canvas, so it goes first.
+                        if (Dialog.anyOpen()) {
+                            Dialog.closeLast()
+                        } else {
+                            G.BPC.escape()
+                        }
                         return true
                     },
                 },

--- a/packages/editor/src/containers/BlueprintContainer.ts
+++ b/packages/editor/src/containers/BlueprintContainer.ts
@@ -15,6 +15,8 @@ import { Tile } from '../core/Tile'
 import { Entity } from '../core/Entity'
 import { Blueprint } from '../core/Blueprint'
 import { IConnection } from '../core/WireConnections'
+import { GroupRelocation } from '../core/PositionGrid'
+import U from '../core/generators/util'
 import { stepZoom, WheelZoom } from '../core/zoomLevels'
 import { IPoint } from '../types'
 import { Dialog } from '../UI/controls/Dialog'
@@ -70,7 +72,14 @@ export enum EditorMode {
     COPY,
     /** Active when selecting multiple entities for deletion */
     DELETE,
+    /** Active while Alt+dragging the rectangle that becomes the persistent selection */
+    SELECT,
+    /** Active while dragging the persistent selection to a new place */
+    MOVE,
 }
+
+/** The live rectangle's colour in SELECT mode - not copy's green nor delete's red. */
+const SELECT_AREA_COLOR = 0x3399ff
 
 export class BlueprintContainer extends Container {
     private static _moveSpeed = 10
@@ -174,6 +183,42 @@ export class BlueprintContainer extends Container {
     private copyModeUpdateFn: ((endX: number, endY: number) => void) | undefined
     private deleteModeUpdateFn: ((endX: number, endY: number) => void) | undefined
     private copySettingsActive = false
+
+    /*
+        The persistent selection: what an Alt-drag swept, kept past the mouse-up
+        so it can be dragged somewhere else or mirrored. The only entity list
+        here that outlives a gesture - copyModeEntities and deleteModeEntities
+        above are emptied on the way out of their modes.
+    */
+    private readonly selectedEntities = new Set<Entity>()
+    /*
+        Set the moment an Alt-drag actually starts a selection sweep, and read
+        (and cleared) once, on the matching AltLeft key-up - see
+        `consumeAltUsedForDrag`. What lets `showInfo` (also bound to plain
+        AltLeft) tell a tap of Alt from an Alt held to select: it defers its
+        toggle to the key-up and skips it exactly when this is true.
+    */
+    private altUsedForDrag = false
+    /*
+        Per member, the function that detaches the listeners keeping it
+        selected: the ones that move its box when it moves and drop it from the
+        set when it is destroyed by anything else - a delete drag, a mine. Every
+        way out of the selection goes through deselect(), which runs and forgets
+        this.
+    */
+    private readonly selectionListeners = new Map<Entity, () => void>()
+    /* The SELECT-mode pair, same shape and lifetime as the copy/delete ones above. */
+    private selectModeEntities: Entity[] = []
+    private selectModeUpdateFn: ((endX: number, endY: number) => void) | undefined
+    /*
+        Present only during a MOVE drag. `moved` flips on the first tile
+        crossed, and is what separates a drag from a click on a selected
+        entity: a click still opens the entity's editor, as it does anywhere.
+    */
+    private moveDrag:
+        | { entities: Entity[]; pressed: Entity; delta: IPoint; moved: boolean }
+        | undefined
+    private moveDragUpdateFn: ((endX: number, endY: number) => void) | undefined
 
     // PIXI properties
     public readonly eventMode = 'static'
@@ -287,6 +332,15 @@ export class BlueprintContainer extends Container {
                 this.viewport.translateBy(e.movement.x, e.movement.y)
             },
             panStart: (): boolean => {
+                /*
+                    First, because it cannot be a sibling action: `pan` is the
+                    first plain-Left, zero-modifier action registered, and
+                    ActionRegistry tries equal-modifier actions in registration
+                    order and stops at the first that answers true - which this
+                    does for every press in NONE. A "drag the selection" action
+                    registered anywhere else would never be reached.
+                */
+                if (this.enterMoveMode()) return true
                 if (this.mode === EditorMode.NONE) {
                     this.cursor = 'move'
                     this.setMode(EditorMode.PAN)
@@ -296,6 +350,10 @@ export class BlueprintContainer extends Container {
                 return false
             },
             panEnd: (): void => {
+                if (this.mode === EditorMode.MOVE) {
+                    this.exitMoveMode()
+                    return
+                }
                 if (this.mode === EditorMode.PAN) {
                     this.off('globalpointermove', panModule._onPan)
                     this.setMode(EditorMode.NONE)
@@ -404,6 +462,11 @@ export class BlueprintContainer extends Container {
 
         let remove = false
         this.mineStart = (): boolean => {
+            // A right-click mid-drag puts the selection back where it was.
+            if (this.mode === EditorMode.MOVE) {
+                this.exitMoveMode(true)
+                return true
+            }
             remove = true
             this.gridData.on('update32', mine)
             mine()
@@ -557,6 +620,17 @@ export class BlueprintContainer extends Container {
         this.on('destroyed', () => {
             this.removeEventListener('pointerdown', onPointerDown)
             G.actions.releaseAll()
+            /*
+                Detach only. The entities outlive this container (a blueprint
+                swap never destroys the outgoing one's entities, see
+                EntityContainer) and the overlay is already gone, so there are
+                no boxes left to hide - only listeners left to unhook.
+            */
+            for (const detach of this.selectionListeners.values()) {
+                detach()
+            }
+            this.selectionListeners.clear()
+            this.selectedEntities.clear()
         })
     }
 
@@ -657,6 +731,13 @@ export class BlueprintContainer extends Container {
     }
 
     public flip(vertical: boolean): void {
+        if (
+            (this.mode === EditorMode.NONE || this.mode === EditorMode.EDIT) &&
+            this.selectedEntities.size !== 0
+        ) {
+            this.mirrorSelection(vertical)
+            return
+        }
         if (this.mode === EditorMode.PAINT && this.painting.canFlipOrRotateByCopying()) {
             try {
                 const copies = this.painting.flippedEntities(vertical)
@@ -688,6 +769,9 @@ export class BlueprintContainer extends Container {
         }
         this.exitCopyMode(true)
         this.exitDeleteMode(true)
+        this.exitSelectMode(true)
+        // Q is a second way out of a selection, alongside Escape.
+        this.clearSelection()
     }
 
     public moveEntity(offset: IPoint) {
@@ -812,6 +896,397 @@ export class BlueprintContainer extends Container {
         }
 
         this.deleteModeEntities = []
+    }
+
+    // Persistent selection --------------------------------------------------
+
+    /** The selection's entity numbers, for tests/persistent-selection.spec.ts. */
+    public get selectedEntityNumbers(): number[] {
+        return [...this.selectedEntities].map(e => e.entityNumber)
+    }
+
+    /** Whether the entity-info overlay is showing. See tests/persistent-selection.spec.ts. */
+    public get infoOverlayVisible(): boolean {
+        return this.overlayContainer.entityInfoVisible
+    }
+
+    /**
+     * Whether an Alt-drag selection sweep started since the last call - and
+     * resets it. `Editor.ts`'s `showInfo` calls this on AltLeft's key-up
+     * rather than toggling on its key-down, so a tap of Alt still shows the
+     * entity-info overlay but holding it to drag a selection does not.
+     */
+    public consumeAltUsedForDrag(): boolean {
+        const used = this.altUsedForDrag
+        this.altUsedForDrag = false
+        return used
+    }
+
+    /** Whether an entity's selection box is drawn as blocked. See tests/persistent-selection.spec.ts. */
+    public selectionHighlightBlocked(entityNumber: number): boolean {
+        return this.overlayContainer.selectionHighlightBlocked(entityNumber)
+    }
+
+    /**
+     * What Escape does on the canvas, innermost state first: a drag in progress
+     * is put back, a rectangle being swept is dropped, and only then does a
+     * settled selection clear. False when there was nothing of the kind to do.
+     */
+    public escape(): boolean {
+        if (this.mode === EditorMode.MOVE) {
+            this.exitMoveMode(true)
+            return true
+        }
+        if (this.mode === EditorMode.SELECT) {
+            this.exitSelectMode(true)
+            return true
+        }
+        if (this.selectedEntities.size !== 0) {
+            this.clearSelection()
+            return true
+        }
+        return false
+    }
+
+    public clearSelection(): void {
+        // Deleting the current member mid-iteration is safe for a Set.
+        for (const entity of this.selectedEntities) {
+            this.deselect(entity)
+        }
+    }
+
+    private select(entity: Entity): void {
+        if (this.selectedEntities.has(entity)) return
+        this.selectedEntities.add(entity)
+
+        const n = entity.entityNumber
+        const redrawBox = (): void => {
+            this.overlayContainer.showSelectionHighlight(
+                n,
+                EntityContainer.containerOf(n).position,
+                entity.size
+            )
+        }
+        const onDestroy = (): void => this.deselect(entity)
+        redrawBox()
+        entity.on('position', redrawBox)
+        // a rotation can change the footprint the box has to fit
+        entity.on('direction', redrawBox)
+        entity.on('destroy', onDestroy)
+        this.selectionListeners.set(entity, () => {
+            entity.off('position', redrawBox)
+            entity.off('direction', redrawBox)
+            entity.off('destroy', onDestroy)
+        })
+    }
+
+    private deselect(entity: Entity): void {
+        const detach = this.selectionListeners.get(entity)
+        if (detach === undefined) return
+        detach()
+        this.selectionListeners.delete(entity)
+        this.selectedEntities.delete(entity)
+        this.overlayContainer.hideSelectionHighlight(entity.entityNumber)
+    }
+
+    /**
+     * Alt+Left-drag: the copy-mode marquee, except that on release the swept
+     * entities *stay* selected instead of being handed to a paint container.
+     * The box each one gets while the rectangle covers it is the persistent
+     * one, so nothing changes visually on release - it simply stops being
+     * cleared. A new sweep replaces the previous selection outright.
+     */
+    public enterSelectMode(): boolean {
+        if (this.mode === EditorMode.SELECT) return false
+        if (this.mode === EditorMode.PAINT) this.painting.destroy()
+
+        this.altUsedForDrag = true
+        this.clearSelection()
+        this.updateHoverContainer(true)
+        this.setMode(EditorMode.SELECT)
+
+        this.overlayContainer.showSelectionArea(SELECT_AREA_COLOR)
+
+        const startPos = { x: this.gridData.x32, y: this.gridData.y32 }
+        this.selectModeUpdateFn = (endX: number, endY: number) => {
+            const X = Math.min(startPos.x, endX)
+            const Y = Math.min(startPos.y, endY)
+            const W = Math.abs(endX - startPos.x) + 1
+            const H = Math.abs(endY - startPos.y) + 1
+
+            for (const e of this.selectModeEntities) {
+                this.overlayContainer.hideSelectionHighlight(e.entityNumber)
+            }
+
+            this.selectModeEntities = this.bp.entityPositionGrid.getEntitiesInArea({
+                x: X + W / 2,
+                y: Y + H / 2,
+                w: W,
+                h: H,
+            })
+
+            for (const e of this.selectModeEntities) {
+                this.overlayContainer.showSelectionHighlight(
+                    e.entityNumber,
+                    EntityContainer.containerOf(e.entityNumber).position,
+                    e.size
+                )
+            }
+        }
+        this.selectModeUpdateFn(startPos.x, startPos.y)
+        this.gridData.on('update32', this.selectModeUpdateFn, this)
+
+        return true
+    }
+
+    public exitSelectMode(cancel = false): void {
+        if (this.mode !== EditorMode.SELECT) return
+
+        this.overlayContainer.hideSelectionArea()
+        if (this.selectModeUpdateFn !== undefined) {
+            this.gridData.off('update32', this.selectModeUpdateFn, this)
+            this.selectModeUpdateFn = undefined
+        }
+
+        this.setMode(EditorMode.NONE)
+        this.updateHoverContainer()
+
+        for (const e of this.selectModeEntities) {
+            if (cancel) {
+                this.overlayContainer.hideSelectionHighlight(e.entityNumber)
+            } else {
+                this.select(e)
+            }
+        }
+        this.selectModeEntities = []
+    }
+
+    /**
+     * Picks the selection up, if a plain Left press landed on one of its
+     * members; false - and nothing done - otherwise, so `panStart` carries on
+     * to pan exactly as it did before selections existed. A press on the
+     * background or on an entity that is not selected is therefore still a pan.
+     *
+     * Nothing is written to the model from here until `exitMoveMode` commits:
+     * the drag previews by displacing the real sprites (`EntityContainer.
+     * setDragOffset`) and the selection boxes, and a cancel just puts them
+     * back. That is what makes cancelling a true no-op and a completed move a
+     * single undo step - the reasons a detach-and-carry design was rejected
+     * (docs/superpowers/specs/2026-09-05-persistent-selection-design.md).
+     */
+    private enterMoveMode(): boolean {
+        if (this.mode !== EditorMode.NONE && this.mode !== EditorMode.EDIT) return false
+        if (this.selectedEntities.size === 0) return false
+
+        const pressed = this.bp.entityPositionGrid.getEntityAtPosition({
+            x: this.gridData.x32,
+            y: this.gridData.y32,
+        })
+        if (pressed === undefined || !this.selectedEntities.has(pressed)) return false
+
+        this.updateHoverContainer(true)
+        this.setMode(EditorMode.MOVE)
+        this.cursor = 'grabbing'
+
+        const start = { x: this.gridData.x32, y: this.gridData.y32 }
+        this.moveDrag = {
+            entities: [...this.selectedEntities],
+            pressed,
+            delta: { x: 0, y: 0 },
+            moved: false,
+        }
+        this.moveDragUpdateFn = (endX: number, endY: number) =>
+            this.previewMove({ x: endX - start.x, y: endY - start.y })
+        this.gridData.on('update32', this.moveDragUpdateFn, this)
+
+        return true
+    }
+
+    private previewMove(delta: IPoint): void {
+        const drag = this.moveDrag
+        if (drag === undefined) return
+
+        drag.delta = delta
+        drag.moved = drag.moved || delta.x !== 0 || delta.y !== 0
+
+        const blocked = !this.canRelocateGroup(this.translationsOf(drag.entities, delta))
+        const px = { x: delta.x * 32, y: delta.y * 32 }
+        for (const e of drag.entities) {
+            const container = EntityContainer.containerOf(e.entityNumber)
+            container.setDragOffset(px)
+            this.overlayContainer.moveSelectionHighlight(e.entityNumber, {
+                x: container.position.x + px.x,
+                y: container.position.y + px.y,
+            })
+            this.overlayContainer.setSelectionHighlightBlocked(e.entityNumber, blocked)
+        }
+    }
+
+    /**
+     * Drops the selection where the drag left it, or on `cancel` where it was.
+     *
+     * A press that never crossed a tile boundary is a click, not a drag, and a
+     * click on an entity opens its editor everywhere else on the canvas - so
+     * it does here too, rather than the selection making its members
+     * un-openable. `openEntityGUI` never saw the press (`panStart` consumed
+     * it), which is why this calls `openEditor` itself.
+     */
+    public exitMoveMode(cancel = false): void {
+        if (this.mode !== EditorMode.MOVE) return
+        const drag = this.moveDrag
+        this.moveDrag = undefined
+        if (this.moveDragUpdateFn !== undefined) {
+            this.gridData.off('update32', this.moveDragUpdateFn, this)
+            this.moveDragUpdateFn = undefined
+        }
+        if (drag === undefined) throw new Error('MOVE mode with no drag in progress')
+
+        for (const e of drag.entities) {
+            const container = EntityContainer.containerOf(e.entityNumber)
+            container.setDragOffset({ x: 0, y: 0 })
+            this.overlayContainer.moveSelectionHighlight(e.entityNumber, container.position)
+            this.overlayContainer.setSelectionHighlightBlocked(e.entityNumber, false)
+        }
+
+        this.setMode(EditorMode.NONE)
+        this.cursor = undefined
+        this.updateHoverContainer()
+
+        if (cancel) return
+        if (!drag.moved) {
+            // updateHoverContainer just re-hovered whatever is under the pointer
+            if (this.hoverContainer?.entity === drag.pressed) {
+                this.openEditor()
+            }
+            return
+        }
+
+        const targets = this.translationsOf(drag.entities, drag.delta)
+        if (!this.canRelocateGroup(targets)) return
+        this.bp.history.transaction('Move selection', () => {
+            for (const { entity, position } of targets) {
+                entity.relocate(position)
+            }
+        })
+    }
+
+    private translationsOf(entities: readonly Entity[], delta: IPoint): GroupRelocation[] {
+        return entities.map(entity => ({
+            entity,
+            position: { x: entity.position.x + delta.x, y: entity.position.y + delta.y },
+            direction: entity.direction,
+        }))
+    }
+
+    /**
+     * Whether the group fits its targets and every wire that reaches now still
+     * reaches afterwards - the two checks `Entity.position`'s setter makes for
+     * one entity, made for the group at once so members do not block each
+     * other. The wire rule is the setter's exactly: a wire that already does
+     * not reach is not a reason to refuse, only one this move would break.
+     */
+    private canRelocateGroup(targets: readonly GroupRelocation[]): boolean {
+        if (!this.bp.entityPositionGrid.canGroupRelocate(targets)) return false
+        if (!this.limitWireReach) return true
+
+        const destination = new Map(targets.map(t => [t.entity, t.position]))
+        return targets.every(({ entity, position }) =>
+            this.bp.wireConnections.getEntityConnections(entity.entityNumber).every(c => {
+                const otherNumber =
+                    c.cps[0].entityNumber === entity.entityNumber
+                        ? c.cps[1].entityNumber
+                        : c.cps[0].entityNumber
+                const other = this.bp.entities.get(otherNumber)
+                if (other === undefined) return true
+                const reach = Math.min(other.maxWireDistance, entity.maxWireDistance)
+                const reachesNow = U.pointInCircle(other.position, entity.position, reach)
+                const reachesAfter = U.pointInCircle(
+                    destination.get(other) ?? other.position,
+                    position,
+                    reach
+                )
+                return !reachesNow || reachesAfter
+            })
+        )
+    }
+
+    /**
+     * Mirrors the selection in place about its own bounding box centre, in one
+     * undo step.
+     *
+     * The per-entity maths - the direction constraint, the splitter priority
+     * swap, the refusal for train stops and rail signals - already lives in
+     * `Entity.getFlippedCopy`, which flips about (0, 0) and hands back a
+     * detached copy because its only other caller (PaintBlueprintContainer)
+     * holds a group already re-centred on the origin. So each member is fed
+     * through it as a throwaway re-centred on this selection's centre, and
+     * what comes back is applied to the live entity through its own setters.
+     * The bounding box's edges are whole tiles, so the centre is a whole or
+     * half tile and `2 * centre - position` keeps every member on the parity
+     * its footprint needs.
+     */
+    private mirrorSelection(vertical: boolean): void {
+        const entities = [...this.selectedEntities]
+
+        let minX = Infinity
+        let minY = Infinity
+        let maxX = -Infinity
+        let maxY = -Infinity
+        for (const e of entities) {
+            minX = Math.min(minX, e.position.x - e.size.x / 2)
+            minY = Math.min(minY, e.position.y - e.size.y / 2)
+            maxX = Math.max(maxX, e.position.x + e.size.x / 2)
+            maxY = Math.max(maxY, e.position.y + e.size.y / 2)
+        }
+        const centre = { x: (minX + maxX) / 2, y: (minY + maxY) / 2 }
+
+        let flipped: { entity: Entity; copy: Entity }[]
+        try {
+            flipped = entities.map(entity => ({
+                entity,
+                copy: new Entity(
+                    {
+                        ...entity.rawEntity,
+                        position: {
+                            x: entity.position.x - centre.x,
+                            y: entity.position.y - centre.y,
+                        },
+                    },
+                    this.bp
+                ).getFlippedCopy(vertical),
+            }))
+        } catch (e) {
+            if (e instanceof IllegalFlipError) {
+                G.logger({ text: e.message, type: 'warning' })
+                return
+            }
+            throw e
+        }
+
+        const targets: GroupRelocation[] = flipped.map(({ entity, copy }) => ({
+            entity,
+            position: { x: copy.position.x + centre.x, y: copy.position.y + centre.y },
+            direction: copy.rawEntity.direction ?? 0,
+        }))
+        if (!this.canRelocateGroup(targets)) {
+            G.logger({ text: 'The mirrored selection does not fit.', type: 'warning' })
+            return
+        }
+
+        this.bp.history.transaction(
+            vertical ? 'Mirror selection vertically' : 'Mirror selection horizontally',
+            () => {
+                for (let i = 0; i < flipped.length; i++) {
+                    const { entity, copy } = flipped[i]
+                    entity.relocate(targets[i].position)
+                    if ((copy.rawEntity.direction ?? 0) !== (entity.rawEntity.direction ?? 0)) {
+                        entity.direction = copy.rawEntity.direction ?? 0
+                    }
+                    entity.splitterInputPriority = copy.splitterInputPriority
+                    entity.splitterOutputPriority = copy.splitterOutputPriority
+                }
+            }
+        )
     }
 
     /**

--- a/packages/editor/src/containers/EntityContainer.ts
+++ b/packages/editor/src/containers/EntityContainer.ts
@@ -51,6 +51,15 @@ export class EntityContainer {
     private undergroundLine: Container | undefined
 
     private readonly m_Entity: Entity
+    /*
+        Where the sprites are drawn relative to where the model says the entity
+        is, in pixels. Non-zero only while the entity is being dragged as part of
+        a selection: the drag previews with the real sprites and writes nothing
+        to the model until the drop, so this is the whole of the preview. Held
+        here rather than recomputed so a redraw mid-drag lands the fresh sprites
+        in the same displaced place.
+    */
+    private dragOffset: IPoint = { x: 0, y: 0 }
 
     public constructor(entity: Entity, sort = true) {
         this.m_Entity = entity
@@ -298,6 +307,30 @@ export class EntityContainer {
         }
     }
 
+    /**
+     * Shifts the drawn sprites and the info overlay without touching the model
+     * - the move-drag preview. Zero puts them back. The wires are not shifted:
+     * `WiresContainer` draws from model positions and re-reads them on the
+     * position event the drop emits, so they catch up on commit rather than
+     * following the drag.
+     */
+    public setDragOffset(offset: IPoint): void {
+        const dx = offset.x - this.dragOffset.x
+        const dy = offset.y - this.dragOffset.y
+        this.dragOffset = offset
+        this.shiftDrawn(dx, dy)
+    }
+
+    private shiftDrawn(dx: number, dy: number): void {
+        if (dx === 0 && dy === 0) return
+        for (const s of this.entitySprites) {
+            s.position.set(s.x + dx, s.y + dy)
+        }
+        if (this.entityInfo !== undefined) {
+            this.entityInfo.position.set(this.entityInfo.x + dx, this.entityInfo.y + dy)
+        }
+    }
+
     /** `undefined` removes the box, which is how every hover-out and mode exit clears it. */
     public set cursorBox(type: keyof CursorBoxSpecification | undefined) {
         if (this.cursorBoxContainer) {
@@ -364,6 +397,12 @@ export class EntityContainer {
                 this.entityInfo.destroy()
             }
             this.entityInfo = G.BPC.overlayContainer.createEntityInfo(this.m_Entity, this.position)
+            if (this.entityInfo !== undefined) {
+                this.entityInfo.position.set(
+                    this.entityInfo.x + this.dragOffset.x,
+                    this.entityInfo.y + this.dragOffset.y
+                )
+            }
         }
 
         G.UI.updateEntityInfoPanel(this.m_Entity)
@@ -458,6 +497,9 @@ export class EntityContainer {
             this.position,
             ignoreConnections ? undefined : G.bp.entityPositionGrid
         )
+        for (const s of this.entitySprites) {
+            s.position.set(s.x + this.dragOffset.x, s.y + this.dragOffset.y)
+        }
         G.BPC.addEntitySprites(this.entitySprites, sort)
     }
 }

--- a/packages/editor/src/containers/OverlayContainer.ts
+++ b/packages/editor/src/containers/OverlayContainer.ts
@@ -42,6 +42,18 @@ export class OverlayContainer extends Container {
     private copyCursorBox: Container | undefined
     // Absent outside a selection drag, same as `copyCursorBox` above.
     private selectionAreaUpdateFn: ((endX: number, endY: number) => void) | undefined
+    /*
+        The box around each entity in the persistent selection, by entity
+        number. Its own map rather than `EntityContainer.cursorBox`: that is a
+        single slot per entity that hover (`regular`), the copy and delete
+        marquees (`copy`, `not_allowed`) and the settings-copy source all
+        already write, each destroying whatever was there. Routed through it,
+        hovering a selected entity would replace its selection box with the
+        hover box and the hover-out would then clear it rather than restore it.
+        Kept apart, a selected-and-hovered entity shows both, which is what the
+        game does for an entity another player has selected.
+    */
+    private readonly selectionHighlights = new Map<number, Container>()
 
     public constructor(bpc: BlueprintContainer) {
         super()
@@ -636,6 +648,59 @@ export class OverlayContainer extends Container {
                 return lineParts
             }
         }
+    }
+
+    /**
+     * Draws the persistent-selection box around an entity, replacing any it
+     * already has - so this is also how the box follows an entity that moved.
+     *
+     * `multiplayer_selection` is the box the game draws around an entity
+     * another player has selected. It is the one `CursorBoxSpecification`
+     * variant here that nothing else in this file uses, so it reads as
+     * "selected" and nothing else, and being a sprite it scales with the
+     * viewport for free where the hand-drawn `selectionArea` rectangle above
+     * has to correct its stroke width on every redraw.
+     */
+    public showSelectionHighlight(entityNumber: number, position: IPoint, size: IPoint): void {
+        this.hideSelectionHighlight(entityNumber)
+        this.selectionHighlights.set(
+            entityNumber,
+            this.createCursorBox(position, size, 'multiplayer_selection')
+        )
+    }
+
+    public hideSelectionHighlight(entityNumber: number): void {
+        const box = this.selectionHighlights.get(entityNumber)
+        if (box === undefined) return
+        box.destroy()
+        this.selectionHighlights.delete(entityNumber)
+    }
+
+    /** Slides the box without rebuilding it - the move-drag preview, once per tile. */
+    public moveSelectionHighlight(entityNumber: number, position: IPoint): void {
+        this.selectionHighlights.get(entityNumber)?.position.set(position.x, position.y)
+    }
+
+    /**
+     * The same red the paint preview turns when it cannot be placed
+     * (`PaintContainer.blocked`), on the selection boxes instead, since a
+     * move-drag previews with the real sprites and tinting those would have
+     * to be undone on cancel.
+     */
+    public setSelectionHighlightBlocked(entityNumber: number, blocked: boolean): void {
+        const box = this.selectionHighlights.get(entityNumber)
+        if (box === undefined) return
+        const tint = blocked ? F.rgbToColorSource(1, 0.4, 0.4) : 0xffffff
+        for (const child of box.children) {
+            if (child instanceof Sprite) child.tint = tint
+        }
+    }
+
+    /** Whether an entity's selection box is currently tinted as blocked. See tests/persistent-selection.spec.ts. */
+    public selectionHighlightBlocked(entityNumber: number): boolean {
+        const box = this.selectionHighlights.get(entityNumber)
+        const first = box?.children[0]
+        return first instanceof Sprite && first.tint !== 0xffffff
     }
 
     public showSelectionArea(color: number): void {

--- a/packages/editor/src/core/Entity.ts
+++ b/packages/editor/src/core/Entity.ts
@@ -280,6 +280,25 @@ export class Entity extends EventEmitter<EntityEvents> {
             )
         if (G.BPC.limitWireReach && connectionsBreak) return
 
+        this.relocate(position)
+    }
+
+    /**
+     * Moves the entity without the checks the `position` setter makes.
+     *
+     * For a caller that has already established the destination is free and
+     * every wire still reaches - for the **whole group at once**, through
+     * `PositionGrid.canGroupRelocate` and `BlueprintContainer`'s group wire
+     * check. The setter's own `canMoveTo` lifts only this entity out of the
+     * grid before asking, so a group whose members trade places, or shift as a
+     * block, is refused one member at a time even though the group as a whole
+     * fits: each member is blocked by a neighbour that is itself about to move
+     * out of the way. The setter still routes through here, so the history
+     * entry and the grid/emit bookkeeping are one piece of code either way.
+     */
+    public relocate(position: IPoint): void {
+        if (util.areObjectsEquivalent(this.m_rawEntity.position, position)) return
+
         this.m_BP.history
             .updateValue(this.m_rawEntity, 'position', position, 'Change position')
             .onDone((newValue, oldValue) => {

--- a/packages/editor/src/core/PositionGrid.ts
+++ b/packages/editor/src/core/PositionGrid.ts
@@ -19,6 +19,13 @@ interface INeighbourData extends IPoint {
     entity: Entity | undefined
 }
 
+/** One member of a group move: where it is going and which way it will face there. */
+export interface GroupRelocation {
+    entity: Entity
+    position: IPoint
+    direction: number
+}
+
 /** Moves X and Y to top left corner from middle (anchor 0.5 0.5 => 0 0) */
 const processArea = (area: IArea): IArea => ({
     ...area,
@@ -436,6 +443,56 @@ export class PositionGrid {
         const spaceAvalible = this.isAreaAvailable(entity.name, newPosition, entity.direction)
         this.setTileData(entity)
         return spaceAvalible
+    }
+
+    /**
+     * Whether every entity in the group may move by `delta` at once. See
+     * `canGroupRelocate`, which this is the translation-only form of.
+     */
+    public canGroupMoveTo(entities: readonly Entity[], delta: IPoint): boolean {
+        return this.canGroupRelocate(
+            entities.map(entity => ({
+                entity,
+                position: { x: entity.position.x + delta.x, y: entity.position.y + delta.y },
+                direction: entity.direction,
+            }))
+        )
+    }
+
+    /**
+     * Whether every entity in the group may take its target at once.
+     *
+     * `canMoveTo` above answers for one entity by lifting only that entity out
+     * of the grid before asking - so asked once per member of a group that is
+     * moving together, it reports a member as blocked by a neighbour that is
+     * itself about to move out of the way, and refuses a group whose members
+     * trade places even though the group as a whole fits. Every member is
+     * lifted out first here, then every target is checked against what
+     * remains, and then every member is put back where it was.
+     *
+     * The put-back is in a `finally`: `isAreaAvailable` reads prototype data
+     * that a stale name could make throw, and a throw between the lifts and the
+     * restores would leave the grid missing entries for entities the blueprint
+     * still holds - the drift `entityAt` exists to catch, caused by the check
+     * that was meant to prevent a bad write.
+     *
+     * A check only. Nothing is written; the caller commits through
+     * `Entity.relocate`, which is what lets it skip the per-member check the
+     * `position` setter would otherwise repeat one member at a time.
+     */
+    public canGroupRelocate(targets: readonly GroupRelocation[]): boolean {
+        for (const { entity } of targets) {
+            this.removeTileData(entity)
+        }
+        try {
+            return targets.every(({ entity, position, direction }) =>
+                this.isAreaAvailable(entity.name, position, direction)
+            )
+        } finally {
+            for (const { entity } of targets) {
+                this.setTileData(entity)
+            }
+        }
     }
 
     /**

--- a/packages/editor/src/core/groupRelocation.test.ts
+++ b/packages/editor/src/core/groupRelocation.test.ts
@@ -1,0 +1,166 @@
+import { beforeAll, describe, expect, it } from 'vite-plus/test'
+import { IPoint } from '../types'
+import { Blueprint } from './Blueprint'
+import { loadData } from './factorioData'
+
+/*
+    PositionGrid.canGroupRelocate, the check behind moving or mirroring a
+    persistent selection as one unit
+    (docs/superpowers/specs/2026-09-05-persistent-selection-design.md).
+
+    canMoveTo lifts one entity out of the grid before asking whether its
+    destination is free. Asked once per member of a group that is moving
+    together, that refuses the group whenever a member's destination is a
+    tile another member is about to vacate - two chests side by side cannot
+    shift one tile along their row, and cannot trade places, even though
+    either move leaves the grid exactly as valid as it found it. The group form
+    lifts every member first, so only what is *not* moving can block.
+
+    Pure grid arithmetic, so vitest and a two-prototype dataset are enough; the
+    drag that calls it is tests/persistent-selection.spec.ts.
+*/
+
+beforeAll(() => {
+    // loadData permanently replaces FD's accessors; vitest's per-file module
+    // isolation keeps this synthetic dataset out of the other test files.
+    loadData(
+        JSON.stringify({
+            items: {},
+            fluids: {},
+            signals: {},
+            recipes: {},
+            entities: {
+                'wooden-chest': {
+                    type: 'container',
+                    name: 'wooden-chest',
+                    collision_box: [
+                        [-0.35, -0.35],
+                        [0.35, 0.35],
+                    ],
+                },
+                'steel-furnace': {
+                    type: 'furnace',
+                    name: 'steel-furnace',
+                    collision_box: [
+                        [-0.7, -0.7],
+                        [0.7, 0.7],
+                    ],
+                },
+            },
+            tiles: {},
+            inventoryLayout: [],
+            utilitySprites: {},
+            utilityConstants: {},
+            guiStyle: {},
+            defines: {},
+        })
+    )
+})
+
+interface Placement {
+    name: string
+    x: number
+    y: number
+}
+
+/**
+ * A blueprint numbered from 1 in the order given. The constructor recentres
+ * everything, so only the offsets between placements survive - every case
+ * below reads positions back rather than using the literals.
+ */
+const blueprintOf = (...placements: Placement[]): Blueprint =>
+    new Blueprint({
+        entities: placements.map((p, i) => ({
+            entity_number: i + 1,
+            name: p.name,
+            position: { x: p.x, y: p.y },
+        })),
+    })
+
+const entityOf = (bp: Blueprint, entityNumber: number) => {
+    const entity = bp.entities.get(entityNumber)
+    if (entity === undefined) throw new Error(`no entity ${entityNumber} in this blueprint`)
+    return entity
+}
+
+const shifted = (bp: Blueprint, entityNumbers: number[], delta: IPoint) =>
+    entityNumbers.map(n => {
+        const entity = entityOf(bp, n)
+        return {
+            entity,
+            position: { x: entity.position.x + delta.x, y: entity.position.y + delta.y },
+            direction: entity.direction,
+        }
+    })
+
+/** Two chests side by side, then a third two tiles further along the row. */
+const ROW = (): Blueprint =>
+    blueprintOf(
+        { name: 'wooden-chest', x: 0.5, y: 0.5 },
+        { name: 'wooden-chest', x: 1.5, y: 0.5 },
+        { name: 'wooden-chest', x: 3.5, y: 0.5 }
+    )
+
+describe('canGroupRelocate lifts the whole group before asking', () => {
+    it('lets two adjacent entities shift along their row together', () => {
+        const bp = ROW()
+        const grid = bp.entityPositionGrid
+
+        // The single-entity check refuses: chest 2 is in chest 1's way.
+        expect(grid.canMoveTo(entityOf(bp, 1), shifted(bp, [1], { x: 1, y: 0 })[0].position)).toBe(
+            false
+        )
+        expect(grid.canGroupRelocate(shifted(bp, [1, 2], { x: 1, y: 0 }))).toBe(true)
+    })
+
+    it('lets two entities trade places', () => {
+        const bp = ROW()
+        const a = entityOf(bp, 1)
+        const b = entityOf(bp, 2)
+
+        expect(
+            bp.entityPositionGrid.canGroupRelocate([
+                { entity: a, position: { ...b.position }, direction: a.direction },
+                { entity: b, position: { ...a.position }, direction: b.direction },
+            ])
+        ).toBe(true)
+    })
+
+    it('still refuses a destination held by something outside the group', () => {
+        const bp = ROW()
+        // Shifting chests 1 and 2 by two lands chest 2 on chest 3, which stays put.
+        expect(bp.entityPositionGrid.canGroupRelocate(shifted(bp, [1, 2], { x: 2, y: 0 }))).toBe(
+            false
+        )
+    })
+
+    it('is a check only: every member is back in the grid afterwards, pass or fail', () => {
+        const bp = ROW()
+        const grid = bp.entityPositionGrid
+
+        grid.canGroupRelocate(shifted(bp, [1, 2], { x: 1, y: 0 }))
+        grid.canGroupRelocate(shifted(bp, [1, 2], { x: 2, y: 0 }))
+
+        for (const n of [1, 2, 3]) {
+            expect(grid.getEntityAtPosition(entityOf(bp, n).position)).toBe(entityOf(bp, n))
+        }
+    })
+
+    it('answers true for an empty group', () => {
+        expect(ROW().entityPositionGrid.canGroupRelocate([])).toBe(true)
+    })
+
+    it('reads the footprint at the target direction, not the current one', () => {
+        // A 2x2 furnace beside a chest: moving the furnace one tile towards the
+        // chest overlaps it whichever way the furnace faces, and the group form
+        // must see that through the direction it is handed.
+        const bp = blueprintOf(
+            { name: 'steel-furnace', x: 1, y: 1 },
+            { name: 'wooden-chest', x: 2.5, y: 0.5 }
+        )
+        expect(bp.entityPositionGrid.canGroupRelocate(shifted(bp, [1], { x: 1, y: 0 }))).toBe(false)
+        expect(bp.entityPositionGrid.canGroupRelocate(shifted(bp, [1, 2], { x: 1, y: 0 }))).toBe(
+            true
+        )
+    })
+})

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -483,6 +483,17 @@ const testApi = {
     */
     editorMode: () => editor.mode,
     /*
+        The persistent selection, its blocked tint, and the history revision.
+        Together the only way a spec can see a selection at all: it is not a
+        mode, its move-drag writes nothing until the drop, and whether that
+        drop was one undo step or two leaves the entities in the same place.
+    */
+    selectedEntityNumbers: () => editor.selectedEntityNumbers,
+    selectionHighlightBlocked: (entityNumber: number) =>
+        editor.selectionHighlightBlocked(entityNumber),
+    historyRevision: () => editor.historyRevision,
+    infoOverlayVisible: () => editor.infoOverlayVisible,
+    /*
         Where an entity sits on screen, so a spec can put the pointer on it.
         Hovering is the only way into EDIT, and that is the entry point for
         pipette, the entity editor and settings copy/paste (issue #44).

--- a/tests/helpers/fbe-test-api.ts
+++ b/tests/helpers/fbe-test-api.ts
@@ -98,10 +98,35 @@ export interface FbeTestApi {
      */
     recipeShapeTally: (blueprint?: unknown) => RecipeShapeTally
     /**
-     * The interaction mode the canvas is in: NONE, EDIT, PAINT, PAN, COPY or
-     * DELETE. See tests/editor-mode-input.spec.ts.
+     * The interaction mode the canvas is in: NONE, EDIT, PAINT, PAN, COPY,
+     * DELETE, SELECT or MOVE. See tests/editor-mode-input.spec.ts.
      */
     editorMode: () => string
+    /**
+     * The entity numbers in the persistent selection. The selection is not a
+     * mode - `editorMode` reads NONE once an Alt-drag is released - so this is
+     * the only way to see what it holds. See tests/persistent-selection.spec.ts.
+     */
+    selectedEntityNumbers: () => number[]
+    /**
+     * Whether the entity's selection box is tinted as blocked, which a move-drag
+     * does while the group would not fit where it is. See
+     * tests/persistent-selection.spec.ts.
+     */
+    selectionHighlightBlocked: (entityNumber: number) => boolean
+    /**
+     * `History.revision` - moves on every outermost commit. A group move must be
+     * one undo step, and the entities end up in the same place whether it took
+     * one transaction or two; only this can tell. See
+     * tests/persistent-selection.spec.ts.
+     */
+    historyRevision: () => number
+    /**
+     * Whether the entity-info overlay is showing - the AltLeft toggle, which
+     * has to defer to Alt's key-up so a tap still shows it while an Alt-drag
+     * selection sweep does not. See tests/persistent-selection.spec.ts.
+     */
+    infoOverlayVisible: () => boolean
     /**
      * Where the entity sits in client coordinates - the space a synthetic
      * pointer move takes - or undefined if the loaded blueprint has no such

--- a/tests/persistent-selection.spec.ts
+++ b/tests/persistent-selection.spec.ts
@@ -1,0 +1,320 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprint as encode, packVersion as version } from './helpers/encode-blueprint'
+import { suppressOverlays } from './helpers/overlays'
+
+/*
+    The persistent selection: Alt+Left-drag sweeps a rectangle whose entities
+    stay selected after release; a plain Left-drag that starts on one of them
+    moves the whole group; Shift+F / Shift+G mirror it in place; Escape clears
+    it. Design and the reasons for each binding:
+    docs/superpowers/specs/2026-09-05-persistent-selection-design.md.
+
+    Everything below is real pointer and keyboard input, in the idiom of
+    tests/editor-mode-input.spec.ts. Three things only a hook can see, and each
+    is why its hook exists: the selection itself (`selectedEntityNumbers` - it
+    is not a mode, so `editorMode` reads NONE the moment the drag is released),
+    the blocked tint a drag shows over an occupied destination
+    (`selectionHighlightBlocked`), and whether a move or mirror was *one* undo
+    step (`historyRevision` - the entities end up in the same place whether it
+    took one transaction or two).
+
+    Runs against the dev server like the rest of tests/ - see CLAUDE.md for the
+    two servers that have to be up.
+*/
+
+const CANVAS = '#editor'
+
+type Page = import('@playwright/test').Page
+type Point = { x: number; y: number }
+
+const modeOf = (page: Page): Promise<string> =>
+    page.evaluate(() => (window as any).__fbe_test.editorMode())
+const selected = async (page: Page): Promise<number[]> =>
+    (await page.evaluate((): number[] => (window as any).__fbe_test.selectedEntityNumbers())).sort(
+        (a, b) => a - b
+    )
+const revision = (page: Page): Promise<number> =>
+    page.evaluate(() => (window as any).__fbe_test.historyRevision())
+const dialogs = (page: Page): Promise<number> =>
+    page.evaluate(() => (window as any).__fbe_test.openDialogCount())
+
+const positionOf = async (page: Page, n: number): Promise<Point> => {
+    const at = await page.evaluate((n: number) => (window as any).__fbe_test.entityPosition(n), n)
+    if (!at) throw new Error(`no entity ${n} in the loaded blueprint`)
+    return at
+}
+
+const screenOf = async (page: Page, n: number): Promise<Point> => {
+    const at = await page.evaluate(
+        (n: number) => (window as any).__fbe_test.entityScreenPosition(n),
+        n
+    )
+    if (!at) throw new Error(`no entity ${n} in the loaded blueprint`)
+    return at
+}
+
+const blocked = (page: Page, n: number): Promise<boolean> =>
+    page.evaluate((n: number) => (window as any).__fbe_test.selectionHighlightBlocked(n), n)
+
+const infoVisible = (page: Page): Promise<boolean> =>
+    page.evaluate(() => (window as any).__fbe_test.infoOverlayVisible())
+
+/** One tile, in client pixels at the current zoom. */
+const tilePx = async (page: Page): Promise<number> =>
+    32 * (await page.evaluate((): number => (window as any).__fbe_test.viewportScale()))
+
+/*
+    Three 1x1 chests in a row at the origin, as tests/editor-mode-input.spec.ts
+    uses: compact, so initBP centres them at a comfortable zoom with empty
+    canvas all around, and numbered by the spec so it can say "chest 2".
+    Storage chests rather than wooden ones because two cases below assert that
+    a click opens the chest's editor, and a wooden chest has none
+    (tests/chest-editor.spec.ts, "a chest with no editor opens nothing").
+*/
+const THREE_CHESTS = encode({
+    item: 'blueprint',
+    version: version(2, 0, 55),
+    entities: [
+        { entity_number: 1, name: 'storage-chest', position: { x: 0.5, y: 0.5 } },
+        { entity_number: 2, name: 'storage-chest', position: { x: 1.5, y: 0.5 } },
+        { entity_number: 3, name: 'storage-chest', position: { x: 2.5, y: 0.5 } },
+    ],
+})
+
+async function openEditorWithChests(page: Page): Promise<void> {
+    await suppressOverlays(page)
+    await page.goto('/')
+    await page.waitForFunction(() => (window as any).__fbe_test !== undefined, { timeout: 60_000 })
+    await expect(page.locator(CANVAS)).toBeVisible()
+    await page.evaluate(async (src: string) => {
+        const t = (window as any).__fbe_test
+        await t.loadBp(await t.getBlueprintOrBookFromSource(src))
+    }, THREE_CHESTS)
+}
+
+/** Alt+Left-drags from one chest to another and releases, then lets go of Alt. */
+async function altSelect(page: Page, from: number, to: number): Promise<void> {
+    const a = await screenOf(page, from)
+    const b = await screenOf(page, to)
+    await page.mouse.move(a.x, a.y)
+    await page.keyboard.down('Alt')
+    await page.mouse.down()
+    expect(await modeOf(page)).toBe('SELECT')
+    await page.mouse.move(b.x, b.y)
+    await page.mouse.up()
+    await page.keyboard.up('Alt')
+    // EDIT rather than NONE when the release leaves the pointer on a chest -
+    // exitSelectMode re-hovers whatever is under it, as every mode exit does.
+    expect(await modeOf(page)).not.toBe('SELECT')
+}
+
+/** A plain Left-drag starting on `chest`, by whole tiles, released at the end. */
+async function dragChest(page: Page, chest: number, tiles: Point): Promise<void> {
+    const at = await screenOf(page, chest)
+    const px = await tilePx(page)
+    await page.mouse.move(at.x, at.y)
+    await page.mouse.down()
+    expect(await modeOf(page)).toBe('MOVE')
+    await page.mouse.move(at.x + tiles.x * px, at.y + tiles.y * px, { steps: 4 })
+    expect(await modeOf(page)).toBe('MOVE')
+    await page.mouse.up()
+    expect(await modeOf(page)).not.toBe('MOVE')
+}
+
+test('Alt and a left drag sweep a selection that outlives the release', async ({ page }) => {
+    await openEditorWithChests(page)
+    expect(await selected(page)).toEqual([])
+
+    await altSelect(page, 1, 2)
+    expect(await selected(page)).toEqual([1, 2])
+
+    // A new sweep replaces the last one rather than adding to it.
+    await altSelect(page, 3, 3)
+    expect(await selected(page)).toEqual([3])
+})
+
+test('dragging a selected chest moves the whole selection in one undo step', async ({ page }) => {
+    await openEditorWithChests(page)
+    await altSelect(page, 1, 2)
+
+    const before = [await positionOf(page, 1), await positionOf(page, 2), await positionOf(page, 3)]
+    const rev = await revision(page)
+
+    await dragChest(page, 1, { x: 0, y: 3 })
+
+    expect(await positionOf(page, 1)).toEqual({ x: before[0].x, y: before[0].y + 3 })
+    expect(await positionOf(page, 2)).toEqual({ x: before[1].x, y: before[1].y + 3 })
+    // the chest that was not selected stays put
+    expect(await positionOf(page, 3)).toEqual(before[2])
+    expect(await revision(page)).toBe(rev + 1)
+    // still selected afterwards, and still both of them
+    expect(await selected(page)).toEqual([1, 2])
+})
+
+test('a left drag on empty space still pans, with a selection active', async ({ page }) => {
+    await openEditorWithChests(page)
+    await altSelect(page, 1, 2)
+
+    const chest = await screenOf(page, 2)
+    const empty = { x: chest.x, y: chest.y + 240 }
+    await page.mouse.move(empty.x, empty.y)
+    expect(await modeOf(page)).toBe('NONE')
+
+    await page.mouse.down()
+    expect(await modeOf(page)).toBe('PAN')
+    await page.mouse.move(empty.x + 64, empty.y + 32)
+    await page.mouse.up()
+    expect(await modeOf(page)).toBe('NONE')
+    expect(await selected(page)).toEqual([1, 2])
+})
+
+test('a press on a chest that is not selected opens its editor, as it always did', async ({
+    page,
+}) => {
+    await openEditorWithChests(page)
+    await altSelect(page, 1, 2)
+
+    const chest = await screenOf(page, 3)
+    await page.mouse.move(chest.x, chest.y)
+    expect(await modeOf(page)).toBe('EDIT')
+    await page.mouse.down()
+    await page.mouse.up()
+    expect(await dialogs(page)).toBe(1)
+    expect(await selected(page)).toEqual([1, 2])
+})
+
+test('a click on a selected chest, without dragging, opens its editor too', async ({ page }) => {
+    await openEditorWithChests(page)
+    await altSelect(page, 1, 2)
+
+    const chest = await screenOf(page, 1)
+    await page.mouse.move(chest.x, chest.y)
+    await page.mouse.down()
+    expect(await modeOf(page)).toBe('MOVE')
+    await page.mouse.up()
+    expect(await dialogs(page)).toBe(1)
+    expect(await positionOf(page, 1)).toEqual(await positionOf(page, 1))
+})
+
+test('Escape mid-drag puts everything back and writes nothing', async ({ page }) => {
+    await openEditorWithChests(page)
+    await altSelect(page, 1, 2)
+
+    const before = [await positionOf(page, 1), await positionOf(page, 2)]
+    const rev = await revision(page)
+
+    const at = await screenOf(page, 1)
+    const px = await tilePx(page)
+    await page.mouse.move(at.x, at.y)
+    await page.mouse.down()
+    await page.mouse.move(at.x, at.y + 3 * px, { steps: 4 })
+    expect(await modeOf(page)).toBe('MOVE')
+
+    await page.keyboard.press('Escape')
+    expect(await modeOf(page)).not.toBe('MOVE')
+    await page.mouse.up()
+
+    expect(await positionOf(page, 1)).toEqual(before[0])
+    expect(await positionOf(page, 2)).toEqual(before[1])
+    expect(await revision(page)).toBe(rev)
+    expect(await selected(page)).toEqual([1, 2])
+})
+
+test('a drag onto an occupied tile shows blocked and does not commit', async ({ page }) => {
+    await openEditorWithChests(page)
+    await altSelect(page, 1, 1)
+
+    const before = await positionOf(page, 1)
+    const rev = await revision(page)
+
+    const at = await screenOf(page, 1)
+    const px = await tilePx(page)
+    await page.mouse.move(at.x, at.y)
+    await page.mouse.down()
+    // one tile right is chest 2, which is not part of the selection
+    await page.mouse.move(at.x + px, at.y, { steps: 2 })
+    expect(await modeOf(page)).toBe('MOVE')
+    expect(await blocked(page, 1)).toBe(true)
+
+    await page.mouse.up()
+    expect(await positionOf(page, 1)).toEqual(before)
+    expect(await revision(page)).toBe(rev)
+    expect(await blocked(page, 1)).toBe(false)
+})
+
+test('Shift+F mirrors the selection in place, in one undo step', async ({ page }) => {
+    await openEditorWithChests(page)
+    await altSelect(page, 1, 2)
+
+    const one = await positionOf(page, 1)
+    const two = await positionOf(page, 2)
+    const rev = await revision(page)
+
+    // pointer off the chests so nothing is hovered or carried
+    await page.mouse.move(one.x, one.y + 240)
+    await page.keyboard.down('Shift')
+    await page.keyboard.press('KeyF')
+    await page.keyboard.up('Shift')
+
+    // about the pair's own centre, so the two swap x and keep y
+    expect(await positionOf(page, 1)).toEqual(two)
+    expect(await positionOf(page, 2)).toEqual(one)
+    expect(await revision(page)).toBe(rev + 1)
+})
+
+test('Escape with nothing in progress clears the selection', async ({ page }) => {
+    await openEditorWithChests(page)
+    await altSelect(page, 1, 2)
+    expect(await selected(page)).toEqual([1, 2])
+
+    await page.keyboard.press('Escape')
+    expect(await selected(page)).toEqual([])
+})
+
+test('Q clears the selection too, not just Escape', async ({ page }) => {
+    await openEditorWithChests(page)
+    await altSelect(page, 1, 2)
+    expect(await selected(page)).toEqual([1, 2])
+
+    // empty space, so Q's EDIT-mode pipette branch does not also fire
+    const chest = await screenOf(page, 1)
+    await page.mouse.move(chest.x, chest.y + 240)
+    await page.keyboard.press('KeyQ')
+    expect(await selected(page)).toEqual([])
+})
+
+test('a tap of Alt toggles the info overlay; held to Alt-drag a selection it does not', async ({
+    page,
+}) => {
+    await openEditorWithChests(page)
+    const initial = await infoVisible(page)
+
+    await page.keyboard.down('Alt')
+    await page.keyboard.up('Alt')
+    expect(await infoVisible(page)).toBe(!initial)
+
+    // back to the starting state before the real assertion
+    await page.keyboard.down('Alt')
+    await page.keyboard.up('Alt')
+    expect(await infoVisible(page)).toBe(initial)
+
+    await altSelect(page, 1, 2)
+    expect(await infoVisible(page)).toBe(initial)
+    expect(await selected(page)).toEqual([1, 2])
+})
+
+test('deleting a selected chest by other means drops it from the selection', async ({ page }) => {
+    await openEditorWithChests(page)
+    await altSelect(page, 1, 2)
+
+    // the existing Ctrl+Right-drag delete, over chest 2 alone
+    const chest = await screenOf(page, 2)
+    await page.mouse.move(chest.x, chest.y)
+    await page.keyboard.down('Control')
+    await page.mouse.down({ button: 'right' })
+    expect(await modeOf(page)).toBe('DELETE')
+    await page.mouse.up({ button: 'right' })
+    await page.keyboard.up('Control')
+
+    expect(await selected(page)).toEqual([1])
+})


### PR DESCRIPTION
Ctrl-drag already sweeps and copies, Ctrl+Right-drag already sweeps and deletes, but both throw the swept list away the moment the mouse button is released. There's no way to select a group and then decide what to do with it, and no way to move an existing group at all short of copying it, placing the copy, and deleting the originals by hand.

Alt+Left-drag sweeps a rectangle the same way copy/delete do, except the entities it covers stay selected after release. A plain Left-drag starting on one of them now picks up and moves the whole group; empty space or a non-selected entity still pans/opens its editor exactly as before. The drag itself writes nothing to the model until it's dropped - it only displaces the sprites - so a completed move is one undo step and cancelling (Escape or right-click) is a real no-op, not a remove that needs undoing back.

Shift+F/Shift+G mirror the selection in place, reusing the existing per-entity flip math rather than duplicating it. Q and Escape both clear the selection, and deleting a selected entity through the existing Ctrl+Right-drag drops it from the selection automatically.

What changed:
- New EditorMode.SELECT (Alt+Left-drag) and EditorMode.MOVE (drag a selected entity), both in BlueprintContainer
- Selection highlight uses Factorio's own multiplayer_selection cursor box, tracked independently of hover/copy/delete so it doesn't fight with them
- New PositionGrid.canGroupRelocate - canMoveTo lifts only one entity out of the grid before checking, so it wrongly refuses a group whose members would block each other (two entities shifting along their own row, for instance); the group form lifts all of them first
- New Entity.relocate, the unchecked write behind a group commit; the position setter now routes through it after its own checks
- Fixed a side effect this surfaced: AltLeft also toggles the entity-info overlay (showInfo), so an Alt-drag was flipping it on every select. The toggle now fires on Alt's key-up and is skipped when a drag happened during the hold - tapping Alt still shows it, holding it to drag doesn't
- vp check clean, vp test 300/300 (new groupRelocation.test.ts included), 12 new Playwright cases in persistent-selection.spec.ts plus the existing mode/keybind specs re-run clean