### PR TITLE
Accept the decider combinator's else_outputs, added by Factorio 2.1.9

### DIFF
--- a/packages/editor/src/core/blueprintSchema.json
+++ b/packages/editor/src/core/blueprintSchema.json
@@ -1014,6 +1014,13 @@
                                                 "items": {
                                                     "$ref": "blueprintSchema.json#/definitions/DeciderCombinatorOutput"
                                                 }
+                                            },
+                                            "else_outputs": {
+                                                "$comment": "Factorio 2.1.9 and later. Written even when empty, so most 2.1 blueprints carry it as [].",
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "blueprintSchema.json#/definitions/DeciderCombinatorOutput"
+                                                }
                                             }
                                         }
                                     },

--- a/packages/editor/src/core/blueprintSchema.test.ts
+++ b/packages/editor/src/core/blueprintSchema.test.ts
@@ -1,0 +1,184 @@
+import { beforeAll, describe, expect, it } from 'vite-plus/test'
+import * as pako from 'pako'
+import { Blueprint } from './Blueprint'
+import { getAndClearLoadWarnings, getBlueprintOrBookFromSource } from './bpString'
+import { loadData } from './factorioData'
+
+/*
+    What `blueprintSchema.json` accepts, tested through the path a user takes -
+    `getBlueprintOrBookFromSource`, whose validation failures surface as the
+    "Blueprint had validation warnings (loaded anyway)" toast rather than as a
+    thrown error. A schema gap is therefore silent apart from that one line, and
+    nothing else in the suite reads it.
+
+    The case here is the decider combinator's `else_outputs`, added by Factorio
+    2.1.9 ("Decider combinator supports else-output", 30. 06. 2026). The schema
+    was written against 2.0 and sets `additionalProperties: false` on
+    `decider_conditions`, so every 2.1 blueprint holding a decider failed
+    validation on that one key - including two files of the committed corpus,
+    `gleba-base-mall-all` (36 deciders) and `vulcanus-starter-mk2` (44).
+
+    The shapes below are transcribed from `tools/oracle/probe-decider-else-outputs.mjs`
+    run against Factorio 2.1.14, not from the Lua API's `DeciderCombinatorParameters`,
+    which describes the runtime concept rather than the serialisation.
+*/
+
+beforeAll(() => {
+    // loadData permanently replaces FD's accessors. Vitest's per-file module
+    // isolation keeps this synthetic dataset out of the other test files.
+    loadData(
+        JSON.stringify({
+            items: { 'decider-combinator': { name: 'decider-combinator' } },
+            fluids: {},
+            signals: {},
+            recipes: {},
+            entities: {
+                'decider-combinator': {
+                    type: 'decider-combinator',
+                    name: 'decider-combinator',
+                    minable: { result: 'decider-combinator' },
+                    collision_box: [
+                        [-0.35, -0.65],
+                        [0.35, 0.65],
+                    ],
+                },
+            },
+            tiles: {},
+            inventoryLayout: [],
+            utilitySprites: {},
+            utilityConstants: {},
+            guiStyle: {},
+            defines: {},
+        })
+    )
+})
+
+/** 2.1.12, the version the two corpus files and the reported blueprint declare. */
+const VERSION_2_1_12 = 2 * 2 ** 48 + 1 * 2 ** 32 + 12 * 2 ** 16
+
+/**
+ * The encoding `decode()` expects: a version byte, then deflated JSON. Written
+ * out rather than reusing `encode()`, which serialises a `Blueprint` - the two
+ * controls below need a key the model would be free to drop on its way through.
+ */
+const sourceFor = (decider_conditions: Record<string, unknown>): string => {
+    const json = JSON.stringify({
+        blueprint: {
+            item: 'blueprint',
+            version: VERSION_2_1_12,
+            // Required by the schema, and not what any case here is about.
+            icons: [{ index: 1, signal: { type: 'item', name: 'decider-combinator' } }],
+            entities: [
+                {
+                    entity_number: 1,
+                    name: 'decider-combinator',
+                    position: { x: 0.5, y: 0 },
+                    control_behavior: { decider_conditions },
+                },
+            ],
+        },
+    })
+    let binary = ''
+    for (const byte of pako.deflate(json)) binary += String.fromCharCode(byte)
+    return `0${btoa(binary)}`
+}
+
+const load = async (decider_conditions: Record<string, unknown>) => {
+    const bp = await getBlueprintOrBookFromSource(sourceFor(decider_conditions))
+    if (!(bp instanceof Blueprint)) throw new Error('expected a blueprint, got a book')
+    return {
+        warnings: getAndClearLoadWarnings(),
+        elseOutputs:
+            bp.serialize().entities?.[0].control_behavior?.decider_conditions?.else_outputs,
+    }
+}
+
+const CONDITIONS = [
+    { first_signal: { type: 'virtual', name: 'signal-A' }, constant: 5, comparator: '>' },
+]
+const OUTPUTS = [
+    { signal: { type: 'virtual', name: 'signal-check' }, copy_count_from_input: false },
+]
+
+describe("a decider combinator's else-outputs (Factorio 2.1.9)", () => {
+    /*
+        The shape that made this visible. Measured: 2.1 writes the key whether or
+        not the else branch holds anything, so an empty array is what most 2.1
+        blueprints carry - all five deciders in the reported blueprint, and every
+        one in the two corpus files.
+    */
+    it('accepts an empty else_outputs, which 2.1 writes even with no else branch', async () => {
+        const { warnings, elseOutputs } = await load({
+            conditions: CONDITIONS,
+            outputs: OUTPUTS,
+            else_outputs: [],
+        })
+        expect(warnings).toEqual([])
+        expect(elseOutputs).toEqual([])
+    })
+
+    /* The `one-else` probe case: a constant output on the else branch. */
+    it('accepts and preserves a constant else-output', async () => {
+        const else_outputs = [
+            {
+                signal: { type: 'virtual', name: 'signal-red' },
+                copy_count_from_input: false,
+                constant: 7,
+            },
+        ]
+        const { warnings, elseOutputs } = await load({
+            conditions: CONDITIONS,
+            outputs: OUTPUTS,
+            else_outputs,
+        })
+        expect(warnings).toEqual([])
+        expect(elseOutputs).toEqual(else_outputs)
+    })
+
+    /*
+        The `else-copy` probe case. It is the one that pins the element type
+        rather than a guess at it: a copying else-output drops
+        `copy_count_from_input` (it defaults to true) and carries `networks`,
+        so this fails against any definition narrower than the `outputs` one.
+    */
+    it('accepts a copying else-output with a network selection', async () => {
+        const else_outputs = [
+            { signal: { name: 'iron-plate' }, networks: { red: true, green: false } },
+        ]
+        const { warnings, elseOutputs } = await load({
+            conditions: CONDITIONS,
+            outputs: OUTPUTS,
+            else_outputs,
+        })
+        expect(warnings).toEqual([])
+        expect(elseOutputs).toEqual(else_outputs)
+    })
+
+    /*
+        The control, and the reason this is not `additionalProperties: true`.
+        `decider_conditions` still refuses a key Factorio never writes, so these
+        tests can fail: without it, adding the key at all would be untested and
+        widening the object to accept anything would pass every case above.
+    */
+    it('still warns about a key Factorio does not write', async () => {
+        const { warnings } = await load({
+            conditions: CONDITIONS,
+            outputs: OUTPUTS,
+            else_outputz: [],
+        })
+        expect(warnings).toEqual(['Blueprint had validation warnings (loaded anyway)'])
+    })
+
+    /*
+        And the element type is not free-form either: an else-output takes the
+        same four keys `outputs` does and no more.
+    */
+    it('still warns about an unknown key inside an else-output', async () => {
+        const { warnings } = await load({
+            conditions: CONDITIONS,
+            outputs: OUTPUTS,
+            else_outputs: [{ signal: { type: 'virtual', name: 'signal-red' }, output_signal: {} }],
+        })
+        expect(warnings).toEqual(['Blueprint had validation warnings (loaded anyway)'])
+    })
+})

