### PR TITLE
Consolidate blueprint icon fallback and cover planet dialogs

### DIFF
--- a/packages/editor/src/UI/BlueprintInfoEditor.ts
+++ b/packages/editor/src/UI/BlueprintInfoEditor.ts
@@ -37,25 +37,7 @@ class BlueprintIconSlot extends Slot<undefined> {
         if (name === undefined) {
             if (this.content !== undefined) this.content = undefined
         } else {
-            try {
-                this.content = F.CreateIcon(name)
-            } catch (error) {
-                /*
-                    `CreateIcon` only resolves item/fluid/recipe/signal/
-                    inventory-group names - nothing in `FD` covers the
-                    `space-location` icons (planet names: vulcanus, fulgora,
-                    gleba...) Space Age blueprints and books carry, since the
-                    exporter emits no such collection at all. Uncaught, this
-                    took the whole dialog constructor down with it (five
-                    corpus files hit it). A blank slot costs one icon; the
-                    warning names which one.
-                */
-                G.logger({
-                    text: `Could not build the "${name}" blueprint icon: ${String(error)}`,
-                    type: 'warning',
-                })
-                if (this.content !== undefined) this.content = undefined
-            }
+            this.content = F.SafeIcon(name, () => F.CreateIcon(name))
         }
         this.emit('changed')
     }

--- a/tests/blueprint-info-editor.spec.ts
+++ b/tests/blueprint-info-editor.spec.ts
@@ -83,6 +83,31 @@ test.beforeEach(async ({ page }) => {
     await waitForEditor(page)
 })
 
+test('planet blueprint icons warn without breaking the dialog or keyboard shortcuts (#231)', async ({
+    page,
+}) => {
+    const errors: string[] = []
+    page.on('pageerror', error => errors.push(error.message))
+    const icons = ['vulcanus', 'fulgora', 'gleba', 'nauvis'].map((name, i) => ({
+        index: i + 1,
+        signal: { type: 'space-location', name },
+    }))
+    await loadBlueprint(page, encode({ item: 'blueprint', version: VERSION, icons }))
+
+    await openBlueprintInfo(page)
+    expect(await page.evaluate(() => window.__fbe_test.openDialogCount())).toBe(1)
+    for (const { signal } of icons) {
+        await expect(page.locator('.toasts-warning', { hasText: signal.name })).toBeVisible()
+    }
+    expect(decodeBlueprintString(await encodeLoaded(page)).blueprint.icons).toEqual(icons)
+
+    await page.keyboard.press('Escape')
+    expect(await page.evaluate(() => window.__fbe_test.openDialogCount())).toBe(0)
+    await page.keyboard.press('e')
+    expect(await page.evaluate(() => window.__fbe_test.openDialogCount())).toBe(1)
+    expect(errors).toEqual([])
+})
+
 test('typing into Absolute X and switching to Relative before blur does not commit a phantom origin position (#243 finding 2)', async ({
     page,
 }) => {


### PR DESCRIPTION
Blueprints carrying planet icons must still open their information dialog and leave keyboard shortcuts usable. The crash guards have already landed across the reported UI paths; this completes #231's shared-guard cleanup by replacing BlueprintInfoEditor's duplicate catch with the existing SafeIcon fallback.

Adds a browser regression covering all four reported planet names: named warnings, unchanged exported space-location signals, successful dialog opening, Escape closing it, and E opening inventory on its first press. Planet graphics remain unavailable because the exporter does not emit space-location prototypes.

Validation: vp check --fix passed; all 439 unit tests passed; 21 of 22 browser tests in blueprint-info-editor, editor-icon-guards, and dialog-registry-leak passed against the verified worktree source, including the new regression. The existing snap-grid toggle test failed once, then passed 5 focused repetitions; a paused-render probe established a separate checkbox hit-testing bug, filed as #423. The first unit run hit the existing Windows CRLF fixture failure (#415); rerun passed after restoring LF locally, with no fixture content change in this PR.

Closes #231.

