### PR TITLE
Cap the three cargo hatches with their closed lids

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,5 +421,30 @@ against the CSP in `packages/website/public/_headers` that permits them.
   candidate visualisation against the layers already emitted before adding it;
   measured over all 155 entities, `agricultural-tower` and `big-mining-drill`
   are the ones where an `always_draw` entry duplicates the main animation.
+- Cargo hatches are drawn parked shut, and that is frame 0 for free - the
+  editor draws frame 0 of every sheet and nothing reads `frame_count`. Three
+  entities have one, and each drew a hole until #362: `cargo-bay` through
+  `hatch_definitions`, `cargo-landing-pad` and `space-platform-hub` through
+  `cargo_station_parameters.giga_hatch_definitions`. Their plain hatches carry
+  no `hatch_graphics` at all, so the giga hatch is the only drawable one.
+  Placement differs between the two: a plain hatch needs `offset` plus each
+  layer's own `shift`, which the shadow layer settles - only that sum lands it
+  in the band the bay's own shadow occupies. A giga hatch has no `offset`.
+  `tests/cargo-hatches.spec.ts` pins all three by layer count, because every
+  guard in both helpers returns an empty array and a drop would otherwise be
+  silent.
+- The cargo bay's five `bridge_*` connection pieces are still not drawn, and
+  the fix is not "add them to the neighbour logic" (issue #362). Measured: all
+  five stay inside the bay's own 4x4 footprint, so they are not spans drawn
+  into a gap; Factorio 2.1 replaced the 12 named wall and corner keys with
+  `tileset` plus a `tileset_mapping` bitmask and left the bridges outside it,
+  so the choice is not a function of the 8-neighbour mask
+  `getCargoBayConnectionSprites` computes. No committed blueprint needs one:
+  bays sit on a 4-tile lattice throughout, gaps are 0, 4 or 8 tiles and never
+  2, and no bay is a pass-through. Two smaller items on the same issue are
+  measured and open: `render_layer` is discarded, which reorders layers on 10
+  of the 14 corpus neighbour masks but changes at most 684 pixels and none at
+  all on the commonest one; and `variants[0]` is taken unconditionally where
+  the game picks at random from 4 wall or 2 corner variants.
 - Logistic filters retain quality metadata but the UI has no quality picker.
 - Blueprint icons round-trip, but the UI has no icon picker.

--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -90,6 +90,7 @@ import {
     BoilerPrototype,
     BurnerGeneratorPrototype,
     CargoBayPrototype,
+    CargoHatchDefinition,
     CargoLandingPadPrototype,
     CargoWagonPrototype,
     ConstantCombinatorPrototype,
@@ -143,6 +144,7 @@ import {
     RocketSiloPrototype,
     SelectorCombinatorPrototype,
     SolarPanelPrototype,
+    GigaCargoHatchDefinition,
     SpacePlatformHubPrototype,
     SplitterPrototype,
     StorageTankPrototype,
@@ -1448,6 +1450,83 @@ function getCargoBayConnectionSprites(
     return sprites
 }
 
+/**
+ * A cargo hatch is an animation of a lid opening for an arriving pod, and the
+ * three entities that have one draw a hole under it that nothing else fills.
+ * Unfixed, `cargo-bay` renders a black 0.75 x 0.66 tile notch ringed with red
+ * indicator lights, and `cargo-landing-pad` and `space-platform-hub` render an
+ * open pit several tiles across - on those two it is the entity's dominant
+ * feature.
+ *
+ * Frame 0 is the lid shut, so no frame has to be asked for: the editor already
+ * draws frame 0 of every sheet, because `EntitySprite.getParts` passes `data.x`
+ * and `data.y`, which default to 0, and nothing reads `frame_count`. Measured
+ * against the 2.0.77 art, the bay lid's opaque pixel count falls monotonically
+ * from 2378 at frame 0 to 1843 at frame 20, and the Lua sets
+ * `run_mode = "forward-then-backward"`, which puts the resting pose at frame 0.
+ * The giga hatches agree: frame 0 is their brightest and most covered frame.
+ *
+ * `draw_as_shadow` layers are dropped for the reason `craneHubLayers` drops
+ * one - `EntitySprite.getParts` skips them, so each would cost a fixture layer
+ * and draw nothing. The emission layers are kept: they are `blend_mode:
+ * "additive"`, which `EntitySprite` maps to Pixi's `add`, and on the bay that
+ * is a red idle status light. This is not the `agricultural-tower` trap, where
+ * the unread field was `tint_as_overlay`.
+ */
+function cargoHatchLayers(
+    hatches: readonly CargoHatchDefinition[] | undefined
+): readonly SpriteData[] {
+    if (!Array.isArray(hatches)) return []
+
+    const layers: SpriteData[] = []
+    for (const hatch of hatches) {
+        if (!hatch?.hatch_graphics) continue
+        // `offset` places the hatch on the entity and each layer's own `shift`
+        // places the art within the hatch, so both apply. The shadow layer is
+        // what settles that: only `offset + shift` lands it in the band the
+        // bay's own shadow occupies (x 1.88..4.50 against the picture's
+        // 1.09..4.38), where `offset` alone puts it on top of the bay body. It
+        // is also the placement that covers the hole, leaving 64 of its 663
+        // dark pixels where `offset` alone leaves 268.
+        const offset = hatch.offset ? util.vectorToTuple(hatch.offset) : ([0, 0] as const)
+        for (const layer of layersOf(hatch.hatch_graphics)) {
+            if (layer.draw_as_shadow) continue
+            layers.push(addToShift(offset, util.duplicate(layer)))
+        }
+    }
+    return layers
+}
+
+/**
+ * The landing pad and the platform hub cover their plain hatches with one big
+ * one, and it is the giga hatch that carries the graphics - every entry in
+ * their `hatch_definitions` has no `hatch_graphics` at all. See
+ * `cargoHatchLayers` for why frame 0 is the pose to draw.
+ *
+ * A `GigaCargoHatchDefinition` has no `offset`; each layer's `shift` is the
+ * whole placement. Back before front is both the definition order and the draw
+ * order - `hatch_render_layer_back` and `hatch_render_layer_front` are both
+ * `above-inserters` here, which is also the layer of the occluder the picture
+ * already ends with, so appending keeps the engine's order.
+ */
+function gigaCargoHatchLayers(
+    hatches: readonly GigaCargoHatchDefinition[] | undefined
+): readonly SpriteData[] {
+    if (!Array.isArray(hatches)) return []
+
+    const layers: SpriteData[] = []
+    for (const hatch of hatches) {
+        for (const animation of [hatch?.hatch_graphics_back, hatch?.hatch_graphics_front]) {
+            if (!animation) continue
+            for (const layer of layersOf(animation)) {
+                if (layer.draw_as_shadow) continue
+                layers.push(util.duplicate(layer))
+            }
+        }
+    }
+    return layers
+}
+
 function draw_cargo_bay(e: CargoBayPrototype): (data: IDrawData) => readonly SpriteData[] {
     return (data: IDrawData) => {
         const base = (e as any).graphics_set.picture.flatMap((p: any) => p.layers)
@@ -1456,7 +1535,7 @@ function draw_cargo_bay(e: CargoBayPrototype): (data: IDrawData) => readonly Spr
             data.position,
             data.positionGrid
         )
-        return [...connections, ...base]
+        return [...connections, ...base, ...cargoHatchLayers(e.hatch_definitions)]
     }
 }
 function draw_cargo_landing_pad(
@@ -1469,7 +1548,11 @@ function draw_cargo_landing_pad(
             data.position,
             data.positionGrid
         )
-        return [...connections, ...base]
+        return [
+            ...connections,
+            ...base,
+            ...gigaCargoHatchLayers(e.cargo_station_parameters?.giga_hatch_definitions),
+        ]
     }
 }
 function draw_cargo_wagon(e: CargoWagonPrototype): (data: IDrawData) => readonly SpriteData[] {
@@ -2529,7 +2612,10 @@ function draw_solar_panel(e: SolarPanelPrototype): (data: IDrawData) => readonly
 function draw_space_platform_hub(
     e: SpacePlatformHubPrototype
 ): (data: IDrawData) => readonly SpriteData[] {
-    return () => (e as any).graphics_set.picture.flatMap((p: any) => p.layers)
+    return () => [
+        ...(e as any).graphics_set.picture.flatMap((p: any) => p.layers),
+        ...gigaCargoHatchLayers(e.cargo_station_parameters?.giga_hatch_definitions),
+    ]
 }
 function draw_splitter(e: SplitterPrototype): (data: IDrawData) => readonly SpriteData[] {
     return (data: IDrawData) => {

--- a/tests/__fixtures__/sprite-data.json
+++ b/tests/__fixtures__/sprite-data.json
@@ -24,8 +24,8 @@
         "burner-inserter": ["3:23c96fbe", "3:2b93478c", "3:6f4acc29", "3:ca754e03"],
         "burner-mining-drill": ["2:5a05aec3", "2:76febf43", "2:97b66334", "2:c263ae5e"],
         "captive-biter-spawner": ["2:26deb24e"],
-        "cargo-bay": ["42:966b3e85"],
-        "cargo-landing-pad": ["13:bccc3ca7"],
+        "cargo-bay": ["44:2f318bc5"],
+        "cargo-landing-pad": ["17:ef1e8a06"],
         "cargo-pod-container": ["2:69ebec7c"],
         "cargo-wagon": ["3:595d3990", "3:5ce699af", "3:74b86925", "3:f31225fe"],
         "centrifuge": ["6:5ca9d563"],
@@ -131,7 +131,7 @@
         "small-electric-pole": ["1:685ccfa6"],
         "small-lamp": ["2:988e4aa4"],
         "solar-panel": ["2:b86cb635"],
-        "space-platform-hub": ["15:3486a776"],
+        "space-platform-hub": ["22:261eb6a9"],
         "splitter": ["8:188df570", "8:4b96fdf2", "8:9ba6c22b", "8:b49efd1c"],
         "stack-inserter": ["3:14e51b74", "3:18aeace5", "3:22fbb480", "3:e2536683"],
         "steam-engine": ["4:2264dd84", "4:4879a94e", "4:6624eb32", "4:778cff42"],
@@ -181,8 +181,8 @@
         "burner-inserter": ["3:23c96fbe", "3:2b93478c", "3:6f4acc29", "3:ca754e03"],
         "burner-mining-drill": ["2:5a05aec3", "2:76febf43", "2:97b66334", "2:c263ae5e"],
         "captive-biter-spawner": ["2:26deb24e"],
-        "cargo-bay": ["5:d40e4267"],
-        "cargo-landing-pad": ["13:bccc3ca7"],
+        "cargo-bay": ["7:7958b553"],
+        "cargo-landing-pad": ["17:ef1e8a06"],
         "cargo-pod-container": ["2:69ebec7c"],
         "cargo-wagon": ["3:595d3990", "3:5ce699af", "3:74b86925", "3:f31225fe"],
         "centrifuge": ["6:5ca9d563"],
@@ -288,7 +288,7 @@
         "small-electric-pole": ["1:685ccfa6"],
         "small-lamp": ["2:988e4aa4"],
         "solar-panel": ["2:b86cb635"],
-        "space-platform-hub": ["15:3486a776"],
+        "space-platform-hub": ["22:261eb6a9"],
         "splitter": ["8:188df570", "8:4b96fdf2", "8:9ba6c22b", "8:b49efd1c"],
         "stack-inserter": ["3:14e51b74", "3:18aeace5", "3:22fbb480", "3:e2536683"],
         "steam-engine": ["4:2264dd84", "4:4879a94e", "4:6624eb32", "4:778cff42"],
@@ -401,8 +401,8 @@
             "6:671aa8bf",
             "6:ed98fae1"
         ],
-        "cargo-bay": ["5:d40e4267"],
-        "cargo-landing-pad": ["13:bccc3ca7"],
+        "cargo-bay": ["7:7958b553"],
+        "cargo-landing-pad": ["17:ef1e8a06"],
         "cargo-wagon": ["3:f31225fe"],
         "centrifuge": ["6:5ca9d563", "9:8bd93858"],
         "chemical-plant": [
@@ -899,7 +899,7 @@
         "small-electric-pole": ["1:1d482b65", "1:57985197", "1:685ccfa6", "1:79d94a79"],
         "small-lamp": ["2:988e4aa4", "5:ee0efe0a"],
         "solar-panel": ["2:b86cb635"],
-        "space-platform-hub": ["15:3486a776"],
+        "space-platform-hub": ["22:261eb6a9"],
         "splitter": ["8:188df570", "8:4b96fdf2", "8:9ba6c22b", "8:b49efd1c"],
         "stack-inserter": [
             "3:14e51b74",
@@ -1076,13 +1076,13 @@
             "2:26deb24e",
             "2:26deb24e"
         ],
-        "cargo-bay": ["5:d40e4267", "5:d40e4267", "5:d40e4267", "5:d40e4267", "5:d40e4267"],
+        "cargo-bay": ["7:7958b553", "7:7958b553", "7:7958b553", "7:7958b553", "7:7958b553"],
         "cargo-landing-pad": [
-            "13:bccc3ca7",
-            "13:bccc3ca7",
-            "13:bccc3ca7",
-            "13:bccc3ca7",
-            "13:bccc3ca7"
+            "17:ef1e8a06",
+            "17:ef1e8a06",
+            "17:ef1e8a06",
+            "17:ef1e8a06",
+            "17:ef1e8a06"
         ],
         "cargo-pod-container": [
             "2:69ebec7c",
@@ -1406,11 +1406,11 @@
         "small-lamp": ["2:988e4aa4", "2:988e4aa4", "2:988e4aa4", "2:988e4aa4", "2:988e4aa4"],
         "solar-panel": ["2:b86cb635", "2:b86cb635", "2:b86cb635", "2:b86cb635", "2:b86cb635"],
         "space-platform-hub": [
-            "15:3486a776",
-            "15:3486a776",
-            "15:3486a776",
-            "15:3486a776",
-            "15:3486a776"
+            "22:261eb6a9",
+            "22:261eb6a9",
+            "22:261eb6a9",
+            "22:261eb6a9",
+            "22:261eb6a9"
         ],
         "splitter": ["8:188df570", "8:9ba6c22b", "8:b49efd1c", "8:4b96fdf2", "8:188df570"],
         "stack-inserter": ["3:18aeace5", "3:e2536683", "3:22fbb480", "3:14e51b74", "3:18aeace5"],
@@ -1548,19 +1548,19 @@
             "6:ed98fae1"
         ],
         "cargo-bay": [
-            "10:8b0cef60",
-            "10:df6bf593",
-            "17:bd2cf44d",
-            "19:8c9bd978",
-            "19:e954dc65",
-            "20:55525606",
-            "5:d40e4267",
-            "9:070569a6",
-            "9:51ac852b",
-            "9:5a86f5ac",
-            "9:ebacf6b9"
+            "11:668cdc94",
+            "11:8a966fb1",
+            "11:b2a7f51f",
+            "11:d47f447a",
+            "12:321e6bb7",
+            "12:e254dfb0",
+            "19:aa31afdd",
+            "21:010a5e98",
+            "21:b6a6f3a5",
+            "22:4c9f425a",
+            "7:7958b553"
         ],
-        "cargo-landing-pad": ["13:bccc3ca7"],
+        "cargo-landing-pad": ["17:ef1e8a06"],
         "cargo-wagon": ["3:f31225fe"],
         "centrifuge": ["6:5ca9d563", "9:8bd93858"],
         "chemical-plant": [
@@ -2511,7 +2511,7 @@
         "small-electric-pole": ["1:1d482b65", "1:57985197", "1:685ccfa6", "1:79d94a79"],
         "small-lamp": ["2:988e4aa4", "5:ee0efe0a"],
         "solar-panel": ["2:b86cb635"],
-        "space-platform-hub": ["15:3486a776"],
+        "space-platform-hub": ["22:261eb6a9"],
         "splitter": [
             "4:0e7b6fc9",
             "4:8438a2b4",

--- a/tests/cargo-hatches.spec.ts
+++ b/tests/cargo-hatches.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprint as encode, packVersion as version } from './helpers/encode-blueprint'
+import { waitForEditor, loadBlueprint } from './helpers/fbe-test-api'
+
+/*
+    Three entities draw a hole in their base art and cover it with a cargo
+    hatch: cargo-bay with a plain `hatch_definitions` entry, cargo-landing-pad
+    and space-platform-hub with a `giga_hatch_definitions` one. Before
+    cargoHatchLayers and gigaCargoHatchLayers the hole was all you saw - a black
+    notch ringed with red indicator lights on the bay, an open pit several tiles
+    across on the other two.
+
+    Both helpers bail to an empty array on every guard: a missing definitions
+    array, a definition with no graphics, an animation with no layers. So a
+    regression is silent - each entity drops back to exactly the layers it had
+    before and looks like an entity that never had a hatch. The sprite-data
+    fixture would move, but its own header says a diff there means "the sprites
+    for that entity changed", which is how a silent drop gets re-recorded rather
+    than investigated.
+
+    This spec is the loud version, and it is a layer-count check on purpose. The
+    fixture already covers placement, because its hash covers the fields that
+    decide where each layer lands - so a hatch drawn at the wrong offset moves a
+    digest there. What the fixture cannot say is which layers were meant to be
+    present, and that is what these counts pin.
+
+    Counts are base layers plus the hatch layers that survive the
+    `draw_as_shadow` filter, since `EntitySprite.getParts` drops shadows at
+    render time and both helpers drop them at build time to match.
+*/
+
+const HATCHES = {
+    /** 5 picture layers + lid + emission. Without the hatch: 5. */
+    'cargo-bay': 7,
+    /** 13 picture layers + back, back emission, front emission, front. Without: 13. */
+    'cargo-landing-pad': 17,
+    /** 15 picture layers + 7 across two giga hatches. Without: 15. */
+    'space-platform-hub': 22,
+} as const
+
+/*
+    A lone cargo bay draws the *most* connection sprites, not the fewest: with a
+    position grid and nothing adjacent, all four walls and all four outer
+    corners apply, which is 37 layers on top of the 7 below. So the counts above
+    are the grid-free ones, and the bay's grid-backed total is pinned separately.
+*/
+const BAY_ALONE_WITH_GRID = 44
+
+/*
+    Placed far enough apart that no footprint touches another, so every entity
+    is judged on its own layers. The bay is 4x4, the landing pad 8x8 and the hub
+    24x24, and only the bay reads the position grid at all.
+*/
+const HATCH_ENTITIES = encode({
+    item: 'blueprint',
+    version: version(2, 0, 55),
+    entities: [
+        { entity_number: 1, name: 'cargo-bay', position: { x: 0, y: 0 } },
+        { entity_number: 2, name: 'cargo-landing-pad', position: { x: 40, y: 0 } },
+        { entity_number: 3, name: 'space-platform-hub', position: { x: 100, y: 0 } },
+    ],
+})
+
+test('cargo bay, landing pad and platform hub all draw their hatch', async ({ page }) => {
+    const pageErrors: string[] = []
+    page.on('pageerror', e => pageErrors.push(String(e)))
+
+    await waitForEditor(page)
+    await loadBlueprint(page, HATCH_ENTITIES)
+
+    const digests = await page.evaluate(() =>
+        window.__fbe_test.spriteDataTally(undefined, { withGrid: false })
+    )
+
+    for (const [name, layers] of Object.entries(HATCHES)) {
+        expect(digests[name], `${name} drew nothing`).toHaveLength(1)
+        expect(
+            digests[name].filter(d => d === 'FAILED'),
+            `${name} failed to generate`
+        ).toEqual([])
+        expect(digests[name][0].split(':')[0], `${name} layer count`).toBe(String(layers))
+    }
+
+    expect(pageErrors, `page errors: ${pageErrors.join(' | ')}`).toEqual([])
+})
+
+test('the bay draws its hatch on top of its connection sprites, not instead of them', async ({
+    page,
+}) => {
+    const pageErrors: string[] = []
+    page.on('pageerror', e => pageErrors.push(String(e)))
+
+    await waitForEditor(page)
+    await loadBlueprint(page, HATCH_ENTITIES)
+
+    /*
+        draw_cargo_bay composes `[...connections, ...base, ...hatch]`, and the
+        hatch is the only one of the three that does not depend on the grid.
+        Appending rather than splicing is what keeps the hatch above the
+        occluder the picture ends with, which is the engine's order - both sit
+        on the `cargo-hatch` render layer.
+    */
+    const digests = await page.evaluate(() => window.__fbe_test.spriteDataTally())
+
+    expect(digests['cargo-bay'], 'cargo-bay drew nothing').toHaveLength(1)
+    expect(digests['cargo-bay'][0].split(':')[0], 'cargo-bay with grid').toBe(
+        String(BAY_ALONE_WITH_GRID)
+    )
+
+    expect(pageErrors, `page errors: ${pageErrors.join(' | ')}`).toEqual([])
+})
+
+test('the hatch does not depend on the position grid or on facing', async ({ page }) => {
+    const pageErrors: string[] = []
+    page.on('pageerror', e => pageErrors.push(String(e)))
+
+    await waitForEditor(page)
+
+    /*
+        The paint preview draws from a bare `{ name, direction }` with no Entity,
+        no position and no grid - the one caller that reaches
+        EntitySprite.getDrawData's defaults. A hatch carries no runtime state and
+        none of these three has a directional graphics set, so every facing must
+        come out identical, and must match the grid-free counts in the first
+        test.
+
+        Worth having as its own test because it is a different code path, not a
+        rephrasing of the first one: the preview never builds an Entity, so a
+        hatch read that came to depend on one would pass there and fail here.
+    */
+    const digests = await page.evaluate(() =>
+        window.__fbe_test.paintPreviewTally([0, 4, 8, 12, undefined])
+    )
+
+    for (const [name, layers] of Object.entries(HATCHES)) {
+        expect(digests[name], `${name} drew nothing`).toHaveLength(5)
+        expect(
+            digests[name].filter(d => d === 'FAILED'),
+            `${name} failed to generate`
+        ).toEqual([])
+        expect(
+            digests[name].every(d => d.startsWith(`${layers}:`)),
+            `${name} expected every facing at ${layers} layers, got ${digests[name].join(' ')}`
+        ).toBe(true)
+        expect(new Set(digests[name]).size, `${name} differs by facing`).toBe(1)
+    }
+
+    expect(pageErrors, `page errors: ${pageErrors.join(' | ')}`).toEqual([])
+})


### PR DESCRIPTION
Three entities draw a hole in their base art for a cargo hatch, and nothing drew the hatch. `cargo-bay` rendered a black 0.75 x 0.66 tile notch ringed with red indicator lights. `cargo-landing-pad` and `space-platform-hub` rendered an open pit several tiles across, which on those two is the entity's dominant feature. 345 of them sit in the committed corpus: 330 bays, 13 pads, 2 hubs.

The issue only named the bay. The other two turned up while measuring it, and they are the bigger defect.

| entity | drawn layers before | after | in corpus |
| --- | --- | --- | --- |
| `cargo-bay` | 5 | 7 | 330 |
| `cargo-landing-pad` | 13 | 17 | 13 |
| `space-platform-hub` | 15 | 22 | 2 |

## What was measured

The issue says outright that none of it is measured, so all four of its items were treated as hypotheses. Item 1 holds. Item 2 does not.

**Frame 0 is the lid shut, and it comes for free.** The editor already draws frame 0 of every sheet - `EntitySprite.getParts` passes `data.x` and `data.y`, which default to 0 - and nothing reads `frame_count`. Against the 2.0.77 art the bay lid's opaque pixel count falls monotonically from 2378 at frame 0 to 1843 at frame 20, and the Lua sets `run_mode = "forward-then-backward"`, which puts the resting pose at frame 0. The giga hatches agree: frame 0 is their brightest and most covered frame.

**Placement differs between the two kinds of hatch.** A plain `hatch_definitions` entry needs `offset` plus each layer's own `shift`. The shadow layer settles which, because only that sum lands it in the band the bay's own shadow occupies - x 1.88..4.50 against the picture's 1.09..4.38 - where `offset` alone puts it on top of the bay body. It is also the placement that covers the hole, leaving 64 of its 663 dark pixels where `offset` alone leaves 268. A `GigaCargoHatchDefinition` has no `offset` at all.

**The pad and the hub have no drawable plain hatch.** Every entry in their `hatch_definitions` has no `hatch_graphics`, because a giga hatch covers them, and that is where the graphics live. `rocket-silo` has a hatch definition too, with no graphics and no giga hatch, so it is untouched.

**Shadow layers are dropped**, the way `craneHubLayers` drops one: `getParts` skips them at render time, so each would cost a fixture layer and draw nothing. **Emission layers are kept** - they are `blend_mode: "additive"`, which `EntitySprite` maps to Pixi's `add`, and on the bay that is a red idle status light. This is not the agricultural tower's trap, where the unread field was `tint_as_overlay`.

All 14 textures were already in the exporter output, so no regeneration is needed.

## What did not change

Only the three entities move, across all five fixture sections, and every count moves by exactly its drawn-layer delta: bay +2, pad +4, hub +7. The `real` section's 372-blueprint count is unaffected.

Verified in the real editor with a throwaway screenshot spec, then deleted - the offline compositor cannot see draw order or the texture cache.

## Tests

`tests/cargo-hatches.spec.ts` pins presence by layer count. Every guard in both helpers returns an empty array, so a regression drops the entity back to exactly the layers it had before and looks like an entity that never had a hatch. The fixture would move, but its own header says a diff there means the sprites changed - which is how a silent drop gets re-recorded rather than investigated.

Mutation-checked both ways:

- Forcing both helpers to return nothing fails all three tests at the pre-fix numbers, 5 and 42 for the bay.
- Dropping the hatch offset instead leaves this spec green and fails all five `sprite-data` sections. That is the division of labour the spec header claims: the fixture covers placement, the spec covers which layers were meant to be there.

Full local run: 261 Playwright tests passed, 300 unit tests passed, `vp check` clean.

## Issues

Closes #377, the landing pad and platform hub half.

**#362 stays open on purpose**, so this deliberately does not close it. It covers four items; this PR fixes item 1 only. Item 2, the five `bridge_*` connection pieces, is refuted as written - the full measurement is in [a comment there](https://github.com/FactoryGameFan/factorio-blueprint-editor/issues/362#issuecomment-5556859605). Items 3 (`render_layer` discarded) and 4 (`variants[0]` taken unconditionally) are real, measured and small, and are what the issue is left tracking. `CLAUDE.md` carries the short version of all of it so nobody re-derives it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rendering support for cargo hatches on cargo bays, cargo landing pads, and space platform hubs.
  - Cargo hatches now display with appropriate placement and non-shadow graphics.

- **Bug Fixes**
  - Improved handling when hatch definitions or graphics are unavailable.
  - Preserved cargo-bay bridge connection sprites during rendering.

- **Tests**
  - Added coverage for hatch rendering across grid-free, paint-preview, and multiple-facing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
