### PR TITLE
Fix stale entities surviving an Alt selection sweep

### DIFF
--- a/packages/editor/src/containers/BlueprintContainer.ts
+++ b/packages/editor/src/containers/BlueprintContainer.ts
@@ -1075,7 +1075,8 @@ export class BlueprintContainer extends Container {
         this.updateHoverContainer()
 
         for (const e of this.selectModeEntities) {
-            if (cancel) {
+            // Undo can destroy a swept entity without another pointer update.
+            if (cancel || !EntityContainer.mappings.has(e.entityNumber)) {
                 this.overlayContainer.hideSelectionHighlight(e.entityNumber)
             } else {
                 this.select(e)

--- a/tests/persistent-selection.spec.ts
+++ b/tests/persistent-selection.spec.ts
@@ -171,6 +171,50 @@ test('Alt and a left drag sweep a selection that outlives the release', async ({
     expect(await selected(page)).toEqual([3])
 })
 
+for (const includeSurvivors of [false, true]) {
+    test(`undo during an Alt sweep discards destroyed entities (survivors: ${includeSurvivors})`, async ({
+        page,
+    }) => {
+        await openEditorWithChests(page)
+        const errors: string[] = []
+        page.on('pageerror', e => errors.push(String(e)))
+        const one = await screenOf(page, 1)
+        const three = await screenOf(page, 3)
+        const px = await tilePx(page)
+        const painted = { x: one.x - 2 * px, y: one.y }
+
+        await page.mouse.move(one.x, one.y)
+        await page.keyboard.press('KeyQ')
+        await page.mouse.click(painted.x, painted.y)
+        await page.keyboard.press('Escape')
+        expect(await containerCount(page)).toBe(4)
+
+        // The painted chest comes first in the sweep; undo it without moving again.
+        await page.mouse.move(painted.x - 4, painted.y - 4)
+        await page.keyboard.down('Alt')
+        await page.mouse.down()
+        const end = includeSurvivors ? three : painted
+        await page.mouse.move(end.x + 4, end.y + 4)
+        expect(await modeOf(page)).toBe('SELECT')
+        await page.keyboard.down('Control')
+        await page.keyboard.press('KeyZ')
+        await page.keyboard.up('Control')
+        expect(await containerCount(page)).toBe(3)
+        await page.mouse.up()
+        await page.keyboard.up('Alt')
+
+        expect(await modeOf(page)).not.toBe('SELECT')
+        expect(await selected(page)).toEqual(includeSurvivors ? [1, 2, 3] : [])
+        await page.keyboard.press('Shift+KeyF')
+        await page.keyboard.press('Shift+KeyG')
+        await page.keyboard.press('Escape')
+        expect(await selected(page)).toEqual([])
+        await altSelect(page, 1, 2)
+        expect(await selected(page)).toEqual([1, 2])
+        expect(errors).toEqual([])
+    })
+}
+
 test('dragging a selected chest moves the whole selection in one undo step', async ({ page }) => {
     await openEditorWithChests(page)
     await altSelect(page, 1, 2)


### PR DESCRIPTION
Undoing a freshly painted entity during an Alt selection sweep left a destroyed entity permanently selected and aborted selection of the remaining entities. On release, discard swept entities whose containers no longer exist and remove their highlights before selecting the survivors.

Adds two browser regressions covering an empty selection and surviving entities later in the sweep, plus subsequent mirroring, clearing, and reselection. Both reproduced the failure before the fix.

Validation: all 17 persistent-selection Playwright tests passed against the local dev server in Chromium; all 351 unit tests passed; `vp check` passed formatting, lint, and type checks.

Closes #388.
