### PR TITLE
Preserve blueprint parameters and stock connections

### DIFF
--- a/packages/editor/src/core/Blueprint.test.ts
+++ b/packages/editor/src/core/Blueprint.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vite-plus/test'
 import { Blueprint } from './Blueprint'
-import { ISignal } from '../types'
+import { Book } from './Book'
+import { IBlueprint, ISignal } from '../types'
 import { encode, getAndClearLoadWarnings, getBlueprintOrBookFromSource } from './bpString'
 import { loadData } from './factorioData'
 
@@ -69,6 +70,61 @@ beforeAll(() => {
             defines: {},
         })
     )
+})
+
+describe('Blueprint opaque metadata (issue #336)', () => {
+    const metadata = {
+        parameters: [{ type: 'id', id: 'parameter-0', name: 'Select the item to load' }],
+        stock_connections: [{ stock: 1, front: 2 }],
+    }
+
+    it.each([metadata, { parameters: [], stock_connections: [] }, {}])(
+        'preserves populated, empty and absent metadata through encode/decode: %j',
+        async (fields: Partial<IBlueprint>) => {
+            const blueprint = new Blueprint(fields)
+            const loaded = await getBlueprintOrBookFromSource(await encode(blueprint))
+            if (!(loaded instanceof Blueprint)) throw new Error('Expected a blueprint')
+            const serialized = loaded.serialize()
+            expect(serialized).toMatchObject(fields)
+            expect(JSON.parse(JSON.stringify(serialized))).toEqual(
+                JSON.parse(JSON.stringify(blueprint.serialize()))
+            )
+            for (const key of ['parameters', 'stock_connections'] as const) {
+                expect(serialized[key]).toEqual(fields[key])
+            }
+        }
+    )
+
+    it('keeps metadata on visited, revisited and untouched nested book entries', async () => {
+        const entries = [metadata, { parameters: [], stock_connections: [] }, metadata].map(
+            (fields, index) => ({ index, blueprint: new Blueprint(fields).serialize() })
+        )
+        const book = new Book({
+            item: 'blueprint-book',
+            version: entries[0].blueprint.version,
+            active_index: 0,
+            blueprints: [
+                {
+                    index: 0,
+                    blueprint_book: {
+                        item: 'blueprint-book',
+                        version: entries[0].blueprint.version,
+                        active_index: 0,
+                        blueprints: entries,
+                    },
+                },
+            ],
+        })
+        book.selectBlueprint(0)
+        book.selectBlueprint(1)
+        book.selectBlueprint(0)
+        const loaded = await getBlueprintOrBookFromSource(await encode(book))
+        if (!(loaded instanceof Book)) throw new Error('Expected a book')
+        expect(loaded.serialize().blueprints?.[0].blueprint_book?.blueprints).toEqual(entries)
+        expect(entries[0].blueprint).toMatchObject(metadata)
+        expect(entries[1].blueprint).toMatchObject({ parameters: [], stock_connections: [] })
+        expect(entries[2].blueprint).toMatchObject(metadata)
+    })
 })
 
 describe('Blueprint icon generation', () => {

--- a/packages/editor/src/core/Blueprint.ts
+++ b/packages/editor/src/core/Blueprint.ts
@@ -168,6 +168,8 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
     public readonly history = new History()
 
     // unused blueprint properties
+    private readonly parameters?: unknown[]
+    private readonly stockConnections?: unknown[]
     /*
         Boxed, unlike its neighbours, because it is the one of them that changes:
         `setSchedule` rewrites it when a locomotive is pasted onto (issue #115),
@@ -483,6 +485,8 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
             }
 
             this.description = data.description
+            this.parameters = data.parameters
+            this.stockConnections = data.stock_connections
             this.scheduleStore.schedules = data.schedules
             this.snapToGridStore.snapToGrid = data['snap-to-grid']
             this.absoluteSnappingStore.absoluteSnapping = data['absolute-snapping']
@@ -1366,6 +1370,8 @@ class Blueprint extends EventEmitter<BlueprintEvents> {
             label: this.name,
             description: this.description,
             schedules: this.scheduleStore.schedules,
+            parameters: this.parameters,
+            stock_connections: this.stockConnections,
             'absolute-snapping': snapToGrid && absoluteSnapping ? true : undefined,
             'snap-to-grid': snapToGrid,
             'position-relative-to-grid':

--- a/packages/editor/src/types.ts
+++ b/packages/editor/src/types.ts
@@ -722,6 +722,8 @@ export interface IBlueprint {
     entities?: IEntity[]
     tiles?: ITile[]
     schedules?: ISchedule[]
+    parameters?: unknown[]
+    stock_connections?: unknown[]
     'absolute-snapping'?: boolean
     'snap-to-grid'?: IPoint
     'position-relative-to-grid'?: IPoint

--- a/tests/blueprint-round-trip.spec.ts
+++ b/tests/blueprint-round-trip.spec.ts
@@ -90,6 +90,9 @@ test('every test blueprint survives the decode/serialize round trip unchanged', 
         let positionChecksum = 0
         let modelPositionChecksum = 0
         let serializedHash = 5381
+        let withoutMetadataHash = 5381
+        let parameterBlueprints = 0
+        let stockConnectionBlueprints = 0
 
         for (const str of strings) {
             const loaded = await api.getBlueprintOrBookFromSource(str)
@@ -140,6 +143,10 @@ test('every test blueprint survives the decode/serialize round trip unchanged', 
                 }
 
                 serializedHash = hashInto(serializedHash, JSON.stringify(obj))
+                const { parameters, stock_connections, ...withoutMetadata } = obj
+                if (parameters !== undefined) parameterBlueprints += 1
+                if (stock_connections !== undefined) stockConnectionBlueprints += 1
+                withoutMetadataHash = hashInto(withoutMetadataHash, JSON.stringify(withoutMetadata))
             }
         }
 
@@ -153,6 +160,9 @@ test('every test blueprint survives the decode/serialize round trip unchanged', 
             positionChecksum,
             modelPositionChecksum,
             serializedHash,
+            withoutMetadataHash,
+            parameterBlueprints,
+            stockConnectionBlueprints,
         }
     }, sources)
 
@@ -211,5 +221,10 @@ const EXPECTED = {
     threw: 0,
     positionChecksum: -44088168,
     modelPositionChecksum: -63922400,
-    serializedHash: 568918011,
+    // #336 preserves previously discarded metadata. Removing only those two
+    // fields reproduces the prior hash; all geometry and counts above hold.
+    serializedHash: 1944909146,
+    withoutMetadataHash: 568918011,
+    parameterBlueprints: 97,
+    stockConnectionBlueprints: 28,
 }


### PR DESCRIPTION
Blueprint import/export now retains top-level parameters and stock_connections, including when browsing and revisiting nested book entries. Populated arrays, empty arrays and absent fields keep their values.

Added unit and nested-book round-trip regressions. The corpus hash changes from 568918011 to 1944909146 solely because metadata is restored: stripping those two fields reproduces the previous hash, every count and position checksum holds, and 97 parameter-bearing / 28 stock-connection-bearing blueprints survive.

Validation: vp check; 443 unit tests; six Playwright corpus/book serialization tests. Local unit validation required LF normalization of the existing rail-box fixture (tracked separately in #415); no fixture changes are included.

Closes #336.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Blueprint metadata in `parameters` and `stock_connections` is now preserved when blueprints are loaded, serialized, and exported.
  - Metadata remains intact when working with nested books and visiting blueprint entries.
  - Blueprints without these optional fields continue to round-trip correctly.
- **Tests**
  - Added coverage for populated, empty, and absent metadata fields to help ensure consistent blueprint round-tripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->