### PR TITLE
Make root package.json the only place the vite-plus version is written

### DIFF
--- a/.github/actions/setup-vp/action.yml
+++ b/.github/actions/setup-vp/action.yml
@@ -2,16 +2,34 @@ name: Setup Vite+
 description: >-
   Install the pinned, checksum-verified Vite+ toolchain (vp) and prime the npm
   download cache. After this runs, vp is on PATH; the caller runs its own
-  vp install. Single source of truth for the vp version + installer checksum.
+  vp install. The version comes from devDependencies.vite-plus in the root
+  package.json; this file is the single source of truth for the installer
+  checksum only.
 
 runs:
   using: composite
   steps:
+    - name: Read the vite-plus pin
+      id: pin
+      shell: bash
+      run: |
+        # The one place the version is written is the root package.json. It is
+        # an exact version there, not a range, and the check below keeps it
+        # that way: a caret would install "whatever is newest" here while the
+        # lockfile pins something older, which is the drift this step exists
+        # to rule out.
+        version="$(jq -r '.devDependencies["vite-plus"]' package.json)"
+        if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "devDependencies.vite-plus in package.json must be an exact version, got '$version'" >&2
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
     - name: Cache Vite+ toolchain
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ~/.vite-plus
-        key: vite-plus-${{ runner.os }}-0.3.0
+        key: vite-plus-${{ runner.os }}-${{ steps.pin.outputs.version }}
 
     - name: Cache npm downloads
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -23,44 +41,48 @@ runs:
 
     - name: Install vp
       shell: bash
+      env:
+        VP_VERSION: ${{ steps.pin.outputs.version }}
       run: |
         # Pin + verify the installer instead of curl | bash. The vp binary and
-        # vite-plus package are already version-pinned (VP_VERSION) and immutable
-        # via the npm registry; this also pins the mutable bootstrap script.
+        # vite-plus package are already version-pinned (VP_VERSION, read from
+        # package.json above) and immutable via the npm registry; this also
+        # pins the mutable bootstrap script.
         #
-        # The two move independently, and this hash has now been bumped for each
-        # reason in turn. A toolchain upgrade bumps VP_VERSION (here + the cache
-        # key above) and usually leaves the hash alone - measured across
-        # 0.2.6 -> 0.2.8, where the script did not change at all. The other
-        # direction is what happened on 2026-08-25: the script rotated on its own
-        # with VP_VERSION untouched, so every job on every branch failed at this
-        # step until the hash was re-taken. That is the pin working, not breaking
-        # - a mismatch fails the step rather than running a script nobody read -
-        # but it does mean a red `Set up Vite+` is not necessarily the fault of
-        # the branch it appears on. Re-fetch, read the diff, then re-hash.
+        # The two move independently. A toolchain upgrade is a package.json
+        # bump and touches nothing in this file - measured across
+        # 0.2.6 -> 0.2.8, the script did not change at all. The other direction
+        # is what happened on 2026-08-25: the script rotated on its own with
+        # the version untouched, so every job on every branch failed at this
+        # step until the hash was re-taken. That is the pin working, not
+        # breaking - a mismatch fails the step rather than running a script
+        # nobody read - but it does mean a red `Set up Vite+` is not
+        # necessarily the fault of the branch it appears on. Re-fetch, read the
+        # diff, then re-hash.
+        #
+        # The global vp installed here defers to the project's local vite-plus
+        # for every tool. Measured 2026-09-07: a global vp 0.2.9 run inside
+        # this repo reports and drives the local 0.3.0 vite, vitest and oxlint,
+        # and `vp check` passes identically. So the version here decides the
+        # shim and the managed Node, and matching it to package.json is about
+        # reproducibility rather than correctness.
         #
         # VP_HOME pins the monolithic ~/.vite-plus layout, which the two lines
