### PR TITLE
Use native compression streams for blueprint strings

### DIFF
--- a/.github/actions/setup-vp/action.yml
+++ b/.github/actions/setup-vp/action.yml
@@ -82,7 +82,7 @@ runs:
         # a bump is a guaranteed cache miss with no existing install to reuse -
         # a layout break would be certain, not intermittent.
         curl -fsSL https://vite.plus -o vp-install.sh
-        echo "3dd88cedb6d9b2665c305eda5413971417c8f183a819386148131b66a2cc6b2e  vp-install.sh" | sha256sum -c -
+        echo "d4a1ffa8245bdfcf39a786d545be6a43e231b771c32d7c02414bb96d4f5d9cdc  vp-install.sh" | sha256sum -c -
         VP_HOME="$HOME/.vite-plus" VP_NODE_MANAGER=yes bash vp-install.sh
         echo "$HOME/.vite-plus/bin" >> "$GITHUB_PATH"
         rm -f vp-install.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -5248,22 +5248,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/pako": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-3.0.1.tgz",
-            "integrity": "sha512-GupotUUI0mlhugKjUs4bjOwLt3nrehy9Ys2dxC0GtgVef5cnKggkDMmf2bq2poCCuVXopWPmqsc9VDT2iJUy+w==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/puzrin"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/nodeca"
-                }
-            ],
-            "license": "(MIT AND Zlib)"
-        },
         "node_modules/parse-svg-path": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.2.0.tgz",
@@ -6754,7 +6738,6 @@
                 "ajv": "^8.20.0",
                 "delaunator": "^5.1.0",
                 "eventemitter3": "^5.0.4",
-                "pako": "^3.0.1",
                 "pathfinding": "^0.4.18",
                 "pixi.js": "^8.19.0"
             },

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -22,7 +22,6 @@
         "ajv": "^8.20.0",
         "delaunator": "^5.1.0",
         "eventemitter3": "^5.0.4",
-        "pako": "^3.0.1",
         "pathfinding": "^0.4.18",
         "pixi.js": "^8.19.0"
     },

--- a/packages/editor/src/UI/ExportDialog.test.ts
+++ b/packages/editor/src/UI/ExportDialog.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, expect, it, vi } from 'vite-plus/test'
+import G from '../common/globals'
+import { ExportDialog } from './ExportDialog'
+
+const addOnce = vi.hoisted(() => vi.fn())
+
+vi.mock('../common/globals', () => ({
+    default: {
+        quickActions: { encodeCurrent: vi.fn() },
+        app: { ticker: { addOnce } },
+        logger: vi.fn(),
+    },
+}))
+
+beforeEach(() => vi.clearAllMocks())
+
+it('ignores older encodes and completion after the export dialog closes', async () => {
+    const pending: ((source: string) => void)[] = []
+    vi.mocked(G.quickActions.encodeCurrent).mockImplementation(
+        () => new Promise(resolve => pending.push(resolve))
+    )
+    // Exercise the real completion handler without creating a renderer or DOM.
+    const input = { text: '', select: vi.fn() }
+    const dialog = Object.assign(Object.create(ExportDialog.prototype), {
+        m_TextInput: input,
+        m_EncodeCount: 0,
+        destroyed: false,
+    })
+
+    dialog.refreshText({ select: false })
+    dialog.refreshText({ select: false })
+    pending[1]('newer')
+    await Promise.resolve()
+    pending[0]('older')
+    await Promise.resolve()
+    expect(input.text).toBe('newer')
+
+    dialog.refreshText({ select: true })
+    dialog.destroyed = true
+    pending[2]('closed')
+    await Promise.resolve()
+    expect(input.text).toBe('newer')
+    expect(addOnce).not.toHaveBeenCalled()
+
+    dialog.destroyed = false
+    dialog.refreshText({ select: true })
+    pending[3]('open')
+    await Promise.resolve()
+    dialog.destroyed = true
+    const selectOnFrame = addOnce.mock.calls[0][0] as () => void
+    selectOnFrame()
+    expect(input.select).not.toHaveBeenCalled()
+})

