### PR TITLE
Fix ALT toggle label contrast in both states

### DIFF
--- a/packages/editor/src/UI/ToolsPanel.ts
+++ b/packages/editor/src/UI/ToolsPanel.ts
@@ -61,7 +61,8 @@ class ActionSlot extends Slot<undefined> {
  * icons that do exist).
  */
 function createTextIcon(text: string): Container {
-    const label = new Text({ text, style: styles.controls.checkbox })
+    const label = new Text({ text, style: styles.controls.checkbox.clone() })
+    label.style.fill = 0xffffff
     label.anchor.set(0.5)
     return label
 }
@@ -287,6 +288,9 @@ export class ToolsPanel extends Panel {
         const altHighlight = addToggleHighlight(altSlot, ALT_ACTIVE_COLOR)
         this.altHighlightTick = () => {
             altHighlight.visible = G.BPC.overlayContainer.entityInfoVisible
+            if (altSlot.content) {
+                altSlot.content.tint = altHighlight.visible ? 0x000000 : 0xffffff
+            }
         }
         G.app.ticker.add(this.altHighlightTick)
 

--- a/tests/tools-panel.spec.ts
+++ b/tests/tools-panel.spec.ts
@@ -65,6 +65,53 @@ test.beforeEach(async ({ page }) => {
     await waitForEditor(page)
 })
 
+test('ALT label is black on amber and white on grey (#429)', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 })
+    const bounds = await page.evaluate(() => window.__fbe_test.toolsPanelBounds())
+    const x = bounds.x + 12
+    const y = bounds.y + 12
+    const expectColors = async (foreground: number[], background: number[]) => {
+        await expect
+            .poll(async () => {
+                const png = await page.screenshot({
+                    clip: { x: x + 4, y: y + 8, width: 28, height: 20 },
+                })
+                return page.evaluate(
+                    async ({ data, foreground, background }) => {
+                        const image = new Image()
+                        image.src = `data:image/png;base64,${data}`
+                        await image.decode()
+                        const canvas = document.createElement('canvas')
+                        canvas.width = image.width
+                        canvas.height = image.height
+                        const context = canvas.getContext('2d')
+                        if (!context) throw new Error('2D canvas unavailable')
+                        context.drawImage(image, 0, 0)
+                        const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data
+                        return [foreground, background].every(color => {
+                            for (let i = 0; i < pixels.length; i += 4) {
+                                if (color.every((channel, j) => pixels[i + j] === channel))
+                                    return true
+                            }
+                            return false
+                        })
+                    },
+                    { data: png.toString('base64'), foreground, background }
+                )
+            })
+            .toBe(true)
+    }
+
+    await expectColors([0, 0, 0], [241, 190, 100])
+    await page.keyboard.press('AltLeft')
+    await expectColors([255, 255, 255], [100, 100, 100])
+    await page.mouse.click(x + 18, y + 18)
+    await page.mouse.move(640, 360)
+    await expectColors([0, 0, 0], [241, 190, 100])
+    await page.keyboard.press('AltLeft')
+    await expectColors([255, 255, 255], [100, 100, 100])
+})
+
 test("ImportDialog's textarea has no length cap and a large blueprint pastes without truncation", async ({
     page,
 }) => {


### PR DESCRIPTION
The ALT label now uses black while entity info is enabled and white while disabled, giving 12.29:1 contrast on amber and 5.92:1 on grey. The existing ticker keeps the label and highlight synchronized after either keyboard or mouse toggles; the label clones its style so other controls are unaffected.

Adds a rendered-pixel regression test covering initial state, keyboard toggling, mouse toggling, and toggling back off.

Validation: `vp check --fix` passed; `vp test` passed all 444 tests after locally normalizing the fixture line endings affected by existing issue #415; all five `tests/tools-panel.spec.ts` browser tests passed. Also visually checked both states and mouse/keyboard interaction in the built-in browser at 1280×720.

Closes #429.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the ALT toggle’s text contrast so its label remains readable in both active and inactive states.
  * Updated text tool icons to match the checkbox styling when their fill color changes.

* **Tests**
  * Added coverage verifying ALT label colors across button states and focus interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->