### PR TITLE
Exclude packages/worker from the root tsconfig so a local wrangler types run cannot redden vp check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,12 @@ specs - so a bare `tsc` against it compiles the whole tree under settings no
 package builds with. Measured, that reports 5 errors that neither a build nor
 `vp check` sees: four in editor code checked against node's fetch types
 (`r.json()` gives `unknown`), one in website code checked against node
-globals. Every package is at 0 under its own project. To check one, name it,
-for example:
+globals. Every package is at 0 under its own project. The root tsconfig does
+carry one `exclude`, `packages/worker`: its gitignored `worker-configuration.d.ts`
+merges Cloudflare's HTMLRewriter `Element` into the DOM's, which made
+`vp check` red on `document.body.append` in a Playwright spec on any machine
+that had run `wrangler types` while CI, which never has the file, stayed green.
+To check one package, name it, for example:
 
 ```sh
 npx tsc --noEmit -p packages/editor/tsconfig.json

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,16 @@
         // narrows this list back to typed-factorio only, so browser code cannot
         // reach node globals - see packages/editor/tsconfig.json.
         "types": ["vite-plus/client", "typed-factorio/prototype", "node"]
-    }
+    },
+
+    // This file has no `include`, so as the nearest tsconfig for tests/, scripts/
+    // and tools/ its program sweeps the whole tree. That sweep used to pick up
+    // packages/worker, whose gitignored, wrangler-generated
+    // worker-configuration.d.ts declares Cloudflare's HTMLRewriter `Element` -
+    // and TypeScript merges that into the DOM's `Element`, so
+    // `document.body.append(node)` in a Playwright spec fails to type (TS2345)
+    // on any machine that has run `wrangler types`. CI never has the file, so it
+    // stayed green while local `vp check` went red. The worker has its own
+    // tsconfig and is already outside the lint pass (vite.config.ts).
+    "exclude": ["node_modules", "packages/worker"]
 }


### PR DESCRIPTION
## The defect

`vp check` was red locally on `tests/paste-event-data.spec.ts` (`document.body.append(field)`, TS2345) while CI was green on the same commit. The cause is the gitignored, wrangler-generated `packages/worker/worker-configuration.d.ts`. It declares Cloudflare's HTMLRewriter `Element`, TypeScript merges that into the DOM's `Element`, and `append` then wants `string | ReadableStream | Response`. CI never has the file. Any machine that has run `wrangler types` does, and that reads as a broken branch.

The root tsconfig has no `include`, so as the nearest tsconfig for `tests/`, `scripts/` and `tools/` its program sweeps the whole tree and picked the d.ts up.

## The fix

One `exclude` on the root tsconfig for `packages/worker`, with the mechanism written above it. The worker has its own tsconfig and was already outside the lint pass.

## Measured

- Root program before: 211 files, including `packages/worker/worker-configuration.d.ts`. After: 210, the d.ts gone.
- `vp check` with the d.ts present: pass, 234 files, 0 errors. Before the change, same tree: 1 error. Moving the d.ts aside without this change also gave 0, which is what pinned the cause.
- `npx tsc --noEmit -p packages/editor/tsconfig.json` and the website equivalent: 0 errors each, and the editor project still lists 113 of its sources.
- Three `packages/worker/src` files remain in the root program because `tests/visitor-count.test.ts` imports them. That is by reference, not by sweep, and they type-check under root settings.

`CLAUDE.md` gets one sentence in the paragraph about the root tsconfig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnEgNixBETdXnBy32t8px7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TypeScript setup guidance to explain exclusions needed for local type checking.
  * Documented a known conflict involving generated worker declarations and Playwright checks.

* **Bug Fixes**
  * Prevented local TypeScript checks from including generated worker declarations that could cause failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->