### PR TITLE
Prune a live move drag on deselect, and relocate with the direction so the grid follows a flip

### DIFF
--- a/packages/editor/src/Editor.ts
+++ b/packages/editor/src/Editor.ts
@@ -15,6 +15,7 @@ import G, { Logger, QuickActions } from './common/globals'
 import { Entity } from './core/Entity'
 import { Blueprint, oilOutpostSettings, IOilOutpostSettings } from './core/Blueprint'
 import { BlueprintContainer, EditorMode, GridPattern } from './containers/BlueprintContainer'
+import { EntityContainer } from './containers/EntityContainer'
 import { PaintTileContainer } from './containers/PaintTileContainer'
 import { UIContainer } from './UI/UIContainer'
 import { Dialog } from './UI/controls/Dialog'
@@ -210,6 +211,17 @@ export class Editor {
     /** Whether the entity's selection box is tinted as blocked. See tests/persistent-selection.spec.ts. */
     public selectionHighlightBlocked(entityNumber: number): boolean {
         return G.BPC.selectionHighlightBlocked(entityNumber)
+    }
+
+    /**
+     * How far the entity's sprites are drawn from where its model says it is,
+     * in pixels. A move-drag previews by displacing the sprites and nothing
+     * else can see that; a leaked offset leaves an entity drawn where it is
+     * not. Undefined for an entity with no container. See
+     * tests/persistent-selection.spec.ts.
+     */
+    public entityDragOffset(entityNumber: number): IPoint | undefined {
+        return EntityContainer.mappings.get(entityNumber)?.dragOffsetPx
     }
 
     /**

--- a/packages/editor/src/containers/BlueprintContainer.ts
+++ b/packages/editor/src/containers/BlueprintContainer.ts
@@ -997,6 +997,17 @@ export class BlueprintContainer extends Container {
             is kept honest.
         */
         if (this.moveDrag !== undefined) {
+            /*
+                exitMoveMode puts sprites back through drag.entities, so one
+                leaving the drag here has to be put back now or it stays drawn
+                where the drag left it. Q mid-drag is the path: pipette clears
+                the selection while the drag is live. `mappings.get` rather than
+                `containerOf`, because on the destroy path the container is
+                already gone.
+            */
+            if (this.moveDrag.entities.includes(entity)) {
+                EntityContainer.mappings.get(entity.entityNumber)?.setDragOffset({ x: 0, y: 0 })
+            }
             this.moveDrag.entities = this.moveDrag.entities.filter(e => e !== entity)
         }
     }

--- a/packages/editor/src/containers/BlueprintContainer.ts
+++ b/packages/editor/src/containers/BlueprintContainer.ts
@@ -987,6 +987,18 @@ export class BlueprintContainer extends Container {
         this.selectionListeners.delete(entity)
         this.selectedEntities.delete(entity)
         this.overlayContainer.hideSelectionHighlight(entity.entityNumber)
+        /*
+            A drag in progress holds its own copy of the selection, taken at the
+            press. Undo is not gated on mode, so it can destroy a member while
+            that copy is live - and the copy would then name an entity with no
+            container, which throws on the next pointer move and again on the
+            release, before exitMoveMode ever reaches setMode(NONE). Every way
+            out of the selection comes through here, so this is where the copy
+            is kept honest.
+        */
+        if (this.moveDrag !== undefined) {
+            this.moveDrag.entities = this.moveDrag.entities.filter(e => e !== entity)
+        }
     }
 
     /**
@@ -1278,10 +1290,8 @@ export class BlueprintContainer extends Container {
             () => {
                 for (let i = 0; i < flipped.length; i++) {
                     const { entity, copy } = flipped[i]
-                    entity.relocate(targets[i].position)
-                    if ((copy.rawEntity.direction ?? 0) !== (entity.rawEntity.direction ?? 0)) {
-                        entity.direction = copy.rawEntity.direction ?? 0
-                    }
+                    // position and direction together: the grid needs both (see relocate)
+                    entity.relocate(targets[i].position, targets[i].direction)
                     entity.splitterInputPriority = copy.splitterInputPriority
                     entity.splitterOutputPriority = copy.splitterOutputPriority
                 }

--- a/packages/editor/src/containers/EntityContainer.ts
+++ b/packages/editor/src/containers/EntityContainer.ts
@@ -316,6 +316,11 @@ export class EntityContainer {
      * position event the drop emits, so they catch up on commit rather than
      * following the drag.
      */
