### PR TITLE
Fix rail footprints used for blueprint Grid position

### DIFF
--- a/packages/editor/src/core/Blueprint.ts
+++ b/packages/editor/src/core/Blueprint.ts
@@ -16,7 +16,12 @@ import {
 } from '../types'
 import G from '../common/globals'
 import util from '../common/util'
-import FD, { getEntitySize, getModuleInventoryIndex, hasModuleFunctionality } from './factorioData'
+import FD, {
+    getEntityGridSize,
+    getEntitySize,
+    getModuleInventoryIndex,
+    hasModuleFunctionality,
+} from './factorioData'
 import { Entity } from './Entity'
 import { WireConnections } from './WireConnections'
 import { PositionGrid } from './PositionGrid'
@@ -824,9 +829,10 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
      * what "this blueprint's content" means. */
     private footprintData(): { x: number; y: number; w: number; h: number }[] {
         return [
-            ...this.entities
-                .valuesArray()
-                .map(e => ({ x: e.position.x, y: e.position.y, w: e.size.x, h: e.size.y })),
+            ...this.entities.valuesArray().map(e => {
+                const size = getEntityGridSize(e.entityData, e.direction)
+                return { x: e.position.x, y: e.position.y, w: size.x, h: size.y }
+            }),
             ...this.tiles.valuesArray().map(t => ({ x: t.x, y: t.y, w: 1, h: 1 })),
         ]
     }
