### PR TITLE
Default settings pane to closed and persist toggles

### DIFF
--- a/packages/website/src/settingsPane.ts
+++ b/packages/website/src/settingsPane.ts
@@ -34,11 +34,22 @@ export function initSettingsPane(
     window.addEventListener('visibilitychange', () =>
         localStorage.setItem('dat.gui.closed', String(gui.closed))
     )
-    gui.domElement
-        .querySelector('.close-button')
-        ?.addEventListener('click', () =>
+    const toggle = gui.domElement.querySelector<HTMLElement>('.close-button')
+    if (toggle) {
+        toggle.tabIndex = 0
+        toggle.setAttribute('role', 'button')
+        toggle.setAttribute('aria-expanded', String(!gui.closed))
+        toggle.addEventListener('keydown', event => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                toggle.click()
+            }
+        })
+        toggle.addEventListener('click', () => {
             localStorage.setItem('dat.gui.closed', String(gui.closed))
-        )
+            toggle.setAttribute('aria-expanded', String(!gui.closed))
+        })
+    }
 
     document.body.appendChild(gui.domElement)
 

--- a/packages/website/src/settingsPane.ts
+++ b/packages/website/src/settingsPane.ts
@@ -19,9 +19,10 @@ export function initSettingsPane(
         autoPlace: false,
         hideable: false,
         closeOnTop: true,
-        closed: localStorage.getItem('dat.gui.closed') === 'true',
         width: 320,
     })
+    // Apply after construction: dat.gui creates its title after setting `closed`.
+    gui.closed = localStorage.getItem('dat.gui.closed') !== 'false'
 
     gui.domElement.style.overflowX = 'hidden'
     gui.domElement.style.overflowY = 'auto'
@@ -33,6 +34,11 @@ export function initSettingsPane(
     window.addEventListener('visibilitychange', () =>
         localStorage.setItem('dat.gui.closed', String(gui.closed))
     )
+    gui.domElement
+        .querySelector('.close-button')
+        ?.addEventListener('click', () =>
+            localStorage.setItem('dat.gui.closed', String(gui.closed))
+        )
 
     document.body.appendChild(gui.domElement)
 

--- a/tests/settings-pane-book-index.spec.ts
+++ b/tests/settings-pane-book-index.spec.ts
@@ -113,6 +113,7 @@ const waitForEntry = (page: Page, index: number): Promise<unknown> =>
 
 test.beforeEach(async ({ page }) => {
     await waitForEditor(page)
+    await page.getByText('Open Settings', { exact: true }).click()
 })
 
 test('Grid position survives repeated book switches without changing exports or other entries', async ({

--- a/tests/settings-pane-click-interception.spec.ts
+++ b/tests/settings-pane-click-interception.spec.ts
@@ -7,9 +7,8 @@ import { suppressOverlays } from './helpers/overlays'
 
     `packages/website/src/settingsPane.ts` builds a dat.gui panel and appends it
     to `document.body`; `packages/website/src/index.css` pins it with
-    `.dg.main { position: fixed; bottom: 0; left: 0; z-index: 5 }`. It is open by
-    default - `closed` reads `localStorage['dat.gui.closed']`, which a fresh
-    profile does not have - so it sits on top of the editor from the first frame.
+    `.dg.main { position: fixed; bottom: 0; left: 0; z-index: 5 }`. #159 defaults
+    it to closed; the interception controls explicitly restore the open state.
 
     Measured at the 1280x720 the config runs: the pane is 320x236 at (0, 484),
     the canvas is the full 1280x720, and `document.elementFromPoint` at the
@@ -103,6 +102,7 @@ const elementAt = (page: Page, at: { x: number; y: number }): Promise<string> =>
     test fails, which is what says it is doing work.
 */
 test('the settings pane takes a press that was meant for the canvas', async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('dat.gui.closed', 'false'))
     await open(page)
 
     const at = await panePressPoint(page)
@@ -124,6 +124,7 @@ test('the settings pane takes a press that was meant for the canvas', async ({ p
 })
 
 test('with the pane suppressed the same press reaches the canvas instead', async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('dat.gui.closed', 'false'))
     await suppressOverlays(page)
     await open(page)
 
@@ -144,4 +145,27 @@ test('with the pane suppressed the same press reaches the canvas instead', async
 
     await page.mouse.up()
     await page.keyboard.up('Control')
+})
+
+test('fresh settings collapse to a title bar and toggles persist immediately', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 })
+    await open(page)
+    const pane = page.locator('.dg.main')
+    const toggle = pane.locator('.close-button')
+    await expect(toggle).toHaveText('Open Settings')
+    await expect.poll(async () => (await pane.boundingBox())?.height).toBe(20)
+    expect(await elementAt(page, { x: 160, y: 602 })).toContain('CANVAS#editor')
+
+    await toggle.click()
+    await expect(toggle).toHaveText('Close Settings')
+    expect(await page.evaluate(() => localStorage.getItem('dat.gui.closed'))).toBe('false')
+    await page.reload()
+    await expect(toggle).toHaveText('Close Settings')
+    await expect.poll(async () => (await pane.boundingBox())?.height).toBeGreaterThan(200)
+
+    await toggle.click()
+    expect(await page.evaluate(() => localStorage.getItem('dat.gui.closed'))).toBe('true')
+    await page.reload()
+    await expect(toggle).toHaveText('Open Settings')
+    await expect.poll(async () => (await pane.boundingBox())?.height).toBe(20)
 })

--- a/tests/settings-pane-click-interception.spec.ts
+++ b/tests/settings-pane-click-interception.spec.ts
@@ -169,3 +169,20 @@ test('fresh settings collapse to a title bar and toggles persist immediately', a
     await expect(toggle).toHaveText('Open Settings')
     await expect.poll(async () => (await pane.boundingBox())?.height).toBe(20)
 })
