### PR TITLE
Draw the turbine and the cockpit that graphics_set.animation holds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,6 +446,21 @@ against the CSP in `packages/website/public/_headers` that permits them.
   `tests/cargo-hatches.spec.ts` pins all three by layer count, because every
   guard in both helpers returns an empty array and a drop would otherwise be
   silent.
+- `graphics_set.animation` sits beside `graphics_set.picture` on exactly two
+  entities, and a picture-only draw dropped it until #364. Swept over all 155,
+  `cargo-landing-pad` and `space-platform-hub` are the pair; the other 22 with
+  an `animation` have no `picture` next to it and already read it. The two are
+  not the same size of defect. The pad's single layer is the fan inside its
+  turbine cowling, which the picture draws empty, so the pad rendered a black
+  hole - the same class as the open hatches above. Scored against the game's own
+  render over the fan's pixels, mean per-channel error falls 30.7 -> 20.9, and
+  under the body instead of over it the score stays at 30.7, because the body
+  covers it. The hub's 22 layers are additive `draw_as_glow` screens in the
+  cockpit windows, not the cockpit body, which `picture` always drew - so the
+  issue's "the whole cockpit missing" overstates it at 3.4% of its pixels.
+  Appending is the game's order: `animation_render_layer` defaults to `object`,
+  neither prototype sets it, and drawing it there rather than last moves 0
+  pixels on either entity. `tests/cargo-hub-animation.spec.ts` pins the split.
 - Cargo bay connection pieces are placed per 2x2 cell and per shared edge, and
   both halves are measured against Factorio 2.0.77 rather than reasoned out
   (issues #378, #362 item 2). The cell rule is Factorio 2.1's `tileset_mapping`

--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -1631,6 +1631,53 @@ function gigaCargoHatchLayers(
     return layers
 }
 
+/**
+ * `graphics_set.animation`, which sits beside `graphics_set.picture` and which
+ * neither draw function used to read (issue #364). Swept over every entity in
+ * `data.json`, `cargo-landing-pad` and `space-platform-hub` are the only two
+ * that carry both keys. The other 22 entities with an `animation` have no
+ * `picture` next to it, and their own draw functions already read it.
+ *
+ * On the landing pad this is one layer, `planet-hub-turbine.png`, and it is not
+ * a detail. The picture leaves an unfilled hole inside the turbine cowling and
+ * this is the fan that fills it, so the defect is the same shape as the open
+ * hatches of #377. Scored against Factorio 2.0.77's own render of the
+ * `pad-bays` arrangement, over the fan's own pixels, mean per-channel error
+ * falls from 30.7 with the picture alone to 20.9 at frame 0 - 10.8 at the frame
+ * the shot happened to catch, since the fan spins. A control patch the fan
+ * never touches reads 44.3 in every arm, so the gain is local to the fan.
+ *
+ * On the hub it is 22 tiny sprites, every one `blend_mode: "additive"` with
+ * `draw_as_glow`. They are the cockpit's lit screens, not the cockpit body,
+ * which `picture` already draws - so the issue's "the whole cockpit missing" is
+ * an overstatement. They move 3.4% of the hub's pixels by a mean of 9.2. They
+ * are kept rather than dropped the way the `agricultural-tower` visualisations
+ * were, because they pass the test those failed: none duplicates a layer
+ * already drawn, 0 of 22 by filename and 0 by frame-0 pixel digest, and
+ * `picture` already draws three `-emission-` layers under the same additive
+ * treatment.
+ *
+ * Frame 0 costs nothing to ask for. `EntitySprite.getParts` passes `data.x` and
+ * `data.y`, which default to 0, and nothing reads `frame_count` - the same
+ * reason `cargoHatchLayers` gets the lids shut.
+ *
+ * Appending is the game's own order. `animation_render_layer` defaults to
+ * `object` and neither prototype sets it, which puts the animation below the
+ * `cargo-hatch` and `above-inserters` occluder groups the picture ends with.
+ * Measured, drawing it there instead of last changes 0 pixels on either entity,
+ * because neither animation reaches an occluder. Order against the picture's
+ * own body does matter: under it the fan scores 30.7, exactly the same as not
+ * drawing it, because the body covers it completely.
+ */
+function graphicsSetAnimationLayers(animation: Animation | undefined): readonly SpriteData[] {
+    if (animation === undefined) return []
+    // `layers` is list-typed, so an empty one exports as `{}` rather than `[]`
+    // and survives a `!== undefined` guard. Read it through `Array.isArray`.
+    const layers = (animation as { layers?: unknown }).layers
+    if (Array.isArray(layers)) return (layers as readonly SpriteData[]).map(l => util.duplicate(l))
+    return 'filename' in animation ? [util.duplicate(animation as unknown as SpriteData)] : []
+}
+
 function draw_cargo_bay(e: CargoBayPrototype): (data: IDrawData) => readonly SpriteData[] {
     return (data: IDrawData) => {
         const base = (e as any).graphics_set.picture.flatMap((p: any) => p.layers)
@@ -1659,6 +1706,7 @@ function draw_cargo_landing_pad(
         return [
             ...connections,
             ...base,
+            ...graphicsSetAnimationLayers((e as any).graphics_set.animation),
             ...gigaCargoHatchLayers(e.cargo_station_parameters?.giga_hatch_definitions),
         ]
     }
@@ -2733,6 +2781,7 @@ function draw_space_platform_hub(
         return [
             ...connections,
             ...(e as any).graphics_set.picture.flatMap((p: any) => p.layers),
+            ...graphicsSetAnimationLayers((e as any).graphics_set.animation),
             ...gigaCargoHatchLayers(e.cargo_station_parameters?.giga_hatch_definitions),
         ]
     }

--- a/packages/editor/src/core/spriteDataBuilder.ts
+++ b/packages/editor/src/core/spriteDataBuilder.ts
@@ -1706,7 +1706,7 @@ function draw_cargo_landing_pad(
         return [
             ...connections,
             ...base,
-            ...graphicsSetAnimationLayers((e as any).graphics_set.animation),
+            ...graphicsSetAnimationLayers(e.graphics_set?.animation),
             ...gigaCargoHatchLayers(e.cargo_station_parameters?.giga_hatch_definitions),
         ]
     }
@@ -2781,7 +2781,7 @@ function draw_space_platform_hub(
         return [
             ...connections,
             ...(e as any).graphics_set.picture.flatMap((p: any) => p.layers),
-            ...graphicsSetAnimationLayers((e as any).graphics_set.animation),
+            ...graphicsSetAnimationLayers(e.graphics_set?.animation),
             ...gigaCargoHatchLayers(e.cargo_station_parameters?.giga_hatch_definitions),
         ]
     }

--- a/tests/__fixtures__/sprite-data.json
+++ b/tests/__fixtures__/sprite-data.json
@@ -25,7 +25,7 @@
         "burner-mining-drill": ["2:5a05aec3", "2:76febf43", "2:97b66334", "2:c263ae5e"],
         "captive-biter-spawner": ["2:26deb24e"],
         "cargo-bay": ["26:cbfac3bd"],
-        "cargo-landing-pad": ["72:50428df2"],
+        "cargo-landing-pad": ["73:53672163"],
         "cargo-pod-container": ["2:69ebec7c"],
         "cargo-wagon": ["3:595d3990", "3:5ce699af", "3:74b86925", "3:f31225fe"],
         "centrifuge": ["6:5ca9d563"],
@@ -131,7 +131,7 @@
         "small-electric-pole": ["1:685ccfa6"],
         "small-lamp": ["2:988e4aa4"],
         "solar-panel": ["2:b86cb635"],
-        "space-platform-hub": ["77:12969cf9"],
+        "space-platform-hub": ["99:390e707c"],
         "splitter": ["8:188df570", "8:4b96fdf2", "8:9ba6c22b", "8:b49efd1c"],
         "stack-inserter": ["3:14e51b74", "3:18aeace5", "3:22fbb480", "3:e2536683"],
         "steam-engine": ["4:2264dd84", "4:4879a94e", "4:6624eb32", "4:778cff42"],
@@ -182,7 +182,7 @@
         "burner-mining-drill": ["2:5a05aec3", "2:76febf43", "2:97b66334", "2:c263ae5e"],
         "captive-biter-spawner": ["2:26deb24e"],
         "cargo-bay": ["7:7958b553"],
-        "cargo-landing-pad": ["17:ef1e8a06"],
+        "cargo-landing-pad": ["18:c17f30df"],
         "cargo-pod-container": ["2:69ebec7c"],
         "cargo-wagon": ["3:595d3990", "3:5ce699af", "3:74b86925", "3:f31225fe"],
         "centrifuge": ["6:5ca9d563"],
@@ -288,7 +288,7 @@
         "small-electric-pole": ["1:685ccfa6"],
         "small-lamp": ["2:988e4aa4"],
         "solar-panel": ["2:b86cb635"],
-        "space-platform-hub": ["22:261eb6a9"],
+        "space-platform-hub": ["44:b518bc2c"],
         "splitter": ["8:188df570", "8:4b96fdf2", "8:9ba6c22b", "8:b49efd1c"],
         "stack-inserter": ["3:14e51b74", "3:18aeace5", "3:22fbb480", "3:e2536683"],
         "steam-engine": ["4:2264dd84", "4:4879a94e", "4:6624eb32", "4:778cff42"],
@@ -402,7 +402,7 @@
             "6:ed98fae1"
         ],
         "cargo-bay": ["7:7958b553"],
-        "cargo-landing-pad": ["17:ef1e8a06"],
+        "cargo-landing-pad": ["18:c17f30df"],
         "cargo-wagon": ["3:f31225fe"],
         "centrifuge": ["6:5ca9d563", "9:8bd93858"],
         "chemical-plant": [
@@ -899,7 +899,7 @@
         "small-electric-pole": ["1:1d482b65", "1:57985197", "1:685ccfa6", "1:79d94a79"],
         "small-lamp": ["2:988e4aa4", "5:ee0efe0a"],
         "solar-panel": ["2:b86cb635"],
-        "space-platform-hub": ["22:261eb6a9"],
+        "space-platform-hub": ["44:b518bc2c"],
         "splitter": ["8:188df570", "8:4b96fdf2", "8:9ba6c22b", "8:b49efd1c"],
         "stack-inserter": [
             "3:14e51b74",
@@ -1078,11 +1078,11 @@
         ],
         "cargo-bay": ["7:7958b553", "7:7958b553", "7:7958b553", "7:7958b553", "7:7958b553"],
         "cargo-landing-pad": [
-            "17:ef1e8a06",
-            "17:ef1e8a06",
-            "17:ef1e8a06",
-            "17:ef1e8a06",
-            "17:ef1e8a06"
+            "18:c17f30df",
+            "18:c17f30df",
+            "18:c17f30df",
+            "18:c17f30df",
+            "18:c17f30df"
         ],
         "cargo-pod-container": [
             "2:69ebec7c",
@@ -1406,11 +1406,11 @@
         "small-lamp": ["2:988e4aa4", "2:988e4aa4", "2:988e4aa4", "2:988e4aa4", "2:988e4aa4"],
         "solar-panel": ["2:b86cb635", "2:b86cb635", "2:b86cb635", "2:b86cb635", "2:b86cb635"],
         "space-platform-hub": [
-            "22:261eb6a9",
-            "22:261eb6a9",
-            "22:261eb6a9",
-            "22:261eb6a9",
-            "22:261eb6a9"
+            "44:b518bc2c",
+            "44:b518bc2c",
+            "44:b518bc2c",
+            "44:b518bc2c",
+            "44:b518bc2c"
         ],
         "splitter": ["8:188df570", "8:9ba6c22b", "8:b49efd1c", "8:4b96fdf2", "8:188df570"],
         "stack-inserter": ["3:18aeace5", "3:e2536683", "3:22fbb480", "3:14e51b74", "3:18aeace5"],
@@ -1560,7 +1560,7 @@
             "27:186186eb",
             "31:71ce61a6"
         ],
-        "cargo-landing-pad": ["64:6edef897", "64:9b4d3ab9", "72:50428df2", "73:6259d270"],
+        "cargo-landing-pad": ["65:4ca256e8", "65:ea60c732", "73:53672163", "74:ff64bfad"],
         "cargo-wagon": ["3:f31225fe"],
         "centrifuge": ["6:5ca9d563", "9:8bd93858"],
         "chemical-plant": [
@@ -2511,7 +2511,7 @@
         "small-electric-pole": ["1:1d482b65", "1:57985197", "1:685ccfa6", "1:79d94a79"],
         "small-lamp": ["2:988e4aa4", "5:ee0efe0a"],
         "solar-panel": ["2:b86cb635"],
-        "space-platform-hub": ["77:12969cf9"],
+        "space-platform-hub": ["99:390e707c"],
         "splitter": [
             "4:0e7b6fc9",
             "4:8438a2b4",

--- a/tests/cargo-bay-connections.spec.ts
+++ b/tests/cargo-bay-connections.spec.ts
@@ -256,13 +256,20 @@ test('a bay joins to a landing pad and to a platform hub, not just to a bay', as
         to a bay against another bay on the same side, because nothing about the
         neighbour's own size reaches the bay's cells.
     */
+    /*
+        These two totals carry the `graphics_set.animation` layers issue #364
+        added - one turbine on the pad, 22 cockpit glows on the hub - so they
+        were 72 and 77 before that. What this test is about is the difference
+        each neighbour makes, and the animation is constant across every
+        arrangement below, so it shifts the baselines and nothing else.
+    */
     await loadBlueprint(page, bp([['cargo-landing-pad', 0, 0]]))
     const lonePad = (await tally(page))['cargo-landing-pad']
-    expect(countsOf(lonePad)).toEqual([72])
+    expect(countsOf(lonePad)).toEqual([73])
 
     await loadBlueprint(page, bp([['space-platform-hub', 0, 0]]))
     const loneHub = (await tally(page))['space-platform-hub']
-    expect(countsOf(loneHub)).toEqual([77])
+    expect(countsOf(loneHub)).toEqual([99])
 
     for (const big of ['cargo-landing-pad', 'space-platform-hub'] as const) {
         // bay to the east: the 8x8 entity is on the west side, so it draws the
@@ -312,7 +319,7 @@ test('a bay joins to a landing pad and to a platform hub, not just to a bay', as
         ])
     )
     const t = await tally(page)
-    expect(countsOf(t['cargo-landing-pad'])).toEqual([73])
+    expect(countsOf(t['cargo-landing-pad'])).toEqual([74])
     expect(countsOf(t['cargo-bay'])).toEqual([25, 22])
 
     expect(pageErrors, `page errors: ${pageErrors.join(' | ')}`).toEqual([])

--- a/tests/cargo-hatches.spec.ts
+++ b/tests/cargo-hatches.spec.ts
@@ -32,11 +32,23 @@ import { waitForEditor, loadBlueprint } from './helpers/fbe-test-api'
 const HATCHES = {
     /** 5 picture layers + lid + emission. Without the hatch: 5. */
     'cargo-bay': 7,
-    /** 13 picture layers + back, back emission, front emission, front. Without: 13. */
-    'cargo-landing-pad': 17,
-    /** 15 picture layers + 7 across two giga hatches. Without: 15. */
-    'space-platform-hub': 22,
+    /**
+     * 13 picture layers + back, back emission, front emission, front, + the
+     * turbine of `graphics_set.animation`. Without the hatch: 14.
+     */
+    'cargo-landing-pad': 18,
+    /**
+     * 15 picture layers + 7 across two giga hatches + 22 cockpit glows from
+     * `graphics_set.animation`. Without the hatch: 37.
+     */
+    'space-platform-hub': 44,
 } as const
+
+/*
+    The two totals above carry the `graphics_set.animation` layers issue #364
+    added; `tests/cargo-hub-animation.spec.ts` pins that half on its own, so a
+    failure here names the hatch and a failure there names the animation.
+*/
 
 /*
     A lone cargo bay draws more with a position grid than without, because

--- a/tests/cargo-hub-animation.spec.ts
+++ b/tests/cargo-hub-animation.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprint as encode, packVersion as version } from './helpers/encode-blueprint'
+import { waitForEditor, loadBlueprint } from './helpers/fbe-test-api'
+
+/*
+    Two entities carry `graphics_set.animation` beside `graphics_set.picture`,
+    and both draw functions used to return the picture alone (issue #364).
+    Swept over every entity in `data.json` those two are the only ones with both
+    keys; the other 22 with an `animation` have no `picture` next to it, so
+    their own draw functions already read it.
+
+    What the animation holds differs between them, and only one of the two is a
+    hole in the art:
+
+    - `cargo-landing-pad` gets one layer, `planet-hub-turbine.png`. The picture
+      draws the turbine's cowling with nothing inside it, so before this the pad
+      rendered a dark ring - the same shape of defect as the open hatches of
+      #377, not a missing detail. Scored against Factorio 2.0.77's own render,
+      over the fan's own pixels, mean per-channel error falls from 30.7 to 20.9
+      at frame 0.
+    - `space-platform-hub` gets 22 tiny additive `draw_as_glow` sprites, the
+      cockpit's lit screens. The cockpit body is in `picture` and was always
+      drawn, so the issue's "the whole cockpit missing" overstates it: they move
+      3.4% of the hub's pixels by a mean of 9.2.
+
+    graphicsSetAnimationLayers returns an empty array on each of its guards - a
+    missing `animation`, a `layers` that is not an array, a bare sprite with no
+    `filename`. So a regression is silent: each entity drops back to exactly the
+    layers it had before and looks like an entity that never had an animation.
+    The sprite-data fixture would move, but its own header says a diff there
+    means "the sprites for that entity changed", which is how a silent drop gets
+    re-recorded rather than investigated. This spec is the loud version.
+
+    It asserts the split, not just the total, so a failure says which half
+    moved. `tests/cargo-hatches.spec.ts` pins the same totals from the hatch
+    side; that is deliberate, and the two disagree usefully - if the exporter
+    ever ships a cockpit with a different number of layers, the hatch spec fails
+    with a bare wrong number while this one still passes.
+*/
+
+/** Picture layers plus the hatch layers that survive the shadow filter. */
+const WITHOUT_ANIMATION = {
+    /** 13 picture + 4 giga hatch. */
+    'cargo-landing-pad': 17,
+    /** 15 picture + 7 across two giga hatches. */
+    'space-platform-hub': 22,
+} as const
+
+/** What `graphics_set.animation` adds. A silent drop reads as 0. */
+const ANIMATION_LAYERS = {
+    'cargo-landing-pad': 1,
+    'space-platform-hub': 22,
+} as const
+
+/*
+    Far enough apart that no footprint touches another, so each entity is judged
+    on its own layers. Neither reads the position grid for its animation, but
+    both do for their connection sprites, and a neighbour would add those.
+*/
+const HUBS = encode({
+    item: 'blueprint',
+    version: version(2, 0, 55),
+    entities: [
+        { entity_number: 1, name: 'cargo-landing-pad', position: { x: 0, y: 0 } },
+        { entity_number: 2, name: 'space-platform-hub', position: { x: 60, y: 0 } },
+    ],
+})
+
+test('the landing pad and the platform hub draw graphics_set.animation', async ({ page }) => {
+    const pageErrors: string[] = []
+    page.on('pageerror', e => pageErrors.push(String(e)))
+
+    await waitForEditor(page)
+    await loadBlueprint(page, HUBS)
+
+    const digests = await page.evaluate(() =>
+        window.__fbe_test.spriteDataTally(undefined, { withGrid: false })
+    )
+
+    for (const name of Object.keys(WITHOUT_ANIMATION) as (keyof typeof WITHOUT_ANIMATION)[]) {
+        expect(digests[name], `${name} drew nothing`).toHaveLength(1)
+        expect(
+            digests[name].filter(d => d === 'FAILED'),
+            `${name} failed to generate`
+        ).toEqual([])
+
+        const drawn = Number(digests[name][0].split(':')[0])
+        expect(
+            drawn - WITHOUT_ANIMATION[name],
+            `${name} animation layers (0 means the animation was dropped)`
+        ).toBe(ANIMATION_LAYERS[name])
+    }
+
+    expect(pageErrors, `page errors: ${pageErrors.join(' | ')}`).toEqual([])
+})
+
+test('the animation does not depend on a position grid or on facing', async ({ page }) => {
+    const pageErrors: string[] = []
+    page.on('pageerror', e => pageErrors.push(String(e)))
+
+    await waitForEditor(page)
+
+    /*
+        The paint preview draws from a bare `{ name, direction }` - no Entity, no
+        position, no grid. That is the only caller reaching
+        EntitySprite.getDrawData's defaults, so a read that came to depend on an
+        Entity would pass the test above and fail here.
+
+        Neither prototype has a directional graphics set and an animation frame
+        carries no runtime state, so every facing must come out identical.
+    */
+    const digests = await page.evaluate(() =>
+        window.__fbe_test.paintPreviewTally([0, 4, 8, 12, undefined])
+    )
+
+    for (const name of Object.keys(WITHOUT_ANIMATION) as (keyof typeof WITHOUT_ANIMATION)[]) {
+        const total = WITHOUT_ANIMATION[name] + ANIMATION_LAYERS[name]
+        expect(digests[name], `${name} drew nothing`).toHaveLength(5)
+        expect(
+            digests[name].filter(d => d === 'FAILED'),
+            `${name} failed to generate`
+        ).toEqual([])
+        expect(
+            digests[name].every(d => d.startsWith(`${total}:`)),
+            `${name} expected every facing at ${total} layers, got ${digests[name].join(' ')}`
+        ).toBe(true)
+        expect(new Set(digests[name]).size, `${name} differs by facing`).toBe(1)
+    }
+
+    expect(pageErrors, `page errors: ${pageErrors.join(' | ')}`).toEqual([])
+})


### PR DESCRIPTION
Closes #364.

## What was wrong

`draw_cargo_landing_pad` and `draw_space_platform_hub` both returned
`graphics_set.picture` and nothing else, so `graphics_set.animation` was never
drawn. Swept over all 155 entities in `data.json`, those two are the only pair
carrying both keys; the other 22 with an `animation` have no `picture` beside it
and their own draw functions already read it.

The two are not the same size of defect, and the issue's ordering of them is
backwards.

**The landing pad** gets one layer, `planet-hub-turbine.png`. The picture draws
the turbine's cowling with nothing inside it, so the pad rendered a black hole -
the same class as the open hatches of #377, not a missing detail.

**The platform hub** gets 22 tiny additive `draw_as_glow` sprites. They are the
lit screens in the cockpit windows, not the cockpit body, which `picture` always
drew. So "the whole cockpit missing" overstates it: they move 3.4% of the hub's
pixels by a mean of 9.2.

## Before and after, from the editor

Real editor renders of a lone entity, before on the left. Cropped to the pixels
the change actually moves, so the strip is not mostly empty ground.

**`cargo-landing-pad`** - the turbine cowling was drawn with nothing inside it.

<img alt="cargo-landing-pad before and after" src="https://github.com/user-attachments/assets/f794f6f9-c4d8-421b-8d5a-c8adee40a6b1" />

**`space-platform-hub`** - the cockpit windows were dead grey glass. The body
was never missing; the 22 layers are the lit screens behind it.

<img alt="space-platform-hub before and after" src="https://github.com/user-attachments/assets/7710105b-05ef-480c-8336-962d9ac2f321" />

## What was measured

Against Factorio 2.0.77's own render of the `pad-bays` arrangement captured for
#378, scoring mean per-channel error over the fan's own pixels, with a control
patch the fan never touches:

| candidate | over the fan | control |
| --- | --- | --- |
| picture alone | 30.7 | 44.3 |
| animation under the body | 30.7 | 44.3 |
| animation over the body, frame 0 | 20.9 | 44.3 |
| animation over the body, best frame | 10.8 | 44.3 |

Under the body it scores exactly what not drawing it scores, because the body
covers it. The best frame beats frame 0 only because the fan spins and the shot
caught an arbitrary frame; the editor draws frame 0 of every sheet.

The hub has no game capture - it needs a space platform surface - so it was
checked the way the agricultural tower's working visualisations were, which is
the check those failed. None of the 22 duplicates a layer already drawn: 0 by
filename and 0 by frame-0 pixel digest. And `picture` already draws three
`-emission-` layers under the same `blend_mode: "additive"` treatment, so this
is 22 more of something the renderer already handles.

Appending is the game's order. `animation_render_layer` defaults to `object` and
neither prototype sets it, which puts the animation below the `cargo-hatch` and
`above-inserters` occluder groups the picture ends with. Measured, drawing it
there rather than last moves 0 pixels on either entity, because neither
animation reaches an occluder.

## The other half of #364 was already closed

The issue also reports that the hub draws no connection sprites and that
`isCargoBayLike` does not match it. Both shipped in #379: the hub calls
`getCargoBayConnectionSprites`, `isCargoBayLike` matches it, and it is in
`EntityContainer`'s update group. `tests/cargo-bay-connections.spec.ts` covers a
bay joined to a hub.

## Tests

`graphicsSetAnimationLayers` returns an empty array on each of its guards, so a
regression is silent - each entity drops back to exactly the layers it had
before. `tests/cargo-hub-animation.spec.ts` is the loud version, and it asserts
the split rather than the total so a failure says which half moved. Mutation
checked: with both calls commented out it fails on
`cargo-landing-pad animation layers (0 means the animation was dropped)`.

Three existing pins move with it, and all of them move by exactly the expected
amount, which was predicted before the run:

- `tests/cargo-hatches.spec.ts` totals: pad 17 -> 18, hub 22 -> 44.
- `tests/cargo-bay-connections.spec.ts` baselines: lone pad 72 -> 73, lone hub
  77 -> 99, pad with two bays 73 -> 74. Those are baselines the neighbour deltas
  are measured against, and the animation is constant across every arrangement,
  so nothing else in that spec moves.
- `tests/__fixtures__/sprite-data.json`: all five sections, both entities, and
  nothing else. Every changed line is one of the two.

`vp check` clean, `vp test` 324 passed, `npx playwright test --workers=2`
267 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmACc6X19cEJ2gP1yAi9hN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cargo landing pads and space platform hubs now render their configured animation graphics alongside base visuals.
  - Animations display consistently across different position-grid settings and facing directions.

- **Bug Fixes**
  - Updated rendering behavior and visual outputs to ensure animated cargo structures display correctly.

- **Tests**
  - Added coverage validating animation layers, sprite generation, rendering errors, and updated cargo structure visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
