### PR TITLE
Use native paste event text for blueprint import

### DIFF
--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -400,7 +400,7 @@ document.addEventListener('paste', (e: ClipboardEvent) => {
     // Fire-and-forget, same as before importReplace reported success/failure
     // to its callers - this one has nothing to do with the resolved value,
     // unlike ImportDialog's Replace button.
-    void importReplace()
+    void importReplace(e.clipboardData?.getData('text/plain') || undefined)
 })
 
 /*

--- a/tests/paste-event-data.spec.ts
+++ b/tests/paste-event-data.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test'
+import { encodeBlueprint, packVersion } from './helpers/encode-blueprint'
+import { waitForEditor } from './helpers/fbe-test-api'
+
+const BLUEPRINT = encodeBlueprint({
+    item: 'blueprint',
+    version: packVersion(2, 0, 55),
+    entities: [{ entity_number: 1, name: 'wooden-chest', position: { x: 0.5, y: 0.5 } }],
+})
+
+test('native Ctrl+V uses event text even when clipboard readText is denied', async ({ page }) => {
+    await waitForEditor(page)
+    // Native copy seeds the clipboard without Chromium-only permission grants.
+    await page.evaluate(text => {
+        const field = document.createElement('textarea')
+        field.id = 'clipboard-seed'
+        field.value = text
+        document.body.append(field)
+        field.focus()
+        field.select()
+    }, BLUEPRINT)
+    await page.keyboard.press('ControlOrMeta+c')
+    await page.locator('#editor').focus()
+    let reads = 0
+    await page.exposeFunction('recordClipboardRead', () => reads++)
+    await page.evaluate(() => {
+        navigator.clipboard.readText = async () => {
+            await (
+                window as unknown as { recordClipboardRead: () => Promise<void> }
+            ).recordClipboardRead()
+            throw new DOMException('Clipboard read denied', 'NotAllowedError')
+        }
+    })
+    await page.keyboard.press('ControlOrMeta+v')
+    await expect.poll(() => page.evaluate(() => window.__fbe_test.entityContainerCount())).toBe(1)
+    expect(reads).toBe(0)
+})
+
+for (const data of ['empty', 'missing'] as const) {
+    test(`paste with ${data} event data falls back to readText`, async ({ page }) => {
+        await waitForEditor(page)
+        await page.locator('#editor').focus()
+        await page.evaluate(
+            ({ text, data }) => {
+                navigator.clipboard.readText = async () => text
+                document.dispatchEvent(
+                    new ClipboardEvent('paste', {
+                        clipboardData: data === 'empty' ? new DataTransfer() : null,
+                        cancelable: true,
+                    })
+                )
+            },
+            { text: BLUEPRINT, data }
+        )
+        await expect
+            .poll(() => page.evaluate(() => window.__fbe_test.entityContainerCount()))
+            .toBe(1)
+    })
+}


### PR DESCRIPTION
Ctrl+V now imports the text already supplied by the native paste event. Empty or missing event text preserves the existing clipboard read fallback. This avoids a second permission-sensitive clipboard read; append and the Import dialog Paste button keep their existing behavior.

Measured before changing the code: Firefox 153.0 on Windows, using native textarea copy then a trusted Ctrl+V on the canvas, successfully imported the blueprint. Its readText call resolved, so the reported Firefox no-op was not reproduced. This is an event-data improvement, not a claim that current Firefox paste was universally broken.

Validation:
- Firefox: 3 new regression cases pass. Native Ctrl+V with a deliberately denied readText failed before the fix; empty and missing event-data controls passed before and after.
- Chromium: all 8 new and existing clipboard shortcut tests pass, including dialog and startup guards.
- Regression file can also run manually with `FBE_BASE_URL=<dev server> playwright test tests/paste-event-data.spec.ts --browser=firefox` after installing Firefox.

Closes #337


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paste handling by using available plain-text paste data directly.
  * Added a fallback to the system clipboard when paste data is unavailable.

* **Tests**
  * Added coverage for native paste events and clipboard fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->