### PR TITLE
Guard the decider combinator's info overlay against an empty outputs list

### DIFF
--- a/packages/editor/src/core/Entity.ts
+++ b/packages/editor/src/core/Entity.ts
@@ -1016,9 +1016,9 @@ export class Entity extends EventEmitter<EntityEvents> {
         if (this.type === 'decider-combinator') {
             const decider_conditions = this.m_rawEntity.control_behavior?.decider_conditions
             return {
-                first_signal: decider_conditions?.conditions?.[0].first_signal,
-                second_signal: decider_conditions?.conditions?.[0].second_signal,
-                output_signal: decider_conditions?.outputs?.[0].signal,
+                first_signal: decider_conditions?.conditions?.[0]?.first_signal,
+                second_signal: decider_conditions?.conditions?.[0]?.second_signal,
+                output_signal: decider_conditions?.outputs?.[0]?.signal,
             }
         }
         if (this.type === 'arithmetic-combinator') {

--- a/tests/pre-2-0-shape-migrations.spec.ts
+++ b/tests/pre-2-0-shape-migrations.spec.ts
@@ -212,3 +212,54 @@ test('the combinator migration is shape-gated, not version-gated', async ({ page
     ])
     expect(errors, `page errors: ${errors.join(' | ')}`).toEqual([])
 })
+
+test('a pre-2.0 decider with no output signal still gets an info overlay', async ({ page }) => {
+    /*
+        A 1.1 decider exported with its output slot empty is the flat
+        `{ constant, comparator, copy_count_from_input }` and nothing else - no
+        first_signal, no output_signal. Blueprint.ts turns that into
+        `conditions: [{...}]` and `outputs: []`, and an empty `outputs` is what
+        Entity.combinatorConditions could not read: `outputs?.[0].signal` guards
+        the list, not the element, so it threw on the element.
+
+        The instance createEntityInfo swallows that into a console warning and
+        the combinator simply draws no overlay, which is how it showed up in the
+        wild: six deciders in a 838-entity 1.1 blueprint logging
+        "Failed to create entity info for decider-combinator". Both readings are
+        pinned - the console line the user saw, and the static call the tally
+        makes, which rethrows instead.
+    */
+    const failures: string[] = []
+    page.on('console', msg => {
+        if (msg.text().includes('Failed to create entity info')) failures.push(msg.text())
+    })
+
+    const errors = await load(
+        page,
+        encode({
+            item: 'blueprint',
+            version: version(1, 1, 110),
+            icons: [{ index: 1, signal: { type: 'item', name: 'decider-combinator' } }],
+            entities: [
+                {
+                    entity_number: 1,
+                    name: 'decider-combinator',
+                    position: { x: 0.5, y: 1 },
+                    control_behavior: {
+                        decider_conditions: {
+                            constant: 0,
+                            comparator: '≤',
+                            copy_count_from_input: true,
+                        },
+                    },
+                },
+            ],
+        })
+    )
+
+    expect(errors, `page errors: ${errors.join(' | ')}`).toEqual([])
+    expect(failures, `overlay failures: ${failures.join(' | ')}`).toEqual([])
+
+    const tally = await page.evaluate(() => window.__fbe_test.overlayInfoTally())
+    expect(tally['decider-combinator']).toHaveLength(1)
+})


### PR DESCRIPTION
## What

A 1.1-era decider combinator whose output slot was empty makes `Entity.combinatorConditions` throw, so the combinator gets no info overlay. Loading https://fbe.factorygamefan.com/?source=https://pastebin.com/uc4n81GP (838 entities, version 1.1.110) logs this six times:

```
Failed to create entity info for decider-combinator: TypeError: Cannot read properties of undefined (reading 'signal')
    at get combinatorConditions (Entity.ts)
```

The blueprint still loads. The six deciders (entity numbers 601, 602, 632, 633, 663, 664) just draw no overlay.

## Why

Each of those deciders is the 1.1 flat shape with no `first_signal` and no `output_signal`, for example `{"constant":0,"comparator":"≤","copy_count_from_input":true}`. The pre-2.0 shape migration in `Blueprint.ts` turns that into `conditions: [{...}]` and `outputs: []`. `combinatorConditions` then read `outputs?.[0].signal`. The `?.` guards the list, not the element, so an empty list throws on `.signal`.

## Fix

`?.[0]?.signal` for the output, and the same guard on the two `conditions?.[0]` reads, which have the identical gap one empty list away. Six characters in `Entity.ts`.

## Measured

Same blueprint, base branch on one dev server and this branch on another:

| Server | "Failed to create entity info" lines | `overlayInfoTally()['decider-combinator']` |
| --- | --- | --- |
| base `11126335` | 6 | throws `reading 'signal'` |
| this branch | 0 | `[1,1,2,2,2,1,1,2,1,1]` |

## Test

`tests/pre-2-0-shape-migrations.spec.ts` gains a synthetic 1.1.110 decider holding exactly the flat shape above. It asserts no page errors, no "Failed to create entity info" console line, and that the tally hook (which calls the static `createEntityInfo`, so a throw propagates) returns one overlay for the decider. Watched red first: both the console assertion and the tally failed with the `reading 'signal'` message at `combinatorConditions`.

`vp check` clean, `vp test` 340 passing, and `overlay-container.spec.ts` plus `entity-accessors.spec.ts` unchanged against the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Af7GznpG5F5PAuanmRBUaB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when decider conditions or output signals are missing.
  - Prevented errors in entity information overlays for legacy decider configurations.

- **Tests**
  - Added regression coverage for older decider condition formats with absent output signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->