-        # below hardcode (the PATH entry, and the cache `path:` above). It is a
-        # no-op at 0.2.9 - that is already where the installer puts things - and
-        # it is here for 0.3.0, which moves a default install to XDG paths
-        # (~/.local/share/vite-plus/bin). Measured: with VP_VERSION=0.3.0 and no
-        # VP_HOME, a sandboxed-HOME install lands in XDG and both lines below are
-        # wrong, so every job fails with `vp: command not found` - which reads as
-        # a broken toolchain rather than a wrong path.
+        # below hardcode (the PATH entry, and the cache `path:` above). From
+        # 0.3.0 a default install follows XDG paths (~/.local/share/vite-plus/bin).
+        # Measured: without VP_HOME, a sandboxed-HOME install lands in XDG and
+        # both lines below are wrong, so every job fails with
+        # `vp: command not found` - which reads as a broken toolchain rather
+        # than a wrong path.
         #
         # The installer does have a compatibility shim for this, and it does not
         # cover us: it only fires when GITHUB_ACTION_REPOSITORY is
-        # voidzero-dev/setup-vp, and this is a hand-rolled composite action. What
-        # protects us today is only that a 0.2.9 payload cannot answer
-        # VP_DUMP_DIRS, so the installer falls back to the legacy layout. A 0.3.0
-        # payload can answer, so it will not fall back. And the vite-plus cache
-        # key carries the version with no restore-keys, so a bump is a guaranteed
-        # cache miss with no existing install to reuse - the break would be
-        # certain, not intermittent.
-        #
-        # So this line has to be here BEFORE VP_VERSION moves, not with it.
+        # voidzero-dev/setup-vp, and this is a hand-rolled composite action. And
+        # the vite-plus cache key carries the version with no restore-keys, so
+        # a bump is a guaranteed cache miss with no existing install to reuse -
+        # a layout break would be certain, not intermittent.
         curl -fsSL https://vite.plus -o vp-install.sh
         echo "3dd88cedb6d9b2665c305eda5413971417c8f183a819386148131b66a2cc6b2e  vp-install.sh" | sha256sum -c -
-        VP_HOME="$HOME/.vite-plus" VP_VERSION=0.3.0 VP_NODE_MANAGER=yes bash vp-install.sh
+        VP_HOME="$HOME/.vite-plus" VP_NODE_MANAGER=yes bash vp-install.sh
         echo "$HOME/.vite-plus/bin" >> "$GITHUB_PATH"
         rm -f vp-install.sh

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -246,9 +246,18 @@
             //
             // The old reason for disabling was that a PR touching only the manifests
             // would leave .github/actions/setup-vp/action.yml behind, so CI would
-            // install a different vp than the lockfile pins - "green, and wrong". That
-            // failure is real, and the customManager at the bottom of this file closes
-            // it: VP_VERSION and the cache key now move in the same PR.
+            // install a different vp than the lockfile pins. That copy no longer
+            // exists: since 2026-09-07 the action reads the version out of the root
+            // package.json with jq, for both VP_VERSION and its cache key, so a
+            // manifest bump is the whole bump. Two regex customManagers used to chase
+            // the action's copies and were deleted with them.
+            //
+            // The mismatch was also less than it was described as. Measured
+            // 2026-09-07: a global vp 0.2.9 run inside this repo reports and drives the
+            // LOCAL 0.3.0 vite, vitest and oxlint, and `vp check` passes identically;
+            // outside a repo the same binary reports every tool as "Not found". The
+            // global CLI defers to the local package, so the action's version decides
+            // the shim and the managed Node, not what lints or tests.
             //
             // The old reason ALSO said Renovate cannot compute the installer sha256, so
             // the checksum would go stale. Two corrections, both measured on
@@ -258,8 +267,7 @@
             // all. Second, and this is the part that was backwards: a stale checksum
             // cannot be "green and wrong", because the action VERIFIES it
             // (`sha256sum -c -`) and a mismatch FAILS THE STEP. It is the one part of
-            // this that is self-guarding. The unguarded part was VP_VERSION, which is
-            // what the customManager now covers.
+            // this that is self-guarding.
             //
             // 24 hours rather than the 3-day default, by explicit decision: this is
             // developer tooling that never ships to users, the whole gate
