### PR TITLE
Match the worker's wrangler range to the lockfile so vp install stops dirtying it

### DIFF
--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -10,6 +10,6 @@
     },
     "devDependencies": {
         "typescript": "^7.0.2",
-        "wrangler": "^4.126.0"
+        "wrangler": "^4.129.0"
     }
 }


### PR DESCRIPTION
One line. `packages/worker/package.json` said `wrangler: ^4.126.0` while the lockfile's entry for that workspace said `^4.129.0`, left that way by Renovate #397, which changed only the lockfile. Every local `vp install` rewrote the lockfile line back to the manifest's range, so a clean checkout went dirty on the first install.

Measured: after the bump, `npm install --package-lock-only` changes nothing in the lockfile, and `vp install` leaves `git status` clean apart from the manifest itself. CI's `--frozen-lockfile` accepted both states, which is why this never showed as red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnEgNixBETdXnBy32t8px7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the worker development tooling to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->