+    /** Where the sprites are drawn relative to the model, in pixels; zero outside a drag. See tests/persistent-selection.spec.ts. */
+    public get dragOffsetPx(): IPoint {
+        return { ...this.dragOffset }
+    }
+
     public setDragOffset(offset: IPoint): void {
         const dx = offset.x - this.dragOffset.x
         const dy = offset.y - this.dragOffset.y

--- a/packages/editor/src/core/Entity.ts
+++ b/packages/editor/src/core/Entity.ts
@@ -314,29 +314,62 @@ export class Entity extends EventEmitter<EntityEvents> {
      * fits: each member is blocked by a neighbour that is itself about to move
      * out of the way. The setter still routes through here, so the history
      * entry and the grid/emit bookkeeping are one piece of code either way.
+     *
+     * A `direction` is written in the same step, for a mirror. It cannot go
+     * through the `direction` setter beside a position write, because the
+     * setter never touches the grid and the grid sizes its cells from the
+     * direction the entity has *now*: a curved-rail-a is 2x6 at direction 2
+     * and 6x2 at 6, so whichever of the two writes runs first is sized
+     * wrongly - and undo runs them in the other order, so no ordering fixes
+     * it. The direction step below lifts the cells laid with the old
+     * footprint and lays the new one, and reads the old footprint from the
+     * value history hands back so it is right on undo as well.
      */
-    public relocate(position: IPoint): void {
-        if (util.areObjectsEquivalent(this.m_rawEntity.position, position)) return
+    public relocate(position: IPoint, direction: number = this.m_rawEntity.direction ?? 0): void {
+        // Raw on both sides: the `direction` getter answers for an electric pole
+        // from its wires, and a move must not write that onto the entity.
+        const moves = !util.areObjectsEquivalent(this.m_rawEntity.position, position)
+        const turns = (this.m_rawEntity.direction ?? 0) !== direction
+        if (!moves && !turns) return
 
-        this.m_BP.history
-            .updateValue(this.m_rawEntity, 'position', position, 'Change position')
-            .onDone((newValue, oldValue) => {
-                /*
-                    History hands both values back as `| undefined` because undo
-                    swaps them and a key can be absent before its first write.
-                    `position` is a required field on the raw entity, so neither
-                    can be missing here - and if one were, the grid would be
-                    updated against the wrong tile and drift from the blueprint,
-                    which is the case entityAt() exists to catch loudly.
-                */
-                if (newValue === undefined || oldValue === undefined) {
-                    throw new Error('position changed to or from no position')
-                }
-                this.m_BP.entityPositionGrid.removeTileData(this, oldValue)
-                this.m_BP.entityPositionGrid.setTileData(this, newValue)
-                this.emit('position', newValue, oldValue)
-            })
-            .commit()
+        this.m_BP.history.transaction(undefined, () => {
+            if (moves) {
+                this.m_BP.history
+                    .updateValue(this.m_rawEntity, 'position', position, 'Change position')
+                    .onDone((newValue, oldValue) => {
+                        /*
+                            History hands both values back as `| undefined` because undo
+                            swaps them and a key can be absent before its first write.
+                            `position` is a required field on the raw entity, so neither
+                            can be missing here - and if one were, the grid would be
+                            updated against the wrong tile and drift from the blueprint,
+                            which is the case entityAt() exists to catch loudly.
+                        */
+                        if (newValue === undefined || oldValue === undefined) {
+                            throw new Error('position changed to or from no position')
+                        }
+                        this.m_BP.entityPositionGrid.removeTileData(this, oldValue)
+                        this.m_BP.entityPositionGrid.setTileData(this, newValue)
+                        this.emit('position', newValue, oldValue)
+                    })
+                    .commit()
+            }
+            if (turns) {
+                this.m_BP.history
+                    .updateValue(this.m_rawEntity, 'direction', direction, 'Change direction')
+                    .onDone((_newValue, oldValue) => {
+                        const grid = this.m_BP.entityPositionGrid
+                        grid.removeTileData(
+                            this,
+                            this.position,
+                            getEntitySize(this.entityData, oldValue ?? 0)
+                        )
+                        grid.setTileData(this)
+                        this.emit('direction')
+                    })
+                    .commit()
+            }
+        })
     }
 
     public get maxWireDistance(): number {

--- a/packages/editor/src/core/PositionGrid.ts
+++ b/packages/editor/src/core/PositionGrid.ts
@@ -408,13 +408,22 @@ export class PositionGrid {
         )
     }
 
-    public removeTileData(entity: Entity, position: IPoint = entity.position): void {
+    /**
+     * `size` is for the one caller whose entity has already turned: cells were
+     * laid with the footprint the entity had at the time, and `entity.size`
+     * reads the direction it has now. `Entity.relocate` passes the old one.
+     */
+    public removeTileData(
+        entity: Entity,
+        position: IPoint = entity.position,
+        size: IPoint = entity.size
+    ): void {
         this.tileDataAction(
             {
                 x: position.x,
                 y: position.y,
-                w: entity.size.x,
-                h: entity.size.y,
+                w: size.x,
+                h: size.y,
             },
             (key, cell) => {
                 if (typeof cell === 'number') {

--- a/packages/editor/src/core/entityRelocate.test.ts
+++ b/packages/editor/src/core/entityRelocate.test.ts
@@ -1,0 +1,149 @@
+import { beforeAll, describe, expect, it } from 'vite-plus/test'
+import { Blueprint } from './Blueprint'
+import { Entity } from './Entity'
+import { loadData } from './factorioData'
+
+/*
+    Entity.relocate with a direction: the position grid has to hold the
+    footprint the entity has *after* the write, in both directions of history.
+
+    A mirror can transpose a footprint - a 1x3 pump facing north becomes 3x1
+    facing east - and the grid sizes its cells from the entity's current
+    direction. Writing the position and the direction as two independent
+    steps therefore leaves whichever step ran first sized wrongly, and undo
+    runs them in the other order, so it cannot be fixed by ordering alone.
+    Grid arithmetic only, so vitest and a two-prototype dataset are enough;
+    the mirror that calls it is tests/persistent-selection.spec.ts.
+*/
+
+beforeAll(() => {
+    // loadData permanently replaces FD's accessors; vitest's per-file module
+    // isolation keeps this synthetic dataset out of the other test files.
+    loadData(
+        JSON.stringify({
+            items: {},
+            fluids: {},
+            signals: {},
+            recipes: {},
+            entities: {
+                'wooden-chest': {
+                    type: 'container',
+                    name: 'wooden-chest',
+                    collision_box: [
+                        [-0.35, -0.35],
+                        [0.35, 0.35],
+                    ],
+                },
+                // 1 wide, 3 tall at north; 3 wide, 1 tall at east
+                pump: {
+                    type: 'pump',
+                    name: 'pump',
+                    collision_box: [
+                        [-0.4, -1.4],
+                        [0.4, 1.4],
+                    ],
+                },
+            },
+            tiles: {},
+            inventoryLayout: [],
+            utilitySprites: {},
+            utilityConstants: {},
+            guiStyle: {},
+            defines: {},
+        })
+    )
+})
+
+const entityOf = (bp: Blueprint, entityNumber: number): Entity => {
+    const entity = bp.entities.get(entityNumber)
+    if (entity === undefined) throw new Error(`no entity ${entityNumber} in this blueprint`)
+    return entity
+}
+
+/** Every tile of a 9x9 window around the origin that the grid says the entity covers. */
+const cellsHolding = (bp: Blueprint, entity: Entity): string[] => {
+    const cells: string[] = []
+    for (let x = -4; x < 5; x++) {
+        for (let y = -4; y < 5; y++) {
+            if (bp.entityPositionGrid.getEntityAtPosition({ x: x + 0.5, y: y + 0.5 }) === entity) {
+                cells.push(`${x},${y}`)
+            }
+        }
+    }
+    return cells.sort()
+}
+
+/** The tiles the entity's own position and size say it covers. */
+const footprintOf = (entity: Entity): string[] => {
+    const cells: string[] = []
+    const { x: w, y: h } = entity.size
+    for (let x = entity.position.x - w / 2; x < entity.position.x + w / 2; x++) {
+        for (let y = entity.position.y - h / 2; y < entity.position.y + h / 2; y++) {
+            cells.push(`${Math.floor(x)},${Math.floor(y)}`)
+        }
+    }
+    return cells.sort()
+}
+
+const pumpFacingNorth = (): Blueprint =>
+    new Blueprint({
+        entities: [{ entity_number: 1, name: 'pump', position: { x: 0.5, y: 1.5 }, direction: 0 }],
+    })
+
+describe('relocate with a direction keeps the grid in step with the footprint', () => {
+    it('holds the transposed footprint after the write', () => {
+        const bp = pumpFacingNorth()
+        const pump = entityOf(bp, 1)
+        expect(pump.size).toEqual({ x: 1, y: 3 })
+        expect(cellsHolding(bp, pump)).toEqual(footprintOf(pump))
+
+        const target = { x: pump.position.x + 1, y: pump.position.y - 1 }
+        bp.history.transaction('turn', () => pump.relocate(target, 4))
+
+        expect(pump.direction).toBe(4)
+        expect(pump.position).toEqual(target)
+        expect(pump.size).toEqual({ x: 3, y: 1 })
+        expect(cellsHolding(bp, pump)).toEqual(footprintOf(pump))
+    })
+
+    it('holds the original footprint again after undo, and the turned one after redo', () => {
+        const bp = pumpFacingNorth()
+        const pump = entityOf(bp, 1)
+        const before = footprintOf(pump)
+
+        const target = { x: pump.position.x + 1, y: pump.position.y - 1 }
+        bp.history.transaction('turn', () => pump.relocate(target, 4))
+        const after = footprintOf(pump)
+
+        bp.history.undo()
+        expect(pump.direction).toBe(0)
+        expect(cellsHolding(bp, pump)).toEqual(before)
+
+        bp.history.redo()
+        expect(pump.direction).toBe(4)
+        expect(cellsHolding(bp, pump)).toEqual(after)
+    })
+
+    it('is one undo step for position and direction together', () => {
+        const bp = pumpFacingNorth()
+        const pump = entityOf(bp, 1)
+        // the constructor recentres, so read the start back rather than assuming it
+        const start = { ...pump.position }
+        const revision = bp.history.revision
+
+        bp.history.transaction('turn', () => pump.relocate({ x: start.x + 1, y: start.y - 1 }, 4))
+        expect(bp.history.revision).toBe(revision + 1)
+
+        bp.history.undo()
+        expect(pump.direction).toBe(0)
+        expect(pump.position).toEqual(start)
+    })
+
+    it('leaves a same-direction relocate as it was', () => {
+        const bp = pumpFacingNorth()
+        const pump = entityOf(bp, 1)
+        bp.history.transaction('shift', () => pump.relocate({ x: 2.5, y: 1.5 }, 0))
+        expect(pump.direction).toBe(0)
+        expect(cellsHolding(bp, pump)).toEqual(footprintOf(pump))
+    })
+})

--- a/packages/editor/src/core/groupRelocation.test.ts
+++ b/packages/editor/src/core/groupRelocation.test.ts
@@ -46,6 +46,16 @@ beforeAll(() => {
                         [0.7, 0.7],
                     ],
                 },
+                // 1 wide, 3 tall at north; 3 wide, 1 tall at east - the one
+                // prototype here whose footprint depends on its direction
+                pump: {
+                    type: 'pump',
+                    name: 'pump',
+                    collision_box: [
+                        [-0.4, -1.4],
+                        [0.4, 1.4],
+                    ],
+                },
             },
             tiles: {},
             inventoryLayout: [],
@@ -151,9 +161,30 @@ describe('canGroupRelocate lifts the whole group before asking', () => {
     })
 
     it('reads the footprint at the target direction, not the current one', () => {
-        // A 2x2 furnace beside a chest: moving the furnace one tile towards the
-        // chest overlaps it whichever way the furnace faces, and the group form
-        // must see that through the direction it is handed.
+        // A 1x3 pump facing north, with a chest one tile to its right at the
+        // pump's middle row. Turned east in place the pump is 3x1 and covers
+        // that tile; kept north it does not. Only a check that sizes the
+        // footprint from the *target* direction can tell the two apart - the
+        // current direction is 0 either way. A square prototype cannot show
+        // this, since its footprint is the same at every direction.
+        const bp = blueprintOf(
+            { name: 'pump', x: 0.5, y: 1.5 },
+            { name: 'wooden-chest', x: 1.5, y: 1.5 }
+        )
+        const pump = entityOf(bp, 1)
+        expect(pump.direction).toBe(0)
+        const inPlace = (direction: number) =>
+            bp.entityPositionGrid.canGroupRelocate([
+                { entity: pump, position: { ...pump.position }, direction },
+            ])
+        expect(inPlace(4)).toBe(false)
+        expect(inPlace(0)).toBe(true)
+    })
+
+    it('a group member may leave a footprint its neighbour is about to take', () => {
+        // The furnace case the direction test used to carry: a 2x2 furnace
+        // beside a chest, moved one tile towards it, overlaps whichever way it
+        // faces - alone it is refused, and with the chest moving too it fits.
         const bp = blueprintOf(
             { name: 'steel-furnace', x: 1, y: 1 },
             { name: 'wooden-chest', x: 2.5, y: 0.5 }

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -491,6 +491,7 @@ const testApi = {
     selectedEntityNumbers: () => editor.selectedEntityNumbers,
     selectionHighlightBlocked: (entityNumber: number) =>
         editor.selectionHighlightBlocked(entityNumber),
+    entityDragOffset: (entityNumber: number) => editor.entityDragOffset(entityNumber),
     historyRevision: () => editor.historyRevision,
     infoOverlayVisible: () => editor.infoOverlayVisible,
     /*

--- a/tests/helpers/fbe-test-api.ts
+++ b/tests/helpers/fbe-test-api.ts
@@ -115,6 +115,12 @@ export interface FbeTestApi {
      */
     selectionHighlightBlocked: (entityNumber: number) => boolean
     /**
+     * How far the entity's sprites are drawn from its model position, in
+     * pixels - non-zero only during a move-drag. A leak here is an entity
+     * drawn where it is not. See tests/persistent-selection.spec.ts.
+     */
+    entityDragOffset: (entityNumber: number) => { x: number; y: number } | undefined
+    /**
      * `History.revision` - moves on every outermost commit. A group move must be
      * one undo step, and the entities end up in the same place whether it took
      * one transaction or two; only this can tell. See

--- a/tests/persistent-selection.spec.ts
+++ b/tests/persistent-selection.spec.ts
@@ -81,7 +81,19 @@ const THREE_CHESTS = encode({
     ],
 })
 
-async function openEditorWithChests(page: Page): Promise<void> {
+/*
+    One curved rail, for the mirror cases below: a curved-rail-a is a 2x6
+    rectangle on the position grid at direction 2 and a 6x2 one at direction
+    6, and a vertical flip maps 2 to 6. It is the smallest entity whose
+    footprint transposes under a flip, which a row of 1x1 chests cannot show.
+*/
+const ONE_CURVED_RAIL = encode({
+    item: 'blueprint',
+    version: version(2, 0, 55),
+    entities: [{ entity_number: 1, name: 'curved-rail-a', position: { x: 0, y: 0 }, direction: 2 }],
+})
+
+async function openEditorWith(page: Page, source: string): Promise<void> {
     await suppressOverlays(page)
     await page.goto('/')
     await page.waitForFunction(() => (window as any).__fbe_test !== undefined, { timeout: 60_000 })
@@ -89,7 +101,32 @@ async function openEditorWithChests(page: Page): Promise<void> {
     await page.evaluate(async (src: string) => {
         const t = (window as any).__fbe_test
         await t.loadBp(await t.getBlueprintOrBookFromSource(src))
-    }, THREE_CHESTS)
+    }, source)
+}
+
+const openEditorWithChests = (page: Page): Promise<void> => openEditorWith(page, THREE_CHESTS)
+
+const containerCount = (page: Page): Promise<number> =>
+    page.evaluate(() => (window as any).__fbe_test.entityContainerCount())
+
+/** Alt+Left-drags a small box around one screen point and releases. */
+async function altSelectAround(page: Page, at: Point): Promise<void> {
+    await page.mouse.move(at.x - 4, at.y - 4)
+    await page.keyboard.down('Alt')
+    await page.mouse.down()
+    await page.mouse.move(at.x + 4, at.y + 4)
+    await page.mouse.up()
+    await page.keyboard.up('Alt')
+}
+
+/** Ctrl+Right-drags a small box around one screen point, the existing delete sweep. */
+async function deleteAround(page: Page, at: Point): Promise<void> {
+    await page.mouse.move(at.x, at.y)
+    await page.keyboard.down('Control')
+    await page.mouse.down({ button: 'right' })
+    await page.mouse.move(at.x + 4, at.y + 4)
+    await page.mouse.up({ button: 'right' })
+    await page.keyboard.up('Control')
 }
 
 /** Alt+Left-drags from one chest to another and releases, then lets go of Alt. */
@@ -317,4 +354,92 @@ test('deleting a selected chest by other means drops it from the selection', asy
     await page.keyboard.up('Control')
 
     expect(await selected(page)).toEqual([1])
+})
+
+test('undo mid-drag that removes a member drops it from the drag and still exits MOVE', async ({
+    page,
+}) => {
+    await openEditorWithChests(page)
+    const errors: string[] = []
+    page.on('pageerror', e => errors.push(String(e)))
+    const px = await tilePx(page)
+
+    // A fourth chest, painted by pipette, so undo has an entity creation to reverse.
+    const one = await screenOf(page, 1)
+    await page.mouse.move(one.x, one.y)
+    expect(await modeOf(page)).toBe('EDIT')
+    await page.keyboard.press('KeyQ')
+    expect(await modeOf(page)).toBe('PAINT')
+    await page.mouse.click(one.x, one.y + 2 * px)
+    await page.keyboard.press('Escape')
+    expect(await containerCount(page)).toBe(4)
+
+    // Sweep all four, then pick chest 1 up and undo the paint while holding.
+    const three = await screenOf(page, 3)
+    await page.mouse.move(one.x - 4, one.y - 4)
+    await page.keyboard.down('Alt')
+    await page.mouse.down()
+    await page.mouse.move(three.x + 4, one.y + 2 * px + 4)
+    await page.mouse.up()
+    await page.keyboard.up('Alt')
+    expect((await selected(page)).length).toBe(4)
+
+    const before = [await positionOf(page, 1), await positionOf(page, 2)]
+    await page.mouse.move(one.x, one.y)
+    await page.mouse.down()
+    await page.mouse.move(one.x, one.y + px, { steps: 2 })
+    expect(await modeOf(page)).toBe('MOVE')
+    await page.keyboard.down('Control')
+    await page.keyboard.press('KeyZ')
+    await page.keyboard.up('Control')
+    expect(await containerCount(page)).toBe(3)
+    expect(await selected(page)).toEqual([1, 2, 3])
+
+    // The drag carries on with the three that are left, and the drop commits them.
+    await page.mouse.move(one.x, one.y + 2 * px, { steps: 2 })
+    await page.mouse.up()
+    expect(await modeOf(page)).not.toBe('MOVE')
+    expect(await positionOf(page, 1)).toEqual({ x: before[0].x, y: before[0].y + 2 })
+    expect(await positionOf(page, 2)).toEqual({ x: before[1].x, y: before[1].y + 2 })
+
+    // And the editor is usable afterwards: Escape clears, a click on empty space is a click.
+    await page.keyboard.press('Escape')
+    expect(await selected(page)).toEqual([])
+    // three tiles left of where chest 1 started: empty, and inside the viewport
+    await page.mouse.click(one.x - 3 * px, one.y)
+    expect(await modeOf(page)).toBe('NONE')
+    expect(errors).toEqual([])
+})
+
+test('mirroring a curved rail keeps the position grid on its new footprint', async ({ page }) => {
+    await openEditorWith(page, ONE_CURVED_RAIL)
+    const errors: string[] = []
+    page.on('pageerror', e => errors.push(String(e)))
+    const px = await tilePx(page)
+
+    const rail = await screenOf(page, 1)
+    await altSelectAround(page, rail)
+    expect(await selected(page)).toEqual([1])
+
+    // pointer off the rail so nothing is hovered or carried
+    await page.mouse.move(rail.x, rail.y + 300)
+    await page.keyboard.down('Shift')
+    await page.keyboard.press('KeyG')
+    await page.keyboard.up('Shift')
+    expect(await positionOf(page, 1)).toEqual(await positionOf(page, 1))
+
+    // Delete the rail, then walk the pointer over the column its 2x6 footprint
+    // covered. If the grid still held those cells, each hover would throw
+    // "Position grid references entity 1, which is not in the blueprint".
+    await page.keyboard.press('Escape')
+    await deleteAround(page, rail)
+    expect(await containerCount(page)).toBe(0)
+    for (let dy = -3; dy <= 3; dy++) {
+        await page.mouse.move(rail.x, rail.y + dy * px, { steps: 2 })
+    }
+    // And along the row the 6x2 footprint covers, which the grid must have released too.
+    for (let dx = -3; dx <= 3; dx++) {
+        await page.mouse.move(rail.x + dx * px, rail.y, { steps: 2 })
+    }
+    expect(errors).toEqual([])
 })

--- a/tests/persistent-selection.spec.ts
+++ b/tests/persistent-selection.spec.ts
@@ -423,10 +423,12 @@ test('mirroring a curved rail keeps the position grid on its new footprint', asy
 
     // pointer off the rail so nothing is hovered or carried
     await page.mouse.move(rail.x, rail.y + 300)
+    const rev = await revision(page)
     await page.keyboard.down('Shift')
     await page.keyboard.press('KeyG')
     await page.keyboard.up('Shift')
-    expect(await positionOf(page, 1)).toEqual(await positionOf(page, 1))
+    // one committed step - the mirror really did write direction 2 -> 6
+    expect(await revision(page)).toBe(rev + 1)
 
     // Delete the rail, then walk the pointer over the column its 2x6 footprint
     // covered. If the grid still held those cells, each hover would throw
@@ -441,5 +443,31 @@ test('mirroring a curved rail keeps the position grid on its new footprint', asy
     for (let dx = -3; dx <= 3; dx++) {
         await page.mouse.move(rail.x + dx * px, rail.y, { steps: 2 })
     }
+    expect(errors).toEqual([])
+})
+
+test('Q mid-drag puts every sprite back where its model is', async ({ page }) => {
+    await openEditorWithChests(page)
+    const errors: string[] = []
+    page.on('pageerror', e => errors.push(String(e)))
+    await altSelect(page, 1, 2)
+    const px = await tilePx(page)
+    const dragOffset = (n: number) =>
+        page.evaluate((n: number) => (window as any).__fbe_test.entityDragOffset(n), n)
+
+    const at = await screenOf(page, 1)
+    await page.mouse.move(at.x, at.y)
+    await page.mouse.down()
+    await page.mouse.move(at.x, at.y + 2 * px, { steps: 2 })
+    expect(await modeOf(page)).toBe('MOVE')
+    expect(await dragOffset(1)).toEqual({ x: 0, y: 64 })
+
+    // Q clears the selection while the drag is live; whatever else it does, the
+    // sprites it drops from the drag must not stay displaced after the release.
+    await page.keyboard.press('KeyQ')
+    await page.mouse.up()
+    expect(await modeOf(page)).not.toBe('MOVE')
+    expect(await dragOffset(1)).toEqual({ x: 0, y: 0 })
+    expect(await dragOffset(2)).toEqual({ x: 0, y: 0 })
     expect(errors).toEqual([])
 })


### PR DESCRIPTION
Follows #369, which merged as `5ce88a87`. These are the three fix commits that were stacked on it as HansLuft778/factorio-blueprint-editor#1 (now closed as superseded), rebased onto the merged base. Two of the three blocking items from the #369 review, plus what CodeRabbit found on the fix itself. All of it was measured by driving the editor with real input.

### Undo during a move drag (review item 1)

`moveDrag.entities` is a copy of the selection taken at the press, and undo has no mode gate. When an undo destroyed a member mid-drag, the next pointer move threw `Entity 4 has no container`, the release threw the same, and every later click or Escape threw `MOVE mode with no drag in progress`. Measured: 5 page errors and the mode never left MOVE.

`deselect` now prunes the drag's copy. Every exit from the selection goes through it, including the `destroy` listener, so the drag carries on with the members that are left. CodeRabbit then caught that the prune alone leaked sprite offsets when Q cleared the selection mid-drag (a 64 px offset survived the release), so `deselect` also resets the offset before pruning. A test-only `entityDragOffset` hook exposes the offset, because nothing else can see it.

### The mirror wrote the direction after the grid was updated (review item 3)

`relocate` sized the grid cells from `entity.size`, which reads the current direction, and the `direction` setter never touches the grid. For a `curved-rail-a` at direction 2, Shift+G left the grid holding the 2x6 cells while the model said 6x2 at direction 6: 8 stale cells and 8 missing. A second Shift+G made it 20 cells for a 12-cell footprint. Delete the rail after that and hovering a stale cell throws `Position grid references entity 1, which is not in the blueprint`.

`relocate` now takes the direction too and writes both in one history step. The direction action lifts the cells laid with the old footprint and lays the new one. It reads the old footprint from the value history hands back, so it is right on undo as well, where the two writes run in the other order. `removeTileData` gained an optional size for that one caller. The other callers of `relocate` are unchanged.

### Review item 2 is not reachable from a mouse

Left alone. A second button pressed while one is held fires `pointermove` with `button=2`, not `pointerdown`, and the editor's only pointer entry is `addEventListener('pointerdown')`. Measured in Chromium: Ctrl+Right during a held left drag entered no mode, and the move committed normally on release. A touch tap with Alt held did not leak the drag either. Review finding 5 (Q mid-drag should cancel the drag first) is also still open; the offset reset above makes it harmless rather than fixing it.

### Tests

`entityRelocate.test.ts` pins the grid before and after a turning relocate, through undo and redo, on a synthetic 1x3 prototype. Three new cases in `persistent-selection.spec.ts` drive the undo-mid-drag, curved-rail mirror, and Q-mid-drag paths with real input; each failed before its fix and passes after. The "reads the footprint at the target direction" case in `groupRelocation.test.ts` now uses a prototype whose footprint actually turns, which CodeRabbit pointed out it did not; with the direction read removed from `canGroupRelocate`, that case fails and nothing else does.

CodeRabbit approved the stack at `7b58bd07` on the throwaway #385, which was closed once it had served. `vp test` 304/304 and `vp check` clean on the rebased tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBc44whGay5DaHGH7JtbG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved entity movement and mirroring for rotated and rectangular entities.
  - Undo and redo now preserve entity positions, directions, and occupied footprints more accurately.
  - Added test access to an entity’s current pixel offset during drag operations.

- **Bug Fixes**
  - Prevented stale drag references and visual offsets after deselection, deletion, or cancelled moves.
  - Improved cleanup of entity footprints when directions change.

- **Tests**
  - Added coverage for rotated entity movement, group relocation, undo/redo, curved rails, and multi-entity drag cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->