@@ -270,10 +278,13 @@
             // The `@voidzero-dev/vite-plus-core` name is here because that is what
             // Renovate sees behind the `overrides` alias, not a second dependency.
             //
-            // STILL TRUE AND STILL THE REVIEWER'S JOB: all five sites must move as one,
-            // and CI cannot see a mismatch between the vp CLI and the local vite-plus.
-            // Read the diff before merging, and if the installer script itself changed,
-            // re-fetch and re-hash by hand.
+            // STILL THE REVIEWER'S JOB: the pin is written in two places, both in the
+            // root package.json - the devDependency and the `overrides` alias - and
+            // both must move. They cannot be one: npm rejects a `$vite-plus` reference
+            // inside an alias override with EINVALIDTAGNAME (measured 2026-09-07). The
+            // workspace packages carry no pin of their own; they resolve the hoisted
+            // root copy. Read the diff before merging, and if the installer script
+            // itself changed, re-fetch and re-hash by hand.
             matchPackageNames: ['vite-plus', '@voidzero-dev/vite-plus-core'],
             enabled: true,
             minimumReleaseAge: '24 hours',
@@ -281,8 +292,8 @@
             addLabels: ['toolchain'],
             prBodyNotes: [
                 'This is the ENTIRE toolchain (Vite, Rolldown, oxlint, oxfmt, Vitest). Nothing under it is independently upgradable.',
-                'Check `.github/actions/setup-vp/action.yml` moved too - `VP_VERSION` and the cache key are updated by a customManager, but **the installer sha256 is not**. Re-fetch https://vite.plus and re-hash if that script changed; a mismatch fails CI rather than passing silently.',
-                'CI runs the Playwright suite in the `e2e` job, so this bump is gated on it - this note said the opposite until 2026-09-01 and was wrong. What CI still cannot see is a mismatch between the `vp` CLI and the local vite-plus, so read the diff and confirm every pin site moved together.',
+                '`.github/actions/setup-vp/action.yml` reads the version from the root package.json, so nothing there needs to move. **The installer sha256 is not automated.** Re-fetch https://vite.plus and re-hash if that script changed; a mismatch fails CI rather than passing silently.',
+                'CI runs the Playwright suite in the `e2e` job, so this bump is gated on it - this note said the opposite until 2026-09-01 and was wrong. Confirm both sites in the root package.json moved: the `vite-plus` devDependency and the `overrides.vite` alias.',
             ],
         },
         {
@@ -376,45 +387,14 @@
         },
     ],
 
