### PR TITLE
Replace three pointers to a spec that was never committed, and make the click test assert

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ closing references such as `Closes #123` in the pull request body.
 - `tests` - Playwright browser and blueprint-corpus tests
 - `test-blueprints` - committed real-world blueprint corpus
 - `tools/oracle` - probes that ask a local Factorio installation what it does
-- `docs/superpowers` - `plans` (9) and `specs` (6) for larger past changes
+- `docs/superpowers` - `specs` (6) for larger past changes
 - `.github/workflows` - CI and deploy; `README.md` holds the job rationale
 
 ## Setup and commands

--- a/packages/editor/src/containers/BlueprintContainer.ts
+++ b/packages/editor/src/containers/BlueprintContainer.ts
@@ -1094,8 +1094,10 @@ export class BlueprintContainer extends Container {
      * the drag previews by displacing the real sprites (`EntityContainer.
      * setDragOffset`) and the selection boxes, and a cancel just puts them
      * back. That is what makes cancelling a true no-op and a completed move a
-     * single undo step - the reasons a detach-and-carry design was rejected
-     * (docs/superpowers/specs/2026-09-05-persistent-selection-design.md).
+     * single undo step, and why the selection is not handed to a paint
+     * container the way a copy-mode sweep is: that route rebuilds entities,
+     * so a cancel would have to put them back and a move would be a delete
+     * and a paste in the history.
      */
     private enterMoveMode(): boolean {
         if (this.mode !== EditorMode.NONE && this.mode !== EditorMode.EDIT) return false

--- a/packages/editor/src/core/groupRelocation.test.ts
+++ b/packages/editor/src/core/groupRelocation.test.ts
@@ -5,8 +5,7 @@ import { loadData } from './factorioData'
 
 /*
     PositionGrid.canGroupRelocate, the check behind moving or mirroring a
-    persistent selection as one unit
-    (docs/superpowers/specs/2026-09-05-persistent-selection-design.md).
+    persistent selection as one unit.
 
     canMoveTo lifts one entity out of the grid before asking whether its
     destination is free. Asked once per member of a group that is moving

--- a/tests/persistent-selection.spec.ts
+++ b/tests/persistent-selection.spec.ts
@@ -6,8 +6,9 @@ import { suppressOverlays } from './helpers/overlays'
     The persistent selection: Alt+Left-drag sweeps a rectangle whose entities
     stay selected after release; a plain Left-drag that starts on one of them
     moves the whole group; Shift+F / Shift+G mirror it in place; Escape clears
-    it. Design and the reasons for each binding:
-    docs/superpowers/specs/2026-09-05-persistent-selection-design.md.
+    it. The bindings reuse what was already there: Alt+Left sits beside the
+    Ctrl+Left copy sweep and the Ctrl+Right delete sweep, Shift+F and Shift+G
+    are the keys that flip a paint container, and Escape is the usual way out.
 
     Everything below is real pointer and keyboard input, in the idiom of
     tests/editor-mode-input.spec.ts. Three things only a hook can see, and each
@@ -224,13 +225,18 @@ test('a click on a selected chest, without dragging, opens its editor too', asyn
     await openEditorWithChests(page)
     await altSelect(page, 1, 2)
 
+    const before = await positionOf(page, 1)
+    const rev = await revision(page)
+
     const chest = await screenOf(page, 1)
     await page.mouse.move(chest.x, chest.y)
     await page.mouse.down()
     expect(await modeOf(page)).toBe('MOVE')
     await page.mouse.up()
     expect(await dialogs(page)).toBe(1)
-    expect(await positionOf(page, 1)).toEqual(await positionOf(page, 1))
+    // a click is not a move: nothing moved and nothing was written
+    expect(await positionOf(page, 1)).toEqual(before)
+    expect(await revision(page)).toBe(rev)
 })
 
 test('Escape mid-drag puts everything back and writes nothing', async ({ page }) => {


### PR DESCRIPTION
The two documentation and test findings from the #369 review, left open at the merge. No behaviour change.

- The design spec `docs/superpowers/specs/2026-09-05-persistent-selection-design.md` was cited from `BlueprintContainer.ts`, `groupRelocation.test.ts` and `tests/persistent-selection.spec.ts`, and it exists on no branch (`git ls-tree` on the PR head and on the base both come up empty). Each site now carries the reasoning it pointed at instead: why the selection previews by displacing sprites rather than being handed to a paint container, and which existing bindings Alt+Left, Shift+F, Shift+G and Escape sit beside.
- `CLAUDE.md` also listed a `docs/superpowers/plans` directory of nine. `git ls-files docs/` shows only the six specs, so the line now names those alone.
- The "click on a selected chest, without dragging" case compared the chest's position to a second read of itself, so it could not fail on a click that moved something. It now records the position and the history revision before the press and asserts both are unchanged after the release, the same pattern its neighbours use.

`vp check` clean; `tests/persistent-selection.spec.ts` 15/15 against a dev server on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBc44whGay5DaHGH7JtbG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved persistent-selection interaction handling so clicking a selected chest without dragging does not move it or create an unnecessary history change.

- **Tests**
  - Expanded coverage for persistent-selection keyboard controls and no-op click behavior.
  - Clarified validation for moving or mirroring persistent selections as a unit.

- **Documentation**
  - Updated repository and editor documentation to better describe selection movement, drag previews, cancellation, and undo behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->