### PR TITLE
Refresh @xmldom/xmldom and fast-uri to clear 14 Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3006,9 +3006,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.8.13",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-            "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+            "version": "0.8.15",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+            "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -4237,9 +4237,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+            "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
             "funding": [
                 {
                     "type": "github",


### PR DESCRIPTION
Both packages were already inside their declared semver ranges, so this is a lockfile refresh with no manifest change.

| package | from | to | pulled in by | alerts cleared |
| --- | --- | --- | --- | ---: |
| `@xmldom/xmldom` | 0.8.13 | 0.8.15 | `pixi.js ^0.8.13` | 10 |
| `fast-uri` | 3.1.5 | 3.1.7 | `ajv ^3.0.1` | 4 |

All 14 are runtime scope. 0.8.15 covers both patch levels the advisories ask for - 8 need 0.8.15 and 2 need 0.8.14.

The diff touches 4 version lines in `package-lock.json` and nothing else.

## What this does not fix

The 15th alert is `sharp` 0.35.2 (high, dev scope), reached through `miniflare`, which pins it exactly. It needs `wrangler >= 4.131.0` - that version is ~7 hours old at time of writing, so it is left as a separate decision rather than folded in here.

## Verification

- `npm audit`: the `@xmldom/xmldom` and `fast-uri` advisories are gone; only the `sharp` chain remains
- `npm run test:unit`: 22 files, 249 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