@@ -1260,16 +1266,9 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
      * with every entity placed afterwards still exporting shifted by it and
      * nothing on screen saying why (#243 review).
      *
-     * Known limit: the footprint reading disagrees with the game for 9 rail
-     * prototypes - `curved-rail-a`/`-b` and their elevated and dummy forms,
-     * `legacy-curved-rail` and `rail-ramp` - which
-     * `tools/oracle/fixtures/entity-tile-size.json` records as the ones
-     * `getEntitySize` misses. A blueprint whose minimum corner is set by one
-     * of them displays 1-2 tiles off what the game shows, and since the
-     * commit solves for this display, typing a target there exports off by
-     * the same amount. `getEntitySize` is not the place to fix it:
-     * tests/rail-footprints.spec.ts records that the game footprints make
-     * occupancy worse in both directions. Tracked as #393.
+     * Rails use measured runtime tile sizes via `getEntityGridSize` (#393).
+     * Placement and selection keep their separate `getEntitySize` rectangles;
+     * tests/rail-footprints.spec.ts records why those must not change.
      */
     public getGridPositionDisplay(): IPoint {
         const center = this.isEmpty() ? { x: 0, y: 0 } : this.computeExportCenter()

--- a/packages/editor/src/core/Blueprint.ts
+++ b/packages/editor/src/core/Blueprint.ts
@@ -823,14 +823,12 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
         return this.entities.isEmpty() && this.tiles.isEmpty()
     }
 
-    /** Every entity's and tile's own footprint, `w`/`h` being the full tile
-     * size rather than a half-extent - shared by `getCenter()` and
-     * `getGridPositionDisplay()` so the two can't independently drift on
-     * what "this blueprint's content" means. */
-    private footprintData(): { x: number; y: number; w: number; h: number }[] {
+    /** Full tile extents. Export centering keeps its existing occupancy sizes;
+     * the Grid position reading uses the game's measured tile sizes instead. */
+    private footprintData(gridPosition = false): { x: number; y: number; w: number; h: number }[] {
         return [
             ...this.entities.valuesArray().map(e => {
-                const size = getEntityGridSize(e.entityData, e.direction)
+                const size = gridPosition ? getEntityGridSize(e.entityData, e.direction) : e.size
                 return { x: e.position.x, y: e.position.y, w: size.x, h: size.y }
             }),
             ...this.tiles.valuesArray().map(t => ({ x: t.x, y: t.y, w: 1, h: 1 })),
@@ -1242,9 +1240,9 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
      * offsets `computeExportCenter()`'s result, so the two stay in lockstep
      * without duplicating that arithmetic.
      *
-     * Reads the minimum corner through `minCorner(footprintData())` - the
-     * same footprint-edge reading `getCenter()` uses - rather than each
-     * entity's own centre. The two used to disagree without anything here
+     * Reads the minimum corner through `minCorner(footprintData(true))`,
+     * using runtime tile edges rather than each entity's own centre.
+     * The two used to disagree without anything here
      * being able to tell: every case measured so far used 1x1 entities on a
      * half-integer centre, where centre-floor and edge-floor land on the
      * same tile by construction. `tools/oracle/fixtures/blueprint-grid-
@@ -1273,7 +1271,7 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
     public getGridPositionDisplay(): IPoint {
         const center = this.isEmpty() ? { x: 0, y: 0 } : this.computeExportCenter()
         const offset = this.gridPositionOffset
-        const min = this.isEmpty() ? { x: 0, y: 0 } : this.minCorner(this.footprintData())
+        const min = this.isEmpty() ? { x: 0, y: 0 } : this.minCorner(this.footprintData(true))
 
         return {
             x: -Math.floor(min.x - center.x + offset.x),

--- a/packages/editor/src/core/factorioData.ts
+++ b/packages/editor/src/core/factorioData.ts
@@ -654,6 +654,31 @@ export function getEntitySize(e: EntityWithOwnerPrototype, dir: number = 0): IPo
     }
 }
 
+/** Runtime tile sizes measured in tools/oracle/fixtures/entity-tile-size.json.
+ * These describe blueprint grid alignment, not placement/selection occupancy. */
+export function getEntityGridSize(e: EntityWithOwnerPrototype, dir: number = 0): IPoint {
+    let size: [number, number]
+    switch (e.type) {
+        case 'curved-rail-a':
+        case 'elevated-curved-rail-a':
+            size = [2, 4]
+            break
+        case 'curved-rail-b':
+        case 'elevated-curved-rail-b':
+            size = [2, 2]
+            break
+        case 'legacy-curved-rail':
+            size = [4, 8]
+            break
+        case 'rail-ramp':
+            size = [2, 16]
+            break
+        default:
+            return getEntitySize(e, dir)
+    }
+    return getEntitySize({ ...e, tile_width: size[0], tile_height: size[1] }, dir)
+}
+
 export function getPossibleRotations(
     e: EntityWithOwnerPrototype,
     assemblingMachineHasFluidRecipe: boolean = false

--- a/tests/blueprint-grid-footprints.test.ts
+++ b/tests/blueprint-grid-footprints.test.ts
@@ -21,6 +21,24 @@ it('matches all 155 measured tile sizes without changing occupancy sizes', () =>
     }
 })
 
+it('preserves ordinary rail exports before any Grid position edit', () => {
+    const blueprint = new Blueprint({
+        entities: [
+            { entity_number: 1, name: 'curved-rail-b', position: { x: 4, y: 4 } },
+            { entity_number: 2, name: 'wooden-chest', position: { x: 10.5, y: 20.5 } },
+        ],
+        tiles: [{ name: 'stone-path', position: { x: 8, y: 18 } }],
+    })
+    blueprint.getGridPositionDisplay()
+    const exported = blueprint.serialize()
+    // Existing occupancy-based centering, including the import's half-tile shift.
+    expect(exported.entities?.map(e => e.position)).toEqual([
+        { x: -3, y: -7.5 },
+        { x: 3.5, y: 9 },
+    ])
+    expect(exported.tiles?.map(t => t.position)).toEqual([{ x: 1, y: 6 }])
+})
+
 // Expected corners come from the game's fixture and exported coordinates, never
 // from the editor's footprint/display helpers. Include all nine mismatches and
 // a non-rail control, both cardinal axes, and a tile owning the minimum corner.
@@ -44,7 +62,7 @@ for (const name of [
                         ? [{ name: 'stone-path', position: { x: -20, y: -20 } }]
                         : undefined,
                 })
-                const livePositions = blueprint.entities.valuesArray().map(e => e.position)
+                const livePositions = blueprint.entities.valuesArray().map(e => ({ ...e.position }))
                 const measuredPosition = () => {
                     const exported = blueprint.serialize()
                     const corners = (exported.entities ?? []).map(e => {

--- a/tests/blueprint-grid-footprints.test.ts
+++ b/tests/blueprint-grid-footprints.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs'
+import { beforeAll, expect, it } from 'vite-plus/test'
+import { Blueprint } from '../packages/editor/src/core/Blueprint'
+import FD, {
+    getEntityGridSize,
+    getEntitySize,
+    loadData,
+} from '../packages/editor/src/core/factorioData'
+import footprints from '../tools/oracle/fixtures/entity-tile-size.json'
+
+beforeAll(() => {
+    loadData(readFileSync('packages/exporter/data/output/data.json', 'utf8'))
+})
+
+it('matches all 155 measured tile sizes without changing occupancy sizes', () => {
+    expect(Object.keys(footprints.entities)).toHaveLength(155)
+    for (const [name, { gameTiles, editorTiles }] of Object.entries(footprints.entities)) {
+        const prototype = FD.entities[name]
+        expect(getEntityGridSize(prototype), name).toEqual({ x: gameTiles[0], y: gameTiles[1] })
+        expect(getEntitySize(prototype), name).toEqual({ x: editorTiles[0], y: editorTiles[1] })
+    }
+})
+
+// Expected corners come from the game's fixture and exported coordinates, never
+// from the editor's footprint/display helpers. Include all nine mismatches and
+// a non-rail control, both cardinal axes, and a tile owning the minimum corner.
+for (const name of [
+    ...footprints.summary.disagreeing.map(row => row.name),
+    'assembling-machine-1',
+]) {
+    for (const direction of [0, 4, 8, 12]) {
+        for (const withTile of [false, true]) {
+            it(`${name}, direction ${direction}, tile ${withTile}: displays and exports the measured grid position`, () => {
+                const blueprint = new Blueprint({
+                    entities: [
+                        { entity_number: 1, name, direction, position: { x: 4, y: 4 } },
+                        {
+                            entity_number: 2,
+                            name: 'wooden-chest',
+                            position: { x: 10.5, y: 20.5 },
+                        },
+                    ],
+                    tiles: withTile
+                        ? [{ name: 'stone-path', position: { x: -20, y: -20 } }]
+                        : undefined,
+                })
+                const livePositions = blueprint.entities.valuesArray().map(e => e.position)
+                const measuredPosition = () => {
+                    const exported = blueprint.serialize()
+                    const corners = (exported.entities ?? []).map(e => {
+                        const [width, height] =
+                            footprints.entities[e.name as keyof typeof footprints.entities]
+                                .gameTiles
+                        const sideways = direction === 4 || direction === 12
+                        return {
+                            x: e.position.x - (sideways ? height : width) / 2,
+                            y: e.position.y - (sideways ? width : height) / 2,
+                        }
+                    })
+                    corners.push(...(exported.tiles ?? []).map(t => t.position))
+                    return {
+                        x: -Math.floor(Math.min(...corners.map(p => p.x))),
+                        y: -Math.floor(Math.min(...corners.map(p => p.y))),
+                    }
+                }
+                expect(blueprint.getGridPositionDisplay()).toEqual(measuredPosition())
+                for (const target of [
+                    { x: 0, y: 0 },
+                    { x: -6, y: 12 },
+                ]) {
+                    const current = blueprint.getGridPositionDisplay()
+                    const offset = blueprint.gridPositionOffset
+                    blueprint.gridPositionOffset = {
+                        x: offset.x + current.x - target.x,
+                        y: offset.y + current.y - target.y,
+                    }
+                    const measured = measuredPosition()
+                    expect(measured.x).toBeCloseTo(target.x)
+                    expect(measured.y).toBeCloseTo(target.y)
+                    expect(blueprint.getGridPositionDisplay()).toEqual(measured)
+                }
+                expect(blueprint.entities.valuesArray().map(e => e.position)).toEqual(livePositions)
+            })
+        }
+    }
+}

--- a/tests/blueprint-grid-position.spec.ts
+++ b/tests/blueprint-grid-position.spec.ts
@@ -92,6 +92,32 @@ const ONE_ASSEMBLER = encode({
 
 const EMPTY_BLUEPRINT = encode({ item: 'blueprint', version: VERSION })
 
+test('rail Grid position exports the measured tile edge at the typed target (#393)', async ({
+    page,
+}) => {
+    await loadBlueprint(
+        page,
+        encode({
+            item: 'blueprint',
+            version: VERSION,
+            entities: [
+                { entity_number: 1, name: 'curved-rail-b', position: { x: 4, y: 4 } },
+                { entity_number: 2, name: 'wooden-chest', position: { x: 10.5, y: 20.5 } },
+            ],
+        })
+    )
+    const align = await openBlueprintInfo(page)
+    await enableSnapToGrid(page, align)
+    await fillGridPositionField(page, align, 'x', '0')
+    await fillGridPositionField(page, align, 'y', '0')
+
+    // The game fixture gives curved-rail-b a 2x2 tile size. Read the floored
+    // tile edge from the export, independently of the editor's display helper.
+    const [rail, chest] = await exportedPositionsOf(page)
+    expect({ x: Math.floor(rail.x - 1), y: Math.floor(rail.y - 1) }).toEqual({ x: 0, y: 0 })
+    expect({ x: chest.x - rail.x, y: chest.y - rail.y }).toEqual({ x: 6.5, y: 16.5 })
+})
+
 /**
  * Types into one of "Grid position"'s two fields and commits on blur (Tab
  * away) - BlueprintAlignment wires those fields to `'blur'` specifically,


### PR DESCRIPTION
Grid position used placement rectangles for nine rail prototypes whose runtime tile sizes differ, causing typed targets to export one or two tiles off the intended grid. Use the measured tile edges for the Grid position reading while preserving existing export centering, placement, and selection geometry. Blueprints exported without a Grid position edit keep their existing coordinates.

Adds fixture-backed coverage for all 155 entity sizes, all nine affected rail prototypes at cardinal rotations, tile-dominated bounds, repeated grid targets, and unchanged default exports. A browser regression types zero into Grid position and checks the exported rail edge independently of the display helper.

Validation: 433 unit tests and 12 focused Playwright tests pass; formatting, lint, and type checks pass for the changed files. The existing oracle fixture needed checkout-only CRLF-to-LF normalization on Windows; no fixture content is changed. Measurements come from the committed Factorio 2.0.77 fixture; the game GUI was not re-run.

Fixes #393.