--- a/packages/editor/src/types.ts
+++ b/packages/editor/src/types.ts
@@ -189,6 +189,11 @@ export interface IDeciderCondition {
     conditions?: DeciderCombinatorCondition[]
     /** post 2.0 */
     outputs?: DeciderCombinatorOutput[]
+    /**
+     * The else branch, added in Factorio 2.1.9. The game writes the key whether
+     * or not it holds anything, so a 2.1 blueprint normally carries it as `[]`.
+     */
+    else_outputs?: DeciderCombinatorOutput[]
 }
 
 /** When not specified, defaults to "*". */

--- a/tools/oracle/README.md
+++ b/tools/oracle/README.md
@@ -54,6 +54,7 @@ This is the part that saves time, and it is not "open a disassembler":
 | `probe-zoom-limits.mjs`              | What zoom range and what per-notch step the game uses (#206, #211)            |
 | `probe-blueprint-snapping.mjs`       | Which snapping mode carries `position-relative-to-grid` (#226, PR #222)       |
 | `probe-blueprint-grid-position.mjs`  | Whether setting a grid position moves the entities (PR #222)                  |
+| `probe-decider-else-outputs.mjs`     | How 2.1 serialises a decider's `else_outputs`, and whether it reimports       |
 
 | `probe-cargo-bay-render.mjs` | What cargo bay arrangements actually look like in the game (#378) |
 

--- a/tools/oracle/probe-decider-else-outputs.mjs
+++ b/tools/oracle/probe-decider-else-outputs.mjs
@@ -39,19 +39,37 @@ const decodeBp = str =>
 const encodeBp = obj =>
     `0${deflateSync(Buffer.from(JSON.stringify(obj), 'utf8')).toString('base64')}`
 
+/*
+    Both version fields this probe needs, read off the binary rather than written
+    down. Two separate reasons, and getting either wrong is quiet:
+
+    - `factorio_version` in the mod's `info.json` must match the binary's
+      major.minor or the mod is silently skipped, the dump never appears, and
+      nothing in Factorio's output names the cause.
+    - the control blueprint's own `version`. A hardcoded one disagrees with the
+      binary the moment `FACTORIO_BIN` points somewhere else, and then a failed
+      import cannot be attributed: the version field and the `else_outputs` key
+      are both candidates and the probe cannot separate them. Deriving it leaves
+      the key as the only thing under test.
+*/
+const version = (() => {
+    const out = spawnSync(factorioBin, ['--version'], { encoding: 'utf8' }).stdout ?? ''
+    const m = /Version:\s*(\d+)\.(\d+)\.(\d+)/.exec(out)
+    if (!m) throw new Error(`could not read a version out of: ${out.slice(0, 200)}`)
+    const [major, minor, patch] = m.slice(1).map(Number)
+    return {
+        modVersion: `${major}.${minor}`,
+        /* How Factorio packs a version: four 16-bit fields, dev last. */
+        packed: major * 2 ** 48 + minor * 2 ** 32 + patch * 2 ** 16,
+    }
+})()
+
 const { work, writeData, modDir, modPath } = prepareProbe({
     name: MOD,
     version: '0.0.1',
     title: 'Decider else-output probe',
     author: 'oracle',
-    // Derived rather than hardcoded: a mismatch against the binary's
-    // major.minor makes the mod silently skipped and the run ends on "No dump".
-    factorio_version: (() => {
-        const out = spawnSync(factorioBin, ['--version'], { encoding: 'utf8' }).stdout ?? ''
-        const m = /Version:\s*(\d+)\.(\d+)/.exec(out)
-        if (!m) throw new Error(`could not read a version out of: ${out.slice(0, 200)}`)
-        return `${m[1]}.${m[2]}`
-    })(),
+    factorio_version: version.modVersion,
     dependencies: ['base'],
 })
 
@@ -64,7 +82,7 @@ const { work, writeData, modDir, modPath } = prepareProbe({
 const REIMPORT = encodeBp({
     blueprint: {
         item: 'blueprint',
-        version: 562954249175042,
+        version: version.packed,
         entities: [
             {
                 entity_number: 1,

--- a/tools/oracle/probe-decider-else-outputs.mjs
+++ b/tools/oracle/probe-decider-else-outputs.mjs
@@ -1,0 +1,212 @@
+/*
+    What a decider combinator's `else_outputs` looks like in a blueprint string,
+    and whether the game accepts one it did not write itself.
+
+    Factorio 2.1.9 added "Decider combinator supports else-output" (changelog,
+    30. 06. 2026). The editor's `blueprintSchema.json` was written against 2.0
+    and sets `additionalProperties: false` on `decider_conditions`, so every 2.1
+    blueprint holding a decider now fails validation on that one key.
+
+    The runtime API says `else_outputs` is an array of `DeciderCombinatorOutput`,
+    the same element type as `outputs`. That is the *Lua* concept, though, not
+    the blueprint serialisation, and the two are allowed to differ - so this asks
+    the game to export the string and reads the JSON back out.
+
+    Four questions, each its own decider so an answer is attributable:
+
+      no-else      Is the key written at all when the else branch is empty?
+      one-else     What does a single else-output serialise as?
+      else-copy    Does a copying else-output carry `networks` the way an
+                   ordinary output does?
+      two-else     Does a second entry appear in order?
+
+    Plus one control that runs the other direction: hand the game a string this
+    editor could have written - `else_outputs` present, everything else the
+    same - and read `import_stack`'s code back. A non-zero code would mean the
+    field is export-only and we must not re-emit it.
+*/
+import { writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+import { inflateSync, deflateSync } from 'node:zlib'
+import { factorioBin, prepareProbe, runProbe } from './factorio-probe.mjs'
+
+const MOD = 'decider_else_outputs'
+const DUMP = 'decider-else-outputs-dump.json'
+
+const decodeBp = str =>
+    JSON.parse(inflateSync(Buffer.from(str.slice(1), 'base64')).toString('utf8'))
+const encodeBp = obj =>
+    `0${deflateSync(Buffer.from(JSON.stringify(obj), 'utf8')).toString('base64')}`
+
+const { work, writeData, modDir, modPath } = prepareProbe({
+    name: MOD,
+    version: '0.0.1',
+    title: 'Decider else-output probe',
+    author: 'oracle',
+    // Derived rather than hardcoded: a mismatch against the binary's
+    // major.minor makes the mod silently skipped and the run ends on "No dump".
+    factorio_version: (() => {
+        const out = spawnSync(factorioBin, ['--version'], { encoding: 'utf8' }).stdout ?? ''
+        const m = /Version:\s*(\d+)\.(\d+)/.exec(out)
+        if (!m) throw new Error(`could not read a version out of: ${out.slice(0, 200)}`)
+        return `${m[1]}.${m[2]}`
+    })(),
+    dependencies: ['base'],
+})
+
+/*
+    The control's input: a string this editor could have written - `else_outputs`
+    present, everything else the same. Built here rather than captured from a
+    case above, so it is our shape being tested and not the game's own output
+    handed back to it.
+*/
+const REIMPORT = encodeBp({
+    blueprint: {
+        item: 'blueprint',
+        version: 562954249175042,
+        entities: [
+            {
+                entity_number: 1,
+                name: 'decider-combinator',
+                position: { x: 0.5, y: 0 },
+                control_behavior: {
+                    decider_conditions: {
+                        conditions: [
+                            {
+                                first_signal: { type: 'virtual', name: 'signal-E' },
+                                constant: 5,
+                                comparator: '>',
+                            },
+                        ],
+                        outputs: [
+                            {
+                                signal: { type: 'virtual', name: 'signal-check' },
+                                copy_count_from_input: false,
+                            },
+                        ],
+                        else_outputs: [
+                            {
+                                signal: { type: 'virtual', name: 'signal-red' },
+                                copy_count_from_input: false,
+                                constant: 7,
+                            },
+                        ],
+                    },
+                },
+            },
+        ],
+    },
+})
+
+writeFileSync(
+    join(modPath, 'control.lua'),
+    `
+local out = {cases = {}, errors = {}}
+
+local function try(label, fn)
+  local ok, err = pcall(fn)
+  if not ok then out.errors[#out.errors + 1] = label .. ": " .. tostring(err) end
+end
+
+local CASES = {
+  {
+    label = "no-else",
+    params = {
+      conditions = {{first_signal = {type = "virtual", name = "signal-A"}, constant = 5, comparator = ">"}},
+      outputs = {{signal = {type = "virtual", name = "signal-check"}, copy_count_from_input = false}},
+      else_outputs = {},
+    },
+  },
+  {
+    label = "one-else",
+    params = {
+      conditions = {{first_signal = {type = "virtual", name = "signal-B"}, constant = 5, comparator = ">"}},
+      outputs = {{signal = {type = "virtual", name = "signal-check"}, copy_count_from_input = false}},
+      else_outputs = {{signal = {type = "virtual", name = "signal-red"}, copy_count_from_input = false, constant = 7}},
+    },
+  },
+  {
+    label = "else-copy",
+    params = {
+      conditions = {{first_signal = {type = "virtual", name = "signal-C"}, constant = 5, comparator = ">"}},
+      outputs = {{signal = {type = "virtual", name = "signal-check"}, copy_count_from_input = false}},
+      else_outputs = {{signal = {type = "item", name = "iron-plate"}, copy_count_from_input = true, networks = {red = true, green = false}}},
+    },
+  },
+  {
+    label = "two-else",
+    params = {
+      conditions = {{first_signal = {type = "virtual", name = "signal-D"}, constant = 5, comparator = ">"}},
+      outputs = {{signal = {type = "virtual", name = "signal-check"}, copy_count_from_input = false}},
+      else_outputs = {
+        {signal = {type = "virtual", name = "signal-green"}, copy_count_from_input = false, constant = 1},
+        {signal = {type = "fluid", name = "water"}, copy_count_from_input = false, constant = 2},
+      },
+    },
+  },
+}
+
+script.on_init(function()
+  local surface = game.surfaces[1]
+  local force = game.forces.player
+
+  surface.request_to_generate_chunks({0, 0}, 3)
+  surface.force_generate_chunk_requests()
+  local tiles = {}
+  for x = -10, 40 do
+    for y = -10, 10 do tiles[#tiles + 1] = {name = "grass-1", position = {x, y}} end
+  end
+  surface.set_tiles(tiles)
+  for _, e in pairs(surface.find_entities_filtered{area = {{-10, -10}, {40, 10}}}) do
+    if e.valid and e.type ~= "character" then e.destroy() end
+  end
+
+  local inv = game.create_inventory(1)
+
+  for i, c in ipairs(CASES) do
+    local x = (i - 1) * 8
+    local rec = {label = c.label}
+    try(c.label, function()
+      local e = surface.create_entity{name = "decider-combinator", position = {x + 0.5, 0}, force = force}
+      if not e then error("create_entity returned nil") end
+      e.get_or_create_control_behavior().parameters = c.params
+      rec.read_back = e.get_control_behavior().parameters
+      inv[1].set_stack{name = "blueprint"}
+      inv[1].create_blueprint{surface = surface, force = force, area = {{x - 2, -3}, {x + 3, 3}}}
+      rec.entities = inv[1].get_blueprint_entities()
+      rec.exported = inv[1].export_stack()
+      e.destroy()
+    end)
+    out.cases[#out.cases + 1] = rec
+  end
+
+  -- Control, the other direction: a string the editor could have written.
+  try("reimport", function()
+    inv[1].set_stack{name = "blueprint"}
+    out.reimport_code = inv[1].import_stack([==[${REIMPORT}]==])
+    out.reimport_entities = inv[1].get_blueprint_entities()
+  end)
+
+  helpers.write_file("${DUMP}", helpers.table_to_json(out))
+  error("DUMPED-OK")
+end)
+`
+)
+
+const { text } = runProbe({ bin: factorioBin, work, writeData, modDir, dump: DUMP })
+const dump = JSON.parse(text)
+
+if (dump.errors?.length) console.log('ERRORS:', dump.errors)
+
+for (const c of dump.cases) {
+    const bp = c.exported ? decodeBp(c.exported) : undefined
+    const dc = bp?.blueprint?.entities?.[0]?.control_behavior?.decider_conditions
+    console.log(`\n=== ${c.label} ===`)
+    console.log('  exported decider_conditions:', JSON.stringify(dc))
+    console.log('  else_outputs key present in string:', dc ? 'else_outputs' in dc : 'no entity')
+}
+
+console.log('\n=== reimport control ===')
+console.log('  import_stack code:', dump.reimport_code, '(0 = accepted)')
+console.log('  entities read back:', JSON.stringify(dump.reimport_entities))


### PR DESCRIPTION
## What was wrong

Any Factorio 2.1 blueprint holding a decider combinator loads with a warning toast and a wall of ajv output in the console:

```
Blueprint validation warnings (loading anyway): [{"instancePath":
"/blueprint/entities/1918/control_behavior/decider_conditions", ...
"params":{"additionalProperty":"else_outputs"},
"message":"must NOT have additional properties" ...
```

Reported against [this blueprint](https://fbe.factorygamefan.com/?source=https://factorioprints.xyz/api/blueprintData/b64151d67a77833b4fe3889357b63514548541c8/position/0), which declares 2.1.12 and has 5 deciders.

Factorio 2.1.9 added "Decider combinator supports else-output" (changelog, 30. 06. 2026). `blueprintSchema.json` was written against 2.0 and sets `additionalProperties: false` on `decider_conditions`, so the new key fails validation.

The blueprint still loads and still round-trips - `decode` logs and carries on, and the editor keeps the raw entity - so nothing is lost. The defect is that a blueprint with nothing wrong with it is reported as broken.

## How quiet it was

Two files of the committed corpus were already in this state:

| File | Declared version | Deciders carrying `else_outputs` |
| --- | --- | --- |
| `JEPAKAZOL/gleba-base-mall-all.txt` | 2.1.12 | 36 |
| `JEPAKAZOL/vulcanus-starter-mk2.txt` | 2.1.12 | 44 |

Nothing in the suite reads the warning, so a green run said nothing about it.

## What the game says

`tools/oracle/probe-decider-else-outputs.mjs` is new. It asks Factorio 2.1.14 rather than reading the shape off the Lua API's `DeciderCombinatorParameters`, which describes the runtime concept and not the serialisation. Four deciders, each its own case, plus one control running the other way.

```
=== no-else ===
  "else_outputs":[]
=== one-else ===
  "else_outputs":[{"signal":{"type":"virtual","name":"signal-red"},
                   "copy_count_from_input":false,"constant":7}]
=== else-copy ===
  "else_outputs":[{"signal":{"name":"iron-plate"},
                   "networks":{"red":true,"green":false}}]
=== two-else ===
  "else_outputs":[{"signal":{"type":"virtual","name":"signal-green"},
                   "copy_count_from_input":false},
                  {"signal":{"type":"fluid","name":"water"},
                   "copy_count_from_input":false,"constant":2}]

=== reimport control ===
  import_stack code: 0 (0 = accepted)
```

Three things, measured:

- The key is written whether or not the else branch holds anything. That is why `[]` is the common shape - all five deciders in the reported blueprint and every one in the two corpus files.
- Its elements are `DeciderCombinatorOutput`, the same type `outputs` takes, with defaults elided the same way. The `else-copy` case is the one that pins this: a copying else-output drops `copy_count_from_input` (it defaults to true) and carries `networks`.
- `import_stack` takes a string we wrote carrying the field and returns code 0, and reads it back unchanged. Re-emitting it is safe.

## The change

Seven lines of schema and five of types. `else_outputs` is an array of the existing `DeciderCombinatorOutput`, so no new definition.

## Testing

`packages/editor/src/core/blueprintSchema.test.ts` is new: three accepted shapes, transcribed from the probe output above, and two controls that keep `decider_conditions` from being widened to accept anything. Mutation-checked - with the schema line reverted, the three fail and the two controls hold.

Verified:

- `vp check` - no warnings, lint errors or type errors in 212 files
- `vp test` - 329 passed
- `npx playwright test` - 266 passed. One unrelated flake, `text-input.spec.ts:195`, which passes on its own - #384.
- Re-validating the whole corpus plus the reported blueprint against the fixed schema: the reported blueprint and both 2.1 corpus files now validate clean.

Two other schema gaps turned up in that corpus sweep, both unrelated to this one and both measured against the game the same way: #382 (a quality-only inserter filter, which has no `name`) and #383 (a root-level `index`, which the game ignores and never writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uXprmDJwazfKRtqDtdPUK



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Factorio 2.1.9 and later decider combinator `else_outputs`.
  - Else branches support empty, constant, network-copying, and multiple outputs.
  - Blueprints containing these outputs can be imported, validated, and round-tripped without losing data.

- **Bug Fixes**
  - Improved blueprint validation for decider conditions and outputs while continuing to warn about unknown fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->