### PR TITLE
Cap the agricultural tower's mast with its crane hub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,5 +400,26 @@ against the CSP in `packages/website/public/_headers` that permits them.
   of the rail, because which cells it blocks depends on the size of the box
   asking, and #142 measured that the game's published `tile_width` does not
   help either. Both are closed. #183 is the live rail defect.
+- The agricultural tower's crane is nine 3D parts the engine poses from live
+  entity state (`LuaEntity.crane_destination`) and projects with a camera the
+  prototype never describes. Only `crane.parts[0]`, the hub, is drawable from
+  data, and it alone carries `allow_sprite_rotation: false`, so its 128 frames
+  are true yaw where the booms store axial roll. #365 draws that one part,
+  parked at frame 0, offset by a fitted 0.526 screen tiles per tile of world
+  height - fitted, because nothing in the data gives the factor. The booms also
+  need `is_contractible_by_cropping` and an arm pose that only exists at
+  runtime; measured, a naive chain walk renders a 12-tile mast through the
+  tower. `tests/agricultural-tower-crane.spec.ts` pins the hub, because all five
+  guards in `craneHubLayers` return an empty array and a drop would otherwise be
+  silent.
+- The same tower's two `always_draw` working visualisations are deliberately not
+  drawn, and #365's original suggestion to draw them was wrong on both. `wv[0]`
+  is byte-identical to the base layer already drawn - it exists only to carry a
+  `fog_mask` rect, and `G.getTexture`'s cache key would hand back the very same
+  `Texture`. `wv[1]` is an `apply_recipe_tint` + `tint_as_overlay` mask, and
+  `EntitySprite` reads neither field, so it would draw as a raw mask. Check a
+  candidate visualisation against the layers already emitted before adding it;
+  measured over all 155 entities, `agricultural-tower` and `big-mining-drill`
+  are the ones where an `always_draw` entry duplicates the main animation.
 - Logistic filters retain quality metadata but the UI has no quality picker.
 - Blueprint icons round-trip, but the UI has no icon picker.

--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -154,6 +154,7 @@ import {
     ValvePrototype,
     WallPrototype,
     RailPrototype,
+    Vector3D,
 } from 'factorio:prototype'
 import { Animation } from 'factorio:prototype'
 import { Animation4Way } from 'factorio:prototype'
@@ -984,10 +985,84 @@ function generateGraphics(e: EntityWithOwnerPrototype): (data: IDrawData) => rea
 function draw_accumulator(e: AccumulatorPrototype): (data: IDrawData) => readonly SpriteData[] {
     return () => need(e, 'chargable_graphics', 'picture', 'layers')
 }