-    // The vite-plus pin does not live only in package.json. Two of its six
-    // occurrences are inside a composite action - a `VP_VERSION=` assignment in a
-    // shell `run:` block and an actions/cache key - and no built-in manager reads
-    // either. That is the specific hole that made this dependency worth disabling
-    // before: Renovate would bump the three manifests and the `overrides` alias,
-    // CI would still install the OLD vp, and the check would pass, because `vp
-    // install` reads the lockfile while the vp CLI itself comes from VP_VERSION.
-    // A CLI and a toolchain one release apart is exactly the kind of mismatch a
-    // green run does not surface.
-    //
-    // These two entries close it, so all six occurrences move in one PR. The
-    // `datasourceTemplate` is npm and the `depNameTemplate` is vite-plus, so
-    // Renovate treats them as the same dependency as the manifests and the
-    // packageRule above (cooldown, grouping, labels, prBodyNotes) applies to them
-    // too - that grouping is the point, not a nicety. Without it they would arrive
-    // as a separate PR and could merge apart from the manifests.
-    //
-    // NOT covered, deliberately: the installer sha256 on the line below
-    // VP_VERSION. It pins the bootstrap script at https://vite.plus, which is
-    // versioned separately from the toolchain and did not move across
-    // 0.2.6 -> 0.2.8. Renovate has no way to compute it, and it does not need one:
-    // the action runs `sha256sum -c -`, so a genuinely changed script fails the
-    // step loudly. Left to the human, and said so in prBodyNotes.
-    customManagers: [
-        {
-            customType: 'regex',
-            managerFilePatterns: ['/^\\.github/actions/setup-vp/action\\.yml$/'],
-            matchStrings: ['VP_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)'],
-            depNameTemplate: 'vite-plus',
-            datasourceTemplate: 'npm',
-        },
-        {
-            customType: 'regex',
-            managerFilePatterns: ['/^\\.github/actions/setup-vp/action\\.yml$/'],
-            matchStrings: [
-                'key: vite-plus-\\$\\{\\{ runner\\.os \\}\\}-(?<currentValue>\\d+\\.\\d+\\.\\d+)',
-            ],
-            depNameTemplate: 'vite-plus',
-            datasourceTemplate: 'npm',
-        },
-    ],
+    // No customManagers. Two regex managers lived here from 2026-08-11 to
+    // 2026-09-07, chasing the two copies of the vite-plus version inside
+    // .github/actions/setup-vp/action.yml (a `VP_VERSION=` assignment and an
+    // actions/cache key). The action now reads the version from the root
+    // package.json with jq, so those copies are gone and the built-in npm manager
+    // covers every remaining site. The installer sha256 in that action is still
+    // deliberately not automated: it pins the bootstrap script at
+    // https://vite.plus, which is versioned separately from the toolchain, and the
+    // action verifies it with `sha256sum -c -`, so a changed script fails the step
+    // loudly. Left to the human, and said so in prBodyNotes.
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,21 +30,26 @@ exactly one place, `devDependencies.vite-plus` in the root `package.json` (the
 cannot express one as a reference to the other). The workspace packages carry
 no pin of their own, and `.github/actions/setup-vp/action.yml` reads that
 field with `jq` for both the version it installs and its cache key. Install the
-`vp` CLI, then let `vp install` fetch the pinned toolchain:
+`vp` CLI once:
 
 ```sh
 curl -fsSL https://vite.plus -o vp-install.sh
 VP_HOME="$HOME/.vite-plus" VP_NODE_MANAGER=yes bash vp-install.sh
 rm vp-install.sh
-vp install
 ```
+
+The installer writes `~/.vite-plus/bin` into your shell's startup files for
+new shells; for the current one, prepend it to `PATH` yourself. Then
+`vp install` fetches the pinned toolchain. The action verifies the installer
+script against a sha256 before running it; to get the same guarantee, take the
+`sha256sum -c` line from the action rather than from a doc, because that digest
+rotates on its own and a copy here would go stale.
 
 The global `vp` does not need to match the pin. It defers to the project's
 local `vite-plus` for every tool - measured, a global `vp` one release behind
 runs the local vite, vitest and oxlint and `vp check` passes identically, and
 outside a repo the same binary reports every tool as "Not found". CI pins it
-anyway, for reproducibility. Prepend `~/.vite-plus/bin` to `PATH`; the root
-package requires npm 12.
+anyway, for reproducibility. The root package requires npm 12.
 
 `VP_HOME` is load-bearing from 0.3.0 on. A default install now follows the XDG
 layout and puts the binaries in `~/.local/share/vite-plus/bin`, so dropping it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,11 +24,27 @@ closing references such as `Closes #123` in the pull request body.
 
 ## Setup and commands
 
