### PR TITLE
Show retry guidance for GitHub gist rate limits

### DIFF
--- a/packages/editor/src/core/bpString.ts
+++ b/packages/editor/src/core/bpString.ts
@@ -83,6 +83,12 @@ class EmptyBlueprintStringError {
     public error = 'There was nothing to import.'
 }
 
+export class GitHubRateLimitError extends Error {
+    constructor() {
+        super('GitHub rate limit reached. Please try importing again later.')
+    }
+}
+
 const keywords: KeywordDefinition[] = [
     {
         keyword: 'entityName',
@@ -310,6 +316,14 @@ function getBlueprintOrBookFromSource(source: string): Promise<Blueprint | Book>
             const fetchData = (url: string): Promise<Response> =>
                 fetch(`/corsproxy?url=${encodeURIComponent(url)}`).then(response => {
                     if (response.ok) return response
+                    if (
+                        new URL(url).hostname === 'api.github.com' &&
+                        (response.status === 429 ||
+                            (response.status === 403 &&
+                                response.headers.get('x-ratelimit-remaining') === '0'))
+                    ) {
+                        throw new GitHubRateLimitError()
+                    }
                     throw new Error('Network response was not ok.')
                 })
 

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -6,6 +6,7 @@ import EDITOR, {
     Blueprint,
     Book,
     CorruptedBlueprintStringError,
+    GitHubRateLimitError,
     BookWithNoBlueprintsError,
     EmptyBlueprintStringError,
     encode,
@@ -1020,6 +1021,11 @@ function createBPImportError(
     */
     if (error instanceof EmptyBlueprintStringError) {
         createToast({ text: error.error, type: 'warning' })
+        return
+    }
+
+    if (error instanceof GitHubRateLimitError) {
+        createToast({ text: error.message, type: 'warning' })
         return
     }
 

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -30,7 +30,7 @@ const CUSTOM_ORIGIN = 'https://fbe.factorygamefan.com'
     `new Headers(resp.headers)` and copied the lot, so a target's Set-Cookie
     landed on our origin and its caching directives spoke for our domain.
 */
-const PASSTHROUGH_RESPONSE_HEADERS = ['content-type']
+const PASSTHROUGH_RESPONSE_HEADERS = ['content-type', 'x-ratelimit-remaining']
 
 /*
     Sent on every outbound fetch, because GitHub's API refuses a request without

--- a/tests/gist-rate-limit.spec.ts
+++ b/tests/gist-rate-limit.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test'
+
+for (const status of [429, 403]) {
+    test(`GitHub ${status} rate limits show retry guidance`, async ({ page }) => {
+        await page.route('**/corsproxy*', route =>
+            route.fulfill({
+                status,
+                headers: status === 403 ? { 'x-ratelimit-remaining': '0' } : {},
+                body: '{"message":"API rate limit exceeded"}',
+            })
+        )
+        await page.goto('/?source=https://gist.github.com/someone/dead1234')
+        await expect(
+            page.getByText('GitHub rate limit reached. Please try importing again later.')
+        ).toBeVisible()
+        await expect(page.getByText('report this bug on github', { exact: false })).toHaveCount(0)
+    })
+}
+
+for (const [source, status, remaining] of [
+    ['https://gist.github.com/someone/dead1234', 403, '1'],
+    ['https://gist.github.com/someone/dead1234', 404, '0'],
+    ['https://pastebin.com/AbCd1234', 429, '0'],
+] as const) {
+    test(`${source} HTTP ${status} without a GitHub rate limit stays a load error`, async ({
+        page,
+    }) => {
+        await page.route('**/corsproxy*', route =>
+            route.fulfill({
+                status,
+                headers: { 'x-ratelimit-remaining': remaining },
+                body: 'request failed',
+            })
+        )
+        await page.goto(`/?source=${encodeURIComponent(source)}`)
+        await expect(
+            page.getByText('Blueprint string could not be loaded.', { exact: false })
+        ).toBeVisible()
+        await expect(page.getByText('GitHub rate limit reached.', { exact: false })).toHaveCount(0)
+    })
+}

--- a/tests/gist-rate-limit.test.ts
+++ b/tests/gist-rate-limit.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, expect, it, vi } from 'vite-plus/test'
+import worker from '../packages/worker/src/index'
+
+afterEach(() => vi.unstubAllGlobals())
+
+it('preserves GitHub rate-limit status and signal without forwarding unsafe headers', async () => {
+    vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+            new Response('rate limited', {
+                status: 403,
+                headers: {
+                    'content-type': 'application/json',
+                    'x-ratelimit-remaining': '0',
+                    'set-cookie': 'session=untrusted',
+                    'cache-control': 'public, max-age=86400',
+                    location: 'https://untrusted.example',
+                },
+            })
+        )
+    )
+    const response = await worker.fetch(
+        new Request(
+            'https://fbe.factorygamefan.com/corsproxy?url=https://api.github.com/gists/dead1234'
+        ),
+        {} as never,
+        {} as never
+    )
+    expect(response.status).toBe(403)
+    expect(response.headers.get('x-ratelimit-remaining')).toBe('0')
+    expect(response.headers.get('set-cookie')).toBeNull()
+    expect(response.headers.get('location')).toBeNull()
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    expect(await response.text()).toBe('rate limited')
+})


### PR DESCRIPTION
GitHub gist imports now show “GitHub rate limit reached. Please try importing again later.” for HTTP 429 and exhausted HTTP 403 responses, instead of asking the user to report an editor bug. The proxy preserves only the additional `x-ratelimit-remaining` signal; cookies, redirects, and upstream caching headers remain stripped.

Verified on the current base in Chromium: the new 429 warning regression failed before the fix and passes afterward. Actual GitHub bucket exhaustion is intermittent, so the regression supplies deterministic upstream error responses without consuming the public quota.

Validation: 21 Playwright source/import tests passed; 28 proxy unit tests passed; focused Vite+ format, lint, and type checks passed. Coverage includes primary 403 limits, headerless 429 limits, unrelated errors, and proxy header safety.

Closes #274


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub imports now clearly indicate when rate limits are reached and provide retry guidance.
  * Rate-limit warnings no longer trigger generic error-reporting prompts.
  * Other GitHub and non-GitHub errors continue to display their existing load-error behavior.

* **Tests**
  * Added coverage for GitHub rate-limit responses and proxy handling, including preservation of rate-limit information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->