### PR TITLE
Preserve Grid position when switching blueprint book entries

### DIFF
--- a/packages/editor/src/core/Book.ts
+++ b/packages/editor/src/core/Book.ts
@@ -1,4 +1,4 @@
-import { IBlueprint, IBlueprintBook, IBlueprintBookEntry, IIcon } from '../types'
+import { IBlueprint, IBlueprintBook, IBlueprintBookEntry, IIcon, IPoint } from '../types'
 import { Blueprint, getFactorioVersion } from './Blueprint'
 
 class Book {
@@ -11,6 +11,8 @@ class Book {
     private _active: Blueprint | undefined
     private _activeIndex: number
     private readonly blueprints: IBlueprintBookEntry[]
+    // Export bakes this into positions; re-importing recentres them and loses it.
+    private readonly gridPositionOffsets = new Map<number, IPoint>()
 
     private readonly label?: string
     private readonly description?: string
@@ -39,6 +41,7 @@ class Book {
 
     private saveActiveBlueprint(): number {
         if (this._active) {
+            this.gridPositionOffsets.set(this._activeIndex, { ...this._active.gridPositionOffset })
             const res = saveBlueprint(this.blueprints, this._activeIndex, this._active.serialize())
             // Not finding a slot used to answer undefined, which serialize() then
             // wrote into `active_index` - a required number - and JSON.stringify
@@ -58,6 +61,9 @@ class Book {
 
         const blueprint = getBlueprintAtFlattenedActiveIndex(this.blueprints, this._activeIndex)
         const bp = new Blueprint(blueprint)
+        bp.gridPositionOffset = this.gridPositionOffsets.get(this._activeIndex) ?? { x: 0, y: 0 }
+        // Restoring book state is not a user edit to undo.
+        bp.history.reset()
         this._active = bp
         return bp
     }

--- a/tests/settings-pane-book-index.spec.ts
+++ b/tests/settings-pane-book-index.spec.ts
@@ -2,8 +2,16 @@ import { test, expect } from '@playwright/test'
 import {
     encodeBlueprintBook as encodeBook,
     packVersion as version,
+    decodeBlueprintString,
 } from './helpers/encode-blueprint'
 import { loadBlueprint, waitForEditor } from './helpers/fbe-test-api'
+import { openBlueprintInfo, enableSnapToGrid } from './helpers/blueprint-info-dialog'
+import {
+    COL1_X,
+    COL2_X,
+    FIELD_WIDTH,
+    ROW_HEIGHT,
+} from '../packages/editor/src/UI/BlueprintAlignment'
 
 /*
     The settings pane's BP Book Index box, and the first coverage its arrow
@@ -105,6 +113,63 @@ const waitForEntry = (page: Page, index: number): Promise<unknown> =>
 
 test.beforeEach(async ({ page }) => {
     await waitForEditor(page)
+})
+
+test('Grid position survives repeated book switches without changing exports or other entries', async ({
+    page,
+}) => {
+    await loadBlueprint(page, BOOK)
+    const input = bpIndexInput(page)
+    for (const [index, x, y] of [
+        [0, '10', '-6'],
+        [1, '-7', '12'],
+    ] as const) {
+        await input.blur()
+        const align = await openBlueprintInfo(page)
+        await enableSnapToGrid(page, align)
+        for (const [col, value] of [
+            [COL1_X, x],
+            [COL2_X, y],
+        ] as const) {
+            await page.mouse.click(align.x + col + FIELD_WIDTH / 2, align.y + ROW_HEIGHT * 2 + 14)
+            await page.keyboard.press('ControlOrMeta+A')
+            await page.keyboard.type(value)
+            await page.keyboard.press('Tab')
+        }
+        expect(
+            await page.evaluate(() =>
+                [...document.querySelectorAll('input')]
+                    .filter(el => el.style.cssText !== '')
+                    .map(el => el.value)
+                    .slice(3, 5)
+            )
+        ).toEqual([x, y])
+        await input.click()
+        await page.keyboard.press('ArrowUp')
+        await waitForEntry(page, index + 1)
+    }
+    const before = decodeBlueprintString(
+        await page.evaluate(() => window.__fbe_test.encodeLoaded())
+    )
+    for (const index of [1, 0, 1, 0]) {
+        await input.click()
+        await page.keyboard.press(
+            index === 1 && (await input.inputValue()) === '0' ? 'ArrowUp' : 'ArrowDown'
+        )
+        await waitForEntry(page, index)
+        await input.blur()
+        await openBlueprintInfo(page)
+        const values = await page.evaluate(() =>
+            [...document.querySelectorAll('input')]
+                .filter(el => el.style.cssText !== '')
+                .map(el => el.value)
+        )
+        expect(values.slice(3, 5)).toEqual(index === 0 ? ['10', '-6'] : ['-7', '12'])
+        const after = decodeBlueprintString(
+            await page.evaluate(() => window.__fbe_test.encodeLoaded())
+        )
+        expect(after.blueprint_book.blueprints).toEqual(before.blueprint_book.blueprints)
+    }
 })
 
 test('CONTROL: the arrow keys step the book index twice over, with no dialog involved', async ({


### PR DESCRIPTION
Fixes #394.

Typing Grid position in Blueprint Info now survives switching away from a book entry and back. Book keeps the export-only offset per flattened entry and restores it after reconstruction without creating an undo action.

The browser regression edits both axes on two entries, switches repeatedly with Blueprint Info open, and verifies the displayed values and complete book entry exports remain unchanged.

Validation: 18 related browser tests passed; the new regression fails without offset restoration. Changed-file lint, formatting, and git diff checks passed. The wider local unit run passed 343 tests with one unrelated Windows CRLF fixture failure; full formatting also reports existing checkout-wide differences.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Grid positions now persist correctly when switching between blueprints.
  - Restoring saved grid positions no longer adds unintended entries to undo history.
  - Blueprint data remains aligned correctly across repeated switches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->