-The pinned toolchain is Vite+ with its managed Node/npm. The pin lives in one
-place, the `Install vp` step of `.github/actions/setup-vp/action.yml`; copy
-the three install lines from there rather than from a doc, then run
-`vp install`. Prepend `~/.vite-plus/bin` to `PATH`; the root package requires
-npm 12.
+The toolchain is Vite+ with its managed Node/npm. Its version is written in
+exactly one place, `devDependencies.vite-plus` in the root `package.json` (the
+`overrides.vite` alias beside it must carry the same number, because npm
+cannot express one as a reference to the other). The workspace packages carry
+no pin of their own, and `.github/actions/setup-vp/action.yml` reads that
+field with `jq` for both the version it installs and its cache key. Install the
+`vp` CLI, then let `vp install` fetch the pinned toolchain:
+
+```sh
+curl -fsSL https://vite.plus -o vp-install.sh
+VP_HOME="$HOME/.vite-plus" VP_NODE_MANAGER=yes bash vp-install.sh
+rm vp-install.sh
+vp install
+```
+
+The global `vp` does not need to match the pin. It defers to the project's
+local `vite-plus` for every tool - measured, a global `vp` one release behind
+runs the local vite, vitest and oxlint and `vp check` passes identically, and
+outside a repo the same binary reports every tool as "Not found". CI pins it
+anyway, for reproducibility. Prepend `~/.vite-plus/bin` to `PATH`; the root
+package requires npm 12.
 
 `VP_HOME` is load-bearing from 0.3.0 on. A default install now follows the XDG
 layout and puts the binaries in `~/.local/share/vite-plus/bin`, so dropping it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,14 +39,21 @@ and filling out the issue template.
   enough to read that field will fetch a matching one; an older npm ignores it
   and runs anyway, which is the version to watch out for.
 - [Vite+](https://vite.plus) - the `vp` CLI this repo builds, lints, formats and
-  tests with. The version is pinned, and the install command lives in one
-  place: the `Install vp` step of
-  [`.github/actions/setup-vp/action.yml`](.github/actions/setup-vp/action.yml).
-  Copy the three lines from there rather than from a doc, so the version you
-  get is the one CI runs. Keep the `VP_HOME=…` part: it puts the toolchain in
-  `~/.vite-plus`, and without it the binaries land somewhere else and `vp`
-  looks missing. The variable assignments go on the `bash` line, not the
-  `curl` line - an assignment ahead of a command applies to that command alone.
+  tests with. Install the CLI once:
+
+    ```shell
+    curl -fsSL https://vite.plus -o vp-install.sh
+    VP_HOME="$HOME/.vite-plus" VP_NODE_MANAGER=yes bash vp-install.sh
+    rm vp-install.sh
+    ```
+
+    You do not need a particular version of it. The project pins its own
+    `vite-plus` in the root `package.json`, `vp install` fetches that, and the
+    global `vp` defers to it for every tool. Keep the `VP_HOME=…` part: it puts
+    the toolchain in `~/.vite-plus`, and without it the binaries land somewhere
+    else and `vp` looks missing. The variable assignments go on the `bash`
+    line, not the `curl` line - an assignment ahead of a command applies to
+    that command alone.
 
     Then put `~/.vite-plus/bin` on your PATH, ahead of any system npm. Two
     things need it there: `npm run localpreview` spawns `vp` directly, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,11 @@ and filling out the issue template.
     the toolchain in `~/.vite-plus`, and without it the binaries land somewhere
     else and `vp` looks missing. The variable assignments go on the `bash`
     line, not the `curl` line - an assignment ahead of a command applies to
-    that command alone.
+    that command alone. If you want to check the installer script before
+    running it, CI does: the `Install vp` step of
+    [`.github/actions/setup-vp/action.yml`](.github/actions/setup-vp/action.yml)
+    verifies it with `sha256sum -c` against a digest kept current there. Take
+    that line from the action, not from a doc - the digest changes on its own.
 
     Then put `~/.vite-plus/bin` on your PATH, ahead of any system npm. Two
     things need it there: `npm run localpreview` spawns `vp` directly, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -6760,8 +6760,7 @@
             },
             "devDependencies": {
                 "@types/pathfinding": "0.1.0",
-                "typed-factorio": "^3.36.0",
-                "vite-plus": "0.3.0"
+                "typed-factorio": "^3.36.0"
             }
         },
         "packages/website": {
@@ -6775,8 +6774,7 @@
             "devDependencies": {
                 "@types/dat.gui": "0.7.13",
                 "rollup-plugin-visualizer": "^7.0.1",
-                "vite-plugin-static-copy": "^4.1.1",
-                "vite-plus": "0.3.0"
+                "vite-plugin-static-copy": "^4.1.1"
             }
         },
         "packages/worker": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -28,7 +28,6 @@
     },
     "devDependencies": {
         "@types/pathfinding": "0.1.0",
-        "typed-factorio": "^3.36.0",
-        "vite-plus": "0.3.0"
+        "typed-factorio": "^3.36.0"
     }
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -16,7 +16,6 @@
     "devDependencies": {
         "@types/dat.gui": "0.7.13",
         "rollup-plugin-visualizer": "^7.0.1",
-        "vite-plugin-static-copy": "^4.1.1",
-        "vite-plus": "0.3.0"
+        "vite-plugin-static-copy": "^4.1.1"
     }
 }


