### PR TITLE
Prevent duplicate logistic filter selections

### DIFF
--- a/packages/editor/src/UI/editors/components/Filters.ts
+++ b/packages/editor/src/UI/editors/components/Filters.ts
@@ -272,9 +272,16 @@ export class Filters extends Container<Slot<number>> {
         if (e.button === 0) {
             if (!this.m_Amount || this.m_Filters[index].name === undefined) {
                 this.emit('selection-started')
+                const usedNames = new Set(
+                    this.m_Filters
+                        .filter(filter => filter.index !== index + 1)
+                        .map(filter => filter.name)
+                )
                 const inv = G.UI.createInventory(
                     'Select Filter',
-                    this.m_Entity.acceptedFilters,
+                    this.m_Entity.acceptedFilters.filter(
+                        name => this.m_Entity.type !== 'logistic-container' || !usedNames.has(name)
+                    ),
                     name => {
                         this.m_Filters[index].name = name
                         if (this.m_Amount) {

--- a/tests/chest-editor.spec.ts
+++ b/tests/chest-editor.spec.ts
@@ -306,6 +306,32 @@ test('picking an item in a filter slot sets the filter on the chest', async ({ p
     expect(errors, `page errors: ${errors.join(' | ')}`).toEqual([])
 })
 
+test('logistic filter pickers exclude used items and offer them again after clearing', async ({
+    page,
+}) => {
+    const errors = await loadChests(page)
+    await openEditorOn(page, 3)
+
+    for (const index of [0, 1]) {
+        const slot = await filterSlotAt(page, index)
+        await page.mouse.click(slot.x, slot.y)
+        const item = await firstInventoryItem(page)
+        await page.mouse.click(item.x, item.y)
+    }
+    const filters = (await filtersOf(page, 3)) as { index: number; name: string }[]
+    expect(errors).toEqual([])
+    expect(filters).toHaveLength(2)
+    expect(filters[1].name).not.toBe(filters[0].name)
+
+    const firstSlot = await filterSlotAt(page, 0)
+    await page.mouse.click(firstSlot.x, firstSlot.y, { button: 'right' })
+    await page.mouse.click(firstSlot.x, firstSlot.y)
+    const item = await firstInventoryItem(page)
+    await page.mouse.click(item.x, item.y)
+    expect(await filtersOf(page, 3)).toEqual(filters)
+    expect(errors).toEqual([])
+})
+
 test('right clicking a filled slot clears the filter', async ({ page }) => {
     /*
         The other half of `Filters.onSlotPointerDown`, and the cheaper one to


### PR DESCRIPTION
Logistic chest filter pickers currently offer items already requested in another slot of the same section; selecting one creates duplicates that Factorio silently collapses. Exclude those names from the picker, while keeping the current slot selectable and other entity filter pickers unchanged. Clearing a slot makes its item available again.

Verified the bug on current main in the built-in browser: a buffer chest accepted wooden-chest in two slots. After the fix, its picker omits wooden-chest. The new Playwright regression failed before the change and passes afterward.

Validation: 25 chest editor/filter browser tests pass; targeted `vp check` passes (format, lint, types).

Closes #338


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Logistic container filter pickers now hide items already assigned to other slots while keeping the current slot’s selection available.
  - Cleared items can be selected again, and different slots can continue using distinct items.

- **Tests**
  - Added end-to-end coverage for logistic container filter selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->