+
+test('the collapsed settings control opens and closes from the keyboard', async ({ page }) => {
+    await open(page)
+    const toggle = page.getByRole('button', { name: 'Open Settings', exact: true })
+    for (let step = 0; step < 5; step++) {
+        await page.keyboard.press('Tab')
+        if (await toggle.evaluate(el => el === document.activeElement)) break
+    }
+    await expect(toggle).toBeFocused()
+    await page.keyboard.press('Enter')
+    const close = page.getByRole('button', { name: 'Close Settings', exact: true })
+    await expect(close).toHaveAttribute('aria-expanded', 'true')
+    expect(await page.evaluate(() => localStorage.getItem('dat.gui.closed'))).toBe('false')
+    await page.keyboard.press('Space')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(await page.evaluate(() => localStorage.getItem('dat.gui.closed'))).toBe('true')
+})


### PR DESCRIPTION
Fresh profiles now start with a labelled, collapsed settings pane, and opening or closing it saves the choice immediately. Explicit stored open/closed preferences are preserved. Apply the initial state after dat.gui construction so its title correctly says Open Settings. The toggle is keyboard accessible with Tab, Enter and Space, with button semantics and expanded-state feedback.

Verified on the live site at 1280x720: the original pane intercepts canvas clicks across a 320x236 rectangle. The collapsed pane measures 320x20, and the former centre now hits CANVAS#editor. No dependency migration is needed.

Validation: full vp check and all 436 unit tests passed on the initial change; focused format/lint/type checks and all 7 settings browser tests pass after the accessibility review fix. Browser tests cover immediate persistence, reloads, keyboard operation, canvas hit testing, book switching and open-pane interception controls. Full browser coverage also runs in CI.

Closes #159.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Settings panes now open in a collapsed state by default.
  - The pane’s expanded or collapsed state is preserved when reopening or reloading the page.
  - The close control now supports keyboard activation and accurately communicates its state to assistive technologies.
  - Settings pane labels and dimensions remain consistent with the saved state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->