--- a/packages/editor/src/UI/ExportDialog.ts
+++ b/packages/editor/src/UI/ExportDialog.ts
@@ -42,7 +42,7 @@ export class ExportDialog extends Dialog {
      * How many times `refreshText` has been *called* this dialog's lifetime
      * - not how many times the `serialize` + `deflate` it starts has
      * actually finished, which this used to claim (#242 review):
-     * `m_EncodeCount += 1` is `refreshText`'s first line, so it moves
+     * The counter increments on `refreshText`'s first line, so it moves
      * synchronously, before `encodeCurrent()`'s promise resolves. That is
      * also why a caller does not need to poll for the value right after
      * `openExportDialog()` returns - it is already whatever it will be, the
@@ -141,10 +141,11 @@ export class ExportDialog extends Dialog {
     }
 
     private refreshText({ select }: { select: boolean }): void {
-        this.m_EncodeCount += 1
+        const encodeCount = ++this.m_EncodeCount
         G.quickActions
             .encodeCurrent()
             .then(source => {
+                if (this.destroyed || encodeCount !== this.m_EncodeCount) return
                 this.m_TextInput.text = source ?? ''
                 if (!select) return
                 /*
@@ -165,12 +166,16 @@ export class ExportDialog extends Dialog {
                     happened this tick.
                 */
                 G.app.ticker.addOnce(
-                    () => this.m_TextInput.select(),
+                    () => {
+                        if (!this.destroyed && encodeCount === this.m_EncodeCount)
+                            this.m_TextInput.select()
+                    },
                     undefined,
                     UPDATE_PRIORITY.UTILITY
                 )
             })
             .catch((error: unknown) => {
+                if (this.destroyed || encodeCount !== this.m_EncodeCount) return
                 G.logger({ text: String(error), type: 'error' })
             })
     }

--- a/packages/editor/src/core/blueprintSchema.test.ts
+++ b/packages/editor/src/core/blueprintSchema.test.ts
@@ -1,5 +1,4 @@
 import { beforeAll, describe, expect, it } from 'vite-plus/test'
-import * as pako from 'pako'
 import { Blueprint } from './Blueprint'
 import { getAndClearLoadWarnings, getBlueprintOrBookFromSource } from './bpString'
 import { loadData } from './factorioData'
@@ -61,7 +60,7 @@ const VERSION_2_1_12 = 2 * 2 ** 48 + 1 * 2 ** 32 + 12 * 2 ** 16
  * out rather than reusing `encode()`, which serialises a `Blueprint` - the two
  * controls below need a key the model would be free to drop on its way through.
  */
-const sourceFor = (decider_conditions: Record<string, unknown>): string => {
+const sourceFor = (decider_conditions: Record<string, unknown>): Promise<string> => {
     return encodeRoot({
         blueprint: {
             item: 'blueprint',
@@ -80,15 +79,18 @@ const sourceFor = (decider_conditions: Record<string, unknown>): string => {
     })
 }
 
-const encodeRoot = (data: unknown): string => {
-    const json = JSON.stringify(data)
+const encodeRoot = async (data: unknown): Promise<string> => {
+    const compressed = new Blob([JSON.stringify(data)])
+        .stream()
+        .pipeThrough(new CompressionStream('deflate'))
     let binary = ''
-    for (const byte of pako.deflate(json)) binary += String.fromCharCode(byte)
+    for (const byte of new Uint8Array(await new Response(compressed).arrayBuffer()))
+        binary += String.fromCharCode(byte)
     return `0${btoa(binary)}`
 }
 
 const load = async (decider_conditions: Record<string, unknown>) => {
-    const bp = await getBlueprintOrBookFromSource(sourceFor(decider_conditions))
+    const bp = await getBlueprintOrBookFromSource(await sourceFor(decider_conditions))
     if (!(bp instanceof Blueprint)) throw new Error('expected a blueprint, got a book')
     return {
         warnings: getAndClearLoadWarnings(),
@@ -123,16 +125,18 @@ describe('a leftover book-slot index at the root (#383)', () => {
             },
         },
     ])('ignores only the root index and preserves the loaded data: %j', async root => {
-        const original = await getBlueprintOrBookFromSource(encodeRoot(root))
+        const original = await getBlueprintOrBookFromSource(await encodeRoot(root))
         expect(getAndClearLoadWarnings()).toEqual([])
-        const loaded = await getBlueprintOrBookFromSource(encodeRoot({ ...root, index: 5 }))
+        const loaded = await getBlueprintOrBookFromSource(await encodeRoot({ ...root, index: 5 }))
         expect(getAndClearLoadWarnings()).toEqual([])
         expect(loaded.serialize()).toEqual(original.serialize())
         expect(loaded).toEqual(original)
     })
 
     it('still warns for another unknown root key alongside index', async () => {
-        await getBlueprintOrBookFromSource(encodeRoot({ blueprint, index: 5, unexpected: true }))
+        await getBlueprintOrBookFromSource(
+            await encodeRoot({ blueprint, index: 5, unexpected: true })
+        )
         expect(getAndClearLoadWarnings()).toEqual([
             'Blueprint had validation warnings (loaded anyway)',
         ])

--- a/packages/editor/src/core/bpString.ts
+++ b/packages/editor/src/core/bpString.ts
@@ -1,5 +1,4 @@
 import Ajv, { KeywordDefinition } from 'ajv'
-import * as pako from 'pako'
 import { IBlueprint, IBlueprintBook, IBlueprintBookEntry } from '../types'
 import G from '../common/globals'
 import FD from './factorioData'
@@ -29,7 +28,7 @@ import { migrateNames } from './nameMigrations'
     in tests/blueprint-string-tolerance.spec.ts and leaves the whitespace ones
     passing.
 */
-const base64ToBytes = (s: string): Uint8Array => {
+const base64ToBytes = (s: string): Uint8Array<ArrayBuffer> => {
     const normalised = s
         .replace(/-/g, '+')
         .replace(/_/g, '/')
@@ -204,19 +203,22 @@ function stripUnknownPrototypes(data: StringData): StrippedNames {
 }
 
 function decode(str: string): Promise<Blueprint | Book> {
-    return new Promise((resolve, reject) => {
+    return (async () => {
         try {
             const decodedStr = base64ToBytes(str.slice(1))
-            const parsedData = JSON.parse(pako.inflate(decodedStr, { toText: true }))
+            const inflated = new Blob([decodedStr])
+                .stream()
+                .pipeThrough(new DecompressionStream('deflate'))
+            const parsedData = JSON.parse(await new Response(inflated).text())
             // Factorio ignores a leftover book-slot index at the root (#383).
             if (parsedData !== null && typeof parsedData === 'object') delete parsedData.index
             // Before validation, since the schema checks names against FD.
             migrateNames(parsedData)
-            resolve(parsedData)
+            return parsedData
         } catch (e) {
-            reject(new CorruptedBlueprintStringError(e))
+            throw new CorruptedBlueprintStringError(e)
         }
-    }).then(data => {
+    })().then(data => {
         if (G.debug) console.log(data)
         loadWarnings = []
         if (!validate(data)) {
@@ -261,17 +263,13 @@ function decode(str: string): Promise<Blueprint | Book> {
     })
 }
 
-function encode(bpOrBook: Blueprint | Book): Promise<string> {
-    return new Promise((resolve, reject) => {
-        try {
-            const keyName = bpOrBook instanceof Blueprint ? 'blueprint' : 'blueprint_book'
-            const data = { [keyName]: bpOrBook.serialize() }
-            const string = JSON.stringify(data)
-            resolve(`0${bytesToBase64(pako.deflate(string))}`)
-        } catch (e) {
-            reject(e)
-        }
-    })
+async function encode(bpOrBook: Blueprint | Book): Promise<string> {
+    const keyName = bpOrBook instanceof Blueprint ? 'blueprint' : 'blueprint_book'
+    const data = { [keyName]: bpOrBook.serialize() }
+    const deflated = new Blob([JSON.stringify(data)])
+        .stream()
+        .pipeThrough(new CompressionStream('deflate'))
+    return `0${bytesToBase64(new Uint8Array(await new Response(deflated).arrayBuffer()))}`
 }
 
 function getBlueprintOrBookFromSource(source: string): Promise<Blueprint | Book> {

--- a/tests/blueprint-string-tolerance.spec.ts
+++ b/tests/blueprint-string-tolerance.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test'
-import { encodeBlueprint as encode, packVersion as version } from './helpers/encode-blueprint'
+import {
+    encodeBlueprint as encode,
+    decodeBlueprintString,
+    packVersion as version,
+} from './helpers/encode-blueprint'
 
 /*
     What `decode` accepts around the edges of a blueprint string's base64.
@@ -138,4 +142,19 @@ test('a genuinely corrupt string is still rejected', async ({ page }) => {
         }
     }, truncated)
     expect(failed).toBe(true)
+})
+
+test('native compression exports zlib UTF-8 and rejects a truncated checksum', async ({ page }) => {
+    const label = 'Factory 工場 🚀'
+    const source = encode({ item: 'blueprint', version: V_2_0, label, entities: [] })
+    const exported = await page.evaluate(async (str: string) => {
+        const api = window.__fbe_test
+        await api.loadBp(await api.getBlueprintOrBookFromSource(str))
+        return api.encodeLoaded()
+    }, source)
+    // The helper uses Node zlib, independently of the browser codec.
+    expect(decodeBlueprintString(exported).blueprint.label).toBe(label)
+    const bytes = Buffer.from(source.slice(1), 'base64')
+    const truncated = `0${bytes.subarray(0, -1).toString('base64')}`
+    await expect(load(page, truncated)).rejects.toThrow()
 })

--- a/tests/quick-actions.spec.ts
+++ b/tests/quick-actions.spec.ts
@@ -617,8 +617,9 @@ test('the export field re-encodes only when the blueprint actually changes, not 
         .poll(() => page.evaluate(() => window.__fbe_test.exportEncodeCount()), { timeout: 2000 })
         .toBe(2)
 
+    // encodeCount records invocation; native compression settles asynchronously.
+    await expect(exportTextarea(page)).not.toHaveValue(textBefore)
     const textAfter = await exportTextarea(page).inputValue()
-    expect(textAfter).not.toBe(textBefore)
     expect(decodeBlueprintString(textAfter).blueprint.entities).toHaveLength(1)
 })
 


### PR DESCRIPTION
Blueprint import/export currently ships pako for zlib compression. Use the platform's CompressionStream and DecompressionStream with the existing Promise API, removing the dependency while retaining base64 tolerance, migration/validation behavior and corrupt-input errors. Schema-test fixtures also use native compression.

Native compression settles asynchronously: the export dialog now ignores superseded results and results arriving after closure, including queued selection and error callbacks. A controlled deferred-encode test reproduces the stale-result overwrite before the guard. The export browser test waits for the completed textarea change separately from its invocation count and still checks the independently decoded entity count.

Addresses item 2 of #158. The Rust and one-line dependency items already shipped; the separate Ajv validation-policy decision remains open.

Measured analyzed production builds at base 1e19bf55 using Node 24.20.0, npm 12.0.0 and Vite+ 0.3.0 (Windows equivalent of the website workspace build:analyze script: VISUALIZE=1 vp build):

| Entry chunk | Before | Final | Saving |
| --- | ---: | ---: | ---: |
| Minified JS | 870.69 kB | 828.52 kB | 42.17 kB (4.8%) |
| Gzip | 242.10 kB | 229.08 kB | 13.02 kB (5.4%) |

The codec uses Factorio's zlib `deflate` framing and requires browsers supporting Compression Streams. No fallback dependency is bundled.

Validation: vp check passes without warnings; all 440 unit tests pass; the complete local browser suite passed 343 tests, followed by all 15 quick-action tests after the async lifecycle guard. Codec/corpus coverage includes Unicode export decoded independently with Node zlib and rejection of a truncated checksum. Built-in-browser smoke confirmed an imported chest renders and the export dialog produces a selected blueprint string. Local fixture line endings were normalized to committed LF to avoid the existing Windows oracle raw-text comparison failure.

CI initially failed before tests because the official Vite+ installer changed. The diff also refreshes its SHA-256 after verifying the payload against upstream commit 3124145c680164caf482904a117732886fa9d57d; download verification remains enforced. Final-head CI passes checks and all four Playwright shards (run 34397035245, head eab65b34). Claude is intentionally skipped on fork PRs; CodeRabbit reports that manual review is required for this OSS repository, so neither bot supplied a code review.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export dialog reliability when multiple blueprint encodings finish asynchronously.
  * Prevented outdated encoding results or callbacks from updating or selecting text after the dialog is replaced or closed.
  * Blueprint strings with truncated checksums are now rejected correctly.
  * Improved support for non-ASCII blueprint labels during compression and decompression.

* **Chores**
  * Updated installer integrity verification.
  * Removed an unnecessary compression dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->