### PR TITLE
Let Renovate and CodeRabbit reach the review job

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,13 +44,24 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Renovate and CodeRabbit both open pull requests here. The action
-          # refuses any non-human actor unless it is listed, so without this the
-          # job fails in about 18 seconds, before it ever reads the diff.
+          # Renovate and CodeRabbit can both trigger this workflow. The action
+          # refuses any non-human actor unless it is listed here, and it fails
+          # in seconds, before it ever reads the diff.
           #
-          # Set the CLAUDE_ALLOWED_BOTS organization variable to change this
-          # list for every repo at once. The literal below is only the fallback
-          # used while that variable is unset.
+          # coderabbitai[bot] is listed even though CodeRabbit has never OPENED
+          # a pull request in this org. The action checks the TRIGGERING actor,
+          # not the PR author (isAllowedBot in src/github/validation/actor.ts),
+          # and a CodeRabbit push to a PR fires `synchronize` with that actor.
+          # So do not delete this entry just because no PR lists it as author.
+          #
+          # Set the CLAUDE_ALLOWED_BOTS organization variable to change the list
+          # for every repo at once. The literal below is only the fallback while
+          # that variable is unset.
+          #
+          # NEVER set that variable to '*'. These repos are public, so '*' lets
+          # any external App invoke this action with a prompt it controls. Note
+          # the variable is the weaker spot: editing this line takes a PR, a
+          # diff and a review, while setting the variable takes none of them.
           allowed_bots: "${{ vars.CLAUDE_ALLOWED_BOTS || 'renovate[bot],coderabbitai[bot]' }}"
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,6 +44,14 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Renovate and CodeRabbit both open pull requests here. The action
+          # refuses any non-human actor unless it is listed, so without this the
+          # job fails in about 18 seconds, before it ever reads the diff.
+          #
+          # Set the CLAUDE_ALLOWED_BOTS organization variable to change this
+          # list for every repo at once. The literal below is only the fallback
+          # used while that variable is unset.
+          allowed_bots: "${{ vars.CLAUDE_ALLOWED_BOTS || 'renovate[bot],coderabbitai[bot]' }}"
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
Renovate's dependency PRs have been failing the `claude-review` check for a
reason that has nothing to do with their diffs. The action stops before it
reads any code:

```
Workflow initiated by non-human actor: renovate (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

It fails in seconds. Measured from the job records: 18s and 17s on
factorio-blueprint-editor #395 and #396, and 9s and 13s on FactorioMapWebUI
#392 and #391 (jobs 101782943151 and 101782864206).

Nothing here is branch protected on `claude-review`, so it blocks no merges,
but it does mean every dependency PR shows a failure that has to be checked by
hand before it can be trusted. That is how a real failure gets missed.

## What is allowed

`renovate[bot]` and `coderabbitai[bot]`, the two bots that can trigger this
workflow. The action lowercases each side and strips a trailing `[bot]` before
comparing, so the suffix is optional; it is written out to match the action's
own docs.

CodeRabbit has never *opened* a PR in this org, so the entry looks like dead
weight until you know the action checks the triggering actor rather than the PR
author. A CodeRabbit push to a PR fires `synchronize` with that actor. The
comment in the file says so, to stop someone deleting it later as unused.

## On the organization variable

The value reads `CLAUDE_ALLOWED_BOTS` first, so the list can be changed for
every repo from one place. The literal is the fallback while that variable is
unset, which it currently is.

That indirection has a cost worth stating plainly: these repos are public, and
setting the variable to `'*'` would let any external App invoke this action
with a prompt it controls. Editing the line below takes a PR, a diff and a
review; setting the variable takes none of them. The file carries that warning
next to the value.

Creating the variable needs `admin:org`, which the token in use here does not
have, so that step is Eric's if he wants it. Nothing depends on it - the
fallback works on its own.

## Deliberately unchanged

`claude.yml` runs on any comment containing `@claude`. Allowing bots there
would let CodeRabbit's review text drive Claude on a public repo.

## Not a full fix alone

The other repo running this workflow needs the same change. These two PRs go
together: factorio-blueprint-editor#398 and FactorioMapWebUI#393.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review configuration to control which bots are permitted to participate.
  * Uses a configurable allowed-bot list, with Renovate and CodeRabbit as defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->