### PR DESCRIPTION
Stacked on #410. Answers the review comment there: "the pin lives in one place" was not true, so this makes it true.

## What changed

The vite-plus version was written in six places. Now it is written in one, `devDependencies.vite-plus` in the root `package.json`, with the `overrides.vite` alias beside it carrying the same number because npm cannot express one as a reference to the other.

| Site | Before | After |
|---|---|---|
| root `package.json` devDependencies | `0.3.0` | the pin |
| root `package.json` overrides alias | `0.3.0` | stays literal (see below) |
| `packages/editor/package.json` | `0.3.0` | deleted |
| `packages/website/package.json` | `0.3.0` | deleted |
| `setup-vp/action.yml` `VP_VERSION` | `0.3.0` | read from root `package.json` with `jq` |
| `setup-vp/action.yml` cache key | `0.3.0` | same step's output |

The two regex custom managers in `renovate.json5` that chased the action's copies are deleted, with their comments rewritten to say why. The built-in npm manager covers both remaining sites. The installer sha256 stays hand-pinned and verified, as before.

The new action step rejects anything that is not an exact version, so a caret sneaking into the pin fails the job instead of installing "newest".

`CLAUDE.md` and `CONTRIBUTING.md` no longer ask contributors to install a matching `vp` version at all, for the reason below.

## Measured

- **The global `vp` defers to the local `vite-plus`.** A global `vp` 0.2.9 installed into a scratch home and run inside this repo reports and drives the local 0.3.0 vite, vitest and oxlint, and `vp check` passes with identical output. Outside a repo the same binary reports every tool as "Not found". So the action's version decides the shim and the managed Node, not what lints or tests. The "green and wrong" mismatch `renovate.json5` described at length cannot happen the way it said.
- `$vite-plus` inside the alias override: npm rejects it with `EINVALIDTAGNAME`. That is why two sites remain rather than one.
- No per-package copy of `vite-plus` exists in `node_modules`; both `vitest.config.ts` and `vite.config.js` resolve the hoisted root copy. Lockfile diff is exactly the two removed lines.
- `npm ci --ignore-scripts` in a scratch copy of the manifests and lockfile installs cleanly with `node_modules/vite` (the alias) and `node_modules/vite-plus` present and no per-package copy.
- The pin step, run locally: accepts `0.3.0`, rejects `^0.3.0`.
- `vp check` passes. `vp test run` from the root: 30 files, 344 tests. From `packages/editor`: 19 files. `npm run build:website` builds.
- Flesch-Kincaid grade of the changed prose: 6.9 and 8.6.

## Not covered

- `actionlint` is not installed here, so the action's first real run is this PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnEgNixBETdXnBy32t8px7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - CI now automatically reads and validates the project’s pinned Vite+ version, keeping caching and installation aligned.
  - Installer integrity is verified using a documented checksum.

- **Documentation**
  - Updated setup and contribution guidance for Vite+ installation, PATH configuration, version management, and checksum verification.
  - Refined dependency update documentation to reflect the streamlined version-management process.

- **Maintenance**
  - Removed redundant package-level Vite+ development dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->