+/**
+ * Screen tiles of rise per tile of world height, used to place the crane's 3D
+ * origin. Fitted, not measured. Factorio projects the crane with a camera the
+ * prototype does not describe - `should_scale_for_perspective` names a
+ * perspective projection whose parameters appear nowhere in the data - so this
+ * is derived from `drawing_box_vertical_extension: 2.5` and checked by eye:
+ * 0.35 sinks the hub into the dome, 0.75 leaves a gap under it. The x half
+ * needs no factor and confirms the rest: `origin.x` of 0.5 tiles lands the hub
+ * 15.5 px right of the sprite centre against the base's mast at 15.0 px.
+ */
+const CRANE_HEIGHT_TO_SCREEN_TILES = 0.526
+
+/**
+ * Which of the hub's 128 yaw frames to park the crane at. A blueprint carries
+ * no crane state - the game poses the arm from `LuaEntity.crane_destination`,
+ * which is live entity state - so there is no resting orientation to read and
+ * this is a choice. Frame 0 is the no-information default the rest of the file
+ * already takes (`EntitySprite.getParts` falls back to `filenames[0]`), and it
+ * is also among the tightest poses: measured over all 128 frames it is 45 px
+ * wide against 140 px at the widest, so the hub stays inside the tower's 3x3
+ * footprint instead of overhanging its neighbours.
+ */
+const CRANE_RESTING_ORIENTATION = 0
+
+/**
+ * `Vector3D` is the 3D sibling of the `Vector` `util.vectorToTuple` handles, and
+ * the crane is the only thing in data.json that uses one. Same reasoning: the
+ * type is `Struct | [x, y, z]` and the runtime data is always the tuple.
+ */
+const vector3ToTuple = (v: Vector3D): readonly [number, number, number] =>
+    Array.isArray(v) ? [v[0], v[1], v[2]] : [v.x, v.y, v.z]
+
+/**
+ * The tower's mast ends in a flat cap because the crane on top of it is nine 3D
+ * parts the engine poses and projects itself. Most of them cannot be drawn from
+ * prototype data: `arm_central` and `arm_outer` are `is_contractible_by_cropping`
+ * booms whose sheets store axial roll rather than yaw, the telescope is
+ * `scale_to_fit_model`, and all of them need an arm pose that only exists at
+ * runtime.
+ *
+ * `parts[0]`, the hub, is the exception, and it is the part that closes the
+ * mast. It is the only part with `allow_sprite_rotation: false`, so its 128
+ * frames are true yaw and the engine never rotates it further - picking one
+ * frame and placing it is the whole job. Its shadow is deliberately not
+ * emitted: `EntitySprite.getParts` drops `draw_as_shadow` layers, so it would
+ * cost a fixture layer and draw nothing.
+ */
+function craneHubLayers(e: AgriculturalTowerPrototype): readonly SpriteData[] {
+    const hub = e.crane?.parts?.[0]?.rotated_sprite
+    if (!hub) return []
+    const { filenames, lines_per_file, line_length, width, height } = hub
+    if (!filenames || !lines_per_file || !line_length || !width || !height) return []
+
+    const perFile = line_length * lines_per_file
+    const file = Math.floor(CRANE_RESTING_ORIENTATION / perFile)
+    if (file >= filenames.length) return []
+    const cell = CRANE_RESTING_ORIENTATION % perFile
+
+    const [ox, oy, oz] = vector3ToTuple(e.crane.origin)
+    const [sx, sy] = hub.shift ? util.vectorToTuple(hub.shift) : [0, 0]
+
+    return [
+        {
+            filename: filenames[file],
+            x: (cell % line_length) * width,
+            y: Math.floor(cell / line_length) * height,
+            width,
+            height,
+            scale: hub.scale,
+            shift: [ox + sx, oy - oz * CRANE_HEIGHT_TO_SCREEN_TILES + sy],
+        },
+    ]
+}
+
 function draw_agricultural_tower(
     e: AgriculturalTowerPrototype
 ): (data: IDrawData) => readonly SpriteData[] {
-    return () => (e as any).graphics_set.animation.layers
+    return () => [...(e as any).graphics_set.animation.layers, ...craneHubLayers(e)]
 }
 function draw_ammo_turret(e: AmmoTurretPrototype): (data: IDrawData) => readonly SpriteData[] {
     return (data: IDrawData) => [

--- a/tests/__fixtures__/sprite-data.json
+++ b/tests/__fixtures__/sprite-data.json
@@ -2,7 +2,7 @@
     "synthetic": {
         "accumulator": ["2:7322c197"],
         "active-provider-chest": ["2:1ba3b50f"],
-        "agricultural-tower": ["2:1ec5a67a"],
+        "agricultural-tower": ["3:aee8ae27"],
         "arithmetic-combinator": ["3:0bc34c26", "3:339accdf", "3:8884e549", "3:97476b7e"],
         "artillery-turret": ["4:09767d50", "4:849b53d8", "4:c2a8f70d", "4:ec9d7e67"],
         "artillery-wagon": ["6:3c92482e", "6:5a10aff6", "6:81f48d06", "6:9e18233e"],
@@ -159,7 +159,7 @@
     "noGrid": {
         "accumulator": ["2:7322c197"],
         "active-provider-chest": ["2:1ba3b50f"],
-        "agricultural-tower": ["2:1ec5a67a"],
+        "agricultural-tower": ["3:aee8ae27"],
         "arithmetic-combinator": ["3:0bc34c26", "3:339accdf", "3:8884e549", "3:97476b7e"],
         "artillery-turret": ["4:09767d50", "4:849b53d8", "4:c2a8f70d", "4:ec9d7e67"],
         "artillery-wagon": ["6:3c92482e", "6:5a10aff6", "6:81f48d06", "6:9e18233e"],
@@ -1001,11 +1001,11 @@
             "2:1ba3b50f"
         ],
         "agricultural-tower": [
-            "2:1ec5a67a",
-            "2:1ec5a67a",
-            "2:1ec5a67a",
-            "2:1ec5a67a",
-            "2:1ec5a67a"
+            "3:aee8ae27",
+            "3:aee8ae27",
+            "3:aee8ae27",
+            "3:aee8ae27",
+            "3:aee8ae27"
         ],
         "arithmetic-combinator": [
             "2:34aa592f",

--- a/tests/agricultural-tower-crane.spec.ts
+++ b/tests/agricultural-tower-crane.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprint as encode, packVersion as version } from './helpers/encode-blueprint'
+import { waitForEditor, loadBlueprint } from './helpers/fbe-test-api'
+
+/*
+    The agricultural tower's base sprite ends in an open-topped mast; the crane
+    that closes it is nine 3D parts the engine poses and projects. Only the hub
+    can be drawn from prototype data, and craneHubLayers draws it - see
+    spriteDataBuilder.ts.
+
+    That draw is guarded five ways (missing crane, missing rotated_sprite,
+    missing filenames / lines_per_file / line_length / width / height, and a
+    file index past the end of filenames), and every one of those guards returns
+    an empty array. So a regression here is silent: the tower drops back to its
+    two base layers and looks exactly like a tower that never had a crane. The
+    sprite-data fixture would move, but its own header says a diff there means
+    "the sprites for that entity changed" - which is how a silent drop gets
+    re-recorded rather than investigated.
+
+    This spec is the loud version. The tower is not in the committed corpus, so
+    the fixture's `real` and `noGridReal` sections cannot cover it at all.
+*/
+
+const TOWER = encode({
+    item: 'blueprint',
+    version: version(2, 0, 55),
+    entities: [{ entity_number: 1, name: 'agricultural-tower', position: { x: 0.5, y: 0.5 } }],
+})
+
+/** base + base shadow + the crane hub. */
+const EXPECTED_LAYERS = 3
+
+test('an agricultural tower draws its crane hub, not just its base', async ({ page }) => {
+    const pageErrors: string[] = []
+    page.on('pageerror', e => pageErrors.push(String(e)))
+
+    await waitForEditor(page)
+    await loadBlueprint(page, TOWER)
+
+    const digests = await page.evaluate(
+        () => window.__fbe_test.spriteDataTally()['agricultural-tower'] ?? []
+    )
+
+    expect(digests).toHaveLength(1)
+    expect(digests.filter(d => d === 'FAILED')).toEqual([])
+    // A dropped hub reads as `2:`, which is what every guard in craneHubLayers
+    // falls back to.
+    expect(digests.every(d => d.startsWith(`${EXPECTED_LAYERS}:`))).toBe(true)
+
+    expect(pageErrors, `page errors: ${pageErrors.join(' | ')}`).toEqual([])
+})
+
+test('the crane hub is parked at one orientation for every facing', async ({ page }) => {
+    const pageErrors: string[] = []
+    page.on('pageerror', e => pageErrors.push(String(e)))
+
+    await waitForEditor(page)
+
+    /*
+        A blueprint carries no crane state, so CRANE_RESTING_ORIENTATION is a
+        fixed frame and the tower must draw identically whichever way it is
+        turned - including the entry that omits `direction` altogether. If this
+        ever splits into distinct digests, the hub frame has picked up a
+        dependency on facing that nothing in the prototype justifies.
+    */
+    const digests = await page.evaluate(
+        () =>
+            window.__fbe_test.paintPreviewTally([0, 4, 8, 12, undefined])['agricultural-tower'] ??
+            []
+    )
+
+    expect(digests).toHaveLength(5)
+    expect(digests.filter(d => d === 'FAILED')).toEqual([])
+    expect(digests.every(d => d.startsWith(`${EXPECTED_LAYERS}:`))).toBe(true)
+    expect(new Set(digests).size).toBe(1)
+
+    expect(pageErrors, `page errors: ${pageErrors.join(' | ')}`).toEqual([])
+})


### PR DESCRIPTION
Closes #365

## What was wrong

The tower drew two layers, its base and its shadow, and the base sprite's mast
ends in a flat dark cap. The crane that belongs on top was missing entirely.

## What this draws

`crane.parts[0]`, the hub. It is the one part of the nine that can be drawn from
prototype data, and it is the part that closes the mast:

| part | drawn | why not |
| --- | --- | --- |
| hub | **yes** | `allow_sprite_rotation: false`, so its 128 frames are true yaw and the engine never rotates it further |
| arm_central, arm_outer | no | `is_contractible_by_cropping` booms; their sheets store axial roll, not yaw |
| telescope | no | `scale_to_fit_model`, needs a stretch length that is runtime state |
| the rest | no | need an arm pose that only exists as `LuaEntity.crane_destination` |

Measured: walking the part chain naively and drawing all nine renders a 12-tile
mast straight through the tower. That is not a near miss, so the scope stops at
the hub.

Visually the tower goes from a dome with a black hole on top to a complete
agricultural tower. Driven in the real editor, not just composited offline.

## Two constants that are choices

Both are documented as such in the source, because neither is derivable:

- **Height factor 0.526** screen tiles per tile of world height. Factorio
  projects the crane with a camera nothing in the data describes -
  `should_scale_for_perspective` names a perspective projection whose parameters
  are absent. Fitted from `drawing_box_vertical_extension: 2.5` and checked
  either side: 0.35 sinks the hub into the dome, 0.75 leaves a gap. The x half
  needs no factor at all and corroborates the placement - `origin.x` of 0.5
  tiles lands the hub 15.5 px right of the sprite centre against the base's mast
  at 15.0 px.
- **Resting orientation frame 0.** A blueprint carries no crane state, so there
  is no pose to read. Frame 0 is the no-information default the file already
  takes elsewhere, and measured over all 128 frames it is in the tightest class
  at 45 px wide against 140 px at the widest, so the hub stays inside the 3x3
  footprint instead of overhanging neighbours.

## What this deliberately does not do

The issue proposed drawing the two `always_draw` working visualisations as the
easy half. Measuring them refuted that, and the Lua source confirms it:

- **`wv[0]` is byte-identical to the base layer already drawn.** Same file, rect,
  shift and scale; only `frame_count` differs (1 vs 64) and nothing reads it. In
  `agricultural-tower-crane.lua` it carries
  `fog_mask = { rect = {{-30,-30},{30,-2.75}}, falloff = 1 }` - it exists to be
  the fog cutout. `G.getTexture`'s cache key is
  `filename-x-y-w-h`, so drawing it would hand the second layer the very same
  `Texture` instance and stack it exactly on the first.
- **`wv[1]` is a tint mask the renderer cannot apply.** It is
  `apply_recipe_tint: "primary"` with `tint_as_overlay: true`, and neither field
  is read anywhere in the repo. Untinted it draws as a raw mask over the dome.
  This is exactly the hazard #356 named when it scoped itself to the
  electromagnetic plant.

Both are recorded in `CLAUDE.md` so the next reader does not re-derive them.

## Fixture

`sprite-data.json` moves in `synthetic`, `noGrid` and `paintPreview` only:
`2:1ec5a67a` -> `3:aee8ae27`, one layer gained. `real` and `noGridReal` do not
move and must not - the 372-blueprint corpus holds no agricultural tower, which
I counted directly (the same decoder totals 372 blueprints and 350,862 entities,
matching the two figures the suite already pins).

## New spec

Every one of the five guards in `craneHubLayers` returns an empty array, so a
regression drops the tower silently back to two layers and looks like a tower
that never had a crane - and the fixture's own header invites re-recording a
diff rather than investigating it. `tests/agricultural-tower-crane.spec.ts` is
the loud version. Mutation checked both ways:

- forcing `craneHubLayers` to return `[]` fails both tests on the layer count;
- making the hub frame depend on `data.dir` fails only the
  direction-independence test.

Full local run: `vp check` clean, `vp test` 300 passed, `npx playwright test`
258 passed.

## Follow-ups found while measuring

A sweep of all 155 entities with `always_draw` working visualisations turned up
three more defects of this class:

- #372 - the foundry renders with no pipe connectors at all (538 in the corpus,
  the most common entity affected)
- #373 - the cryogenic plant never draws its glass layer
- #374 - big-mining-drill draws two of its layers twice

and #375 covers the three short crane parts this PR stopped short of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvzvJMADddKYcNcAKvc4wP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Agricultural tower cranes now display a crane hub layer alongside the existing tower animation.
  - Crane hub rendering remains consistent across different viewing directions, including unspecified directions.
  - Incomplete or unavailable crane data is handled gracefully without disrupting tower rendering.

- **Documentation**
  - Added guidance describing supported agricultural tower crane rendering behavior and known visual limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
