### PR TITLE
Add a one-time GitHub star prompt in the editor

### DIFF
--- a/packages/website/src/index.css
+++ b/packages/website/src/index.css
@@ -264,7 +264,7 @@ html {
     pointer-events: none;
 }
 /*
-    The exception, and the only toast a click still reaches: one created with
+    The whole-toast exception: one created with
     `timeout: Infinity` has no other way to be dismissed. Applied by toasts.ts,
     which owns the class name - see PERSISTENT_TOAST_CLASS.
 */
@@ -301,6 +301,21 @@ html {
 .toasts-text {
     font-size: 14px;
     color: #fff;
+}
+.star-prompt-action {
+    /* Keep the rest of the toast click-through to the editor. */
+    pointer-events: auto;
+    color: #fff;
+    font: inherit;
+    text-decoration: underline;
+    background: none;
+    border: 0;
+    padding: 6px 0;
+    display: inline-block;
+    cursor: pointer;
+}
+.star-prompt-action + .star-prompt-action {
+    margin-left: 8px;
 }
 .toasts-success {
     border-bottom-color: #51c625;

--- a/packages/website/src/index.ts
+++ b/packages/website/src/index.ts
@@ -306,6 +306,7 @@ editor
             */
             .then(() => {
                 startupFinished = true
+                setTimeout(createStarMessage, 60000)
                 if (import.meta.env.DEV) {
                     ;(window as any).__fbe_test = testApi
                 }
@@ -974,6 +975,23 @@ function registerActions(): void {
         } else {
             localStorage.removeItem('keybinds2')
         }
+    })
+}
+
+function createStarMessage(): void {
+    try {
+        if (localStorage.getItem('starPromptShown')) return
+        localStorage.setItem('starPromptShown', 'true')
+    } catch {
+        // Storage can be disabled; the prompt still appears only once this visit.
+    }
+    createToast({
+        text:
+            '<span role="status">Enjoying the editor? We\'re open source!</span><br>' +
+            '<a class="star-prompt-action" href="https://github.com/FactoryGameFan/factorio-blueprint-editor" ' +
+            'target="_blank" rel="noopener noreferrer">★ Give us a star on GitHub</a> ' +
+            '<button class="star-prompt-action" type="button" aria-label="Dismiss star prompt">Dismiss</button>',
+        timeout: 30000,
     })
 }
 

--- a/tests/helpers/overlays.ts
+++ b/tests/helpers/overlays.ts
@@ -6,7 +6,7 @@ type Page = import('@playwright/test').Page
  * editor was displaying.
  */
 const CSS = `
-    .toasts-container, .toasts-persistent { pointer-events: none !important; }
+    .toasts-container, .toasts-persistent, .star-prompt-action { pointer-events: none !important; }
     .dg.main { pointer-events: none !important; }
 `
 

--- a/tests/star-prompt.spec.ts
+++ b/tests/star-prompt.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test'
+
+test('star prompt is delayed, accessible, dismissible, and shown only once', async ({ page }) => {
+    await page.clock.install()
+    await page.goto('/')
+    await page.waitForFunction(() => window.__fbe_test !== undefined)
+    const link = page.getByRole('link', { name: 'Give us a star on GitHub' })
+    await expect(link).toHaveCount(0)
+    await page.clock.fastForward(59000)
+    await expect(link).toHaveCount(0)
+    await page.clock.fastForward(1000)
+    await expect(link).toBeVisible()
+    await expect(link).toHaveAttribute(
+        'href',
+        'https://github.com/FactoryGameFan/factorio-blueprint-editor'
+    )
+    await expect(link).toHaveAttribute('target', '_blank')
+    await expect(link).toHaveCSS('pointer-events', 'auto')
+    await expect(page.getByRole('status')).toHaveText("Enjoying the editor? We're open source!")
+    await expect(page.getByRole('status')).toHaveCSS('pointer-events', 'none')
+
+    const dismiss = page.getByRole('button', { name: 'Dismiss star prompt' })
+    await dismiss.focus()
+    await page.keyboard.press('Enter')
+    await expect(link).toHaveCount(0)
+
+    await page.reload()
+    await page.waitForFunction(() => window.__fbe_test !== undefined)
+    await page.clock.fastForward(60000)
+    await expect(link).toHaveCount(0)
+})
+
+test('star prompt expires without interaction', async ({ page }) => {
+    await page.clock.install()
+    await page.goto('/')
+    await page.waitForFunction(() => window.__fbe_test !== undefined)
+    await page.clock.fastForward(60000)
+    const link = page.getByRole('link', { name: 'Give us a star on GitHub' })
+    await expect(link).toBeVisible()
+    await page.clock.fastForward(30000)
+    await expect(link).toHaveCount(0)
+})


### PR DESCRIPTION
Adds a one-time toast after one minute in the editor: “Enjoying the editor? We're open source!” with a link to star FactoryGameFan/factorio-blueprint-editor on GitHub.

The prompt opens GitHub in a new tab, supports keyboard dismissal, and expires after 30 seconds. Local storage prevents repeat prompts on later visits; only its two controls intercept canvas clicks. No new dependencies.

Validation: `vp check`, all 444 unit tests, and five focused Playwright tests covering timing, persistence, dismissal, expiry, and existing toast click-through behavior. Visually checked in the editor. The local Windows fixture needed LF normalization for the existing issue #415; no fixture change is included.

Screenshot of the prompt (keyboard focus shown):

<img width="1280" height="720" alt="star-prompt-desktop" src="https://github.com/user-attachments/assets/d7c11c20-009e-4a4d-b6da-84c5fcb938d3" />