### PR TITLE
Preserve splitter lane priorities on every mirror

### DIFF
--- a/packages/editor/src/core/Entity.ts
+++ b/packages/editor/src/core/Entity.ts
@@ -1347,17 +1347,6 @@ export class Entity extends EventEmitter<EntityEvents> {
         const axisDir = vertical ? 12 : 8
         const direction = this.constrainDirection((axisDir * 2 - this.direction) % 16)
 
-        let input_priority = this.m_rawEntity.input_priority
-        let output_priority = this.m_rawEntity.output_priority
-
-        if (
-            (vertical && (direction === 4 || direction === 8)) ||
-            (!vertical && (direction === 0 || direction === 12))
-        ) {
-            input_priority = this.changePriority(input_priority)
-            output_priority = this.changePriority(output_priority)
-        }
-
         const position = vertical
             ? { x: this.m_rawEntity.position.x, y: -this.m_rawEntity.position.y }
             : { x: -this.m_rawEntity.position.x, y: this.m_rawEntity.position.y }
@@ -1365,8 +1354,8 @@ export class Entity extends EventEmitter<EntityEvents> {
             ...this.m_rawEntity,
             direction,
             position,
-            input_priority,
-            output_priority,
+            input_priority: this.changePriority(this.m_rawEntity.input_priority),
+            output_priority: this.changePriority(this.m_rawEntity.output_priority),
         }
         if (direction === 0) delete updatedRawEntity.direction
 

--- a/tests/persistent-selection.spec.ts
+++ b/tests/persistent-selection.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test'
-import { encodeBlueprint as encode, packVersion as version } from './helpers/encode-blueprint'
+import {
+    decodeBlueprintString,
+    encodeBlueprint as encode,
+    packVersion as version,
+} from './helpers/encode-blueprint'
 import { suppressOverlays } from './helpers/overlays'
 
 /*
@@ -304,6 +308,51 @@ test('Shift+F mirrors the selection in place, in one undo step', async ({ page }
     expect(await positionOf(page, 2)).toEqual(one)
     expect(await revision(page)).toBe(rev + 1)
 })
+
+for (const [key, directions] of [
+    ['KeyG', [8, 4, 0, 12]],
+    ['KeyF', [0, 12, 8, 4]],
+] as const) {
+    for (const [index, direction] of [0, 4, 8, 12].entries()) {
+        test(`${key} mirrors splitter priorities at direction ${direction} and restores them on a second flip`, async ({
+            page,
+        }) => {
+            await openEditorWith(
+                page,
+                encode({
+                    item: 'blueprint',
+                    version: version(2, 0, 55),
+                    entities: [
+                        {
+                            entity_number: 1,
+                            name: 'splitter',
+                            position: { x: 0, y: 0 },
+                            direction,
+                            input_priority: 'right',
+                            output_priority: 'left',
+                        },
+                    ],
+                })
+            )
+            const exported = async () =>
+                decodeBlueprintString(
+                    await page.evaluate(() => (window as any).__fbe_test.encodeLoaded())
+                ).blueprint.entities[0]
+            const before = await exported()
+            await altSelectAround(page, await screenOf(page, 1))
+            expect(await selected(page)).toEqual([1])
+
+            await page.keyboard.press(`Shift+${key}`)
+            const mirrored = await exported()
+            expect(mirrored.direction ?? 0).toBe(directions[index])
+            expect(mirrored.input_priority).toBe('left')
+            expect(mirrored.output_priority).toBe('right')
+
+            await page.keyboard.press(`Shift+${key}`)
+            expect(await exported()).toEqual(before)
+        })
+    }
+}
 
 test('Escape with nothing in progress clears the selection', async ({ page }) => {
     await openEditorWithChests(page)


### PR DESCRIPTION
Mirroring south- or west-facing splitters kept the wrong lane priorities. Swap input and output priorities on every reflection in `Entity.getFlippedCopy`, fixing both persistent selections and flipped blueprint placement.

Add browser regression cases for all four cardinal directions on both axes. Each uses real Alt-drag selection and Shift+F/G input, reads priorities through `encodeLoaded`, and checks that a second flip restores the original exported entity.

Validation: reproduced the south-facing Shift+G failure before the fix; all 23 persistent-selection browser tests, 351 unit tests, and format/lint/type checks pass locally. Local checks used the existing Vite+ 0.2.9 installation; CI uses the pinned 0.3.0 toolchain.